### PR TITLE
moves stateful variables into their own folder & centralize types

### DIFF
--- a/lib/agent0/agent0/hyperdrive/policies/lpandarb.py
+++ b/lib/agent0/agent0/hyperdrive/policies/lpandarb.py
@@ -8,17 +8,20 @@ from dataclasses import dataclass
 from statistics import mean
 from typing import TYPE_CHECKING
 
-from agent0.base import MarketType, Trade
-from agent0.hyperdrive.state import HyperdriveActionType, HyperdriveMarketAction
 from fixedpointmath import FixedPoint
+
+from agent0.base import MarketType, Trade
+from agent0.hyperdrive.state import (HyperdriveActionType,
+                                     HyperdriveMarketAction)
 
 from .hyperdrive_policy import HyperdrivePolicy
 
 if TYPE_CHECKING:
-    from agent0.hyperdrive.state import HyperdriveWallet
-    from ethpy.hyperdrive import PoolConfig, PoolInfo
     from ethpy.hyperdrive.api import HyperdriveInterface
+    from ethpy.hyperdrive.state import PoolConfig, PoolInfo
     from numpy.random._generator import Generator as NumpyGenerator
+
+    from agent0.hyperdrive.state import HyperdriveWallet
 
 # pylint: disable=too-many-arguments, too-many-locals
 

--- a/lib/agent0/agent0/hyperdrive/policies/lpandarb.py
+++ b/lib/agent0/agent0/hyperdrive/policies/lpandarb.py
@@ -11,8 +11,7 @@ from typing import TYPE_CHECKING
 from fixedpointmath import FixedPoint
 
 from agent0.base import MarketType, Trade
-from agent0.hyperdrive.state import (HyperdriveActionType,
-                                     HyperdriveMarketAction)
+from agent0.hyperdrive.state import HyperdriveActionType, HyperdriveMarketAction
 
 from .hyperdrive_policy import HyperdrivePolicy
 

--- a/lib/agent0/agent0/hyperdrive/policies/random.py
+++ b/lib/agent0/agent0/hyperdrive/policies/random.py
@@ -4,16 +4,19 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from fixedpointmath import FixedPoint
+
 from agent0.base import WEI, MarketType, Trade
 from agent0.hyperdrive.state import HyperdriveActionType, HyperdriveMarketAction
-from fixedpointmath import FixedPoint
 
 from .hyperdrive_policy import HyperdrivePolicy
 
 if TYPE_CHECKING:
-    from agent0.hyperdrive.state import HyperdriveWallet
-    from ethpy.hyperdrive.api import HyperdriveInterface, PoolState
+    from ethpy.hyperdrive.api import HyperdriveInterface
+    from ethpy.hyperdrive.state import PoolState
     from numpy.random._generator import Generator as NumpyGenerator
+
+    from agent0.hyperdrive.state import HyperdriveWallet
 
 
 class Random(HyperdrivePolicy):

--- a/lib/agent0/bin/checkpoint_bot.py
+++ b/lib/agent0/bin/checkpoint_bot.py
@@ -6,8 +6,6 @@ import logging
 import os
 import time
 
-from agent0.base.agents import EthAgent
-from agent0.base.config import EnvironmentConfig
 from eth_account.account import Account
 from ethpy import EthConfig, build_eth_config
 from ethpy.base import (
@@ -21,6 +19,9 @@ from ethpy.hyperdrive import fetch_hyperdrive_address_from_uri, get_hyperdrive_p
 from fixedpointmath import FixedPoint
 from hyperlogs import logs
 from web3.contract.contract import Contract
+
+from agent0.base.agents import EthAgent
+from agent0.base.config import EnvironmentConfig
 
 # The portion of the checkpoint that the bot will wait before attempting to
 # mint a new checkpoint.
@@ -103,7 +104,7 @@ def main() -> None:
     # every checkpoint after a waiting period. It will poll very infrequently
     # to reduce the probability of needing to mint a checkpoint.
     config = get_hyperdrive_pool_config(hyperdrive_contract)
-    checkpoint_duration = config["checkpointDuration"]
+    checkpoint_duration = config.checkpoint_duration
 
     logging.info(
         "Checkpoint Duration: %s; Block time: %s; Block timestamp interval: %s",

--- a/lib/chainsync/chainsync/db/hyperdrive/convert_data.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/convert_data.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from ethpy.base import get_transaction_logs
 from ethpy.hyperdrive import BASE_TOKEN_SYMBOL, HyperdriveAddresses, decode_asset_id
-from ethpy.hyperdrive.addresses import camel_to_snake
+from ethpy.hyperdrive.state.conversions import camel_to_snake
 from fixedpointmath import FixedPoint
 from hexbytes import HexBytes
 from web3 import Web3

--- a/lib/ethpy/ethpy/hyperdrive/__init__.py
+++ b/lib/ethpy/ethpy/hyperdrive/__init__.py
@@ -6,13 +6,6 @@ from .errors import HyperdriveErrors, lookup_hyperdrive_error_selector
 from .get_web3_and_hyperdrive_contracts import get_web3_and_hyperdrive_contracts
 from .receipt_breakdown import ReceiptBreakdown
 from .transactions import (
-    Checkpoint,
-    Fees,
-    PoolConfig,
-    PoolInfo,
-    convert_hyperdrive_checkpoint_types,
-    convert_hyperdrive_pool_config_types,
-    convert_hyperdrive_pool_info_types,
     get_event_history_from_chain,
     get_hyperdrive_checkpoint,
     get_hyperdrive_pool_config,

--- a/lib/ethpy/ethpy/hyperdrive/__init__.py
+++ b/lib/ethpy/ethpy/hyperdrive/__init__.py
@@ -1,5 +1,5 @@
 """Interfaces for bots and hyperdrive smart contracts."""
-from .addresses import HyperdriveAddresses, camel_to_snake, fetch_hyperdrive_address_from_uri
+from .addresses import HyperdriveAddresses, fetch_hyperdrive_address_from_uri
 from .assets import BASE_TOKEN_SYMBOL, AssetIdPrefix, decode_asset_id, encode_asset_id
 from .deploy import DeployedHyperdrivePool, deploy_hyperdrive_from_factory
 from .errors import HyperdriveErrors, lookup_hyperdrive_error_selector

--- a/lib/ethpy/ethpy/hyperdrive/addresses.py
+++ b/lib/ethpy/ethpy/hyperdrive/addresses.py
@@ -2,12 +2,13 @@
 from __future__ import annotations
 
 import logging
-import re
 import time
 
 import attr
 import requests
 from eth_typing import Address, ChecksumAddress
+
+from .state.conversions import camel_to_snake
 
 
 @attr.s
@@ -20,19 +21,6 @@ class HyperdriveAddresses:
     hyperdrive_factory: Address | ChecksumAddress = attr.ib()
     mock_hyperdrive: Address | ChecksumAddress = attr.ib()
     mock_hyperdrive_math: Address | ChecksumAddress | None = attr.ib()
-
-
-def camel_to_snake(snake_string: str) -> str:
-    """Convert camel case string to snake case string."""
-    return re.sub(r"(?<!^)(?=[A-Z])", "_", snake_string).lower()
-
-
-def snake_to_camel(snake_string: str) -> str:
-    """Convert snake case string to camel case string."""
-    # First capitalize the letters following the underscores and remove underscores
-    camel_string = re.sub(r"_([a-z])", lambda x: x.group(1).upper(), snake_string)
-    # Ensure the first character is lowercase to achieve lowerCamelCase
-    return camel_string[0].lower() + camel_string[1:] if camel_string else camel_string
 
 
 def fetch_hyperdrive_address_from_uri(contracts_uri: str) -> HyperdriveAddresses:

--- a/lib/ethpy/ethpy/hyperdrive/addresses.py
+++ b/lib/ethpy/ethpy/hyperdrive/addresses.py
@@ -27,6 +27,14 @@ def camel_to_snake(snake_string: str) -> str:
     return re.sub(r"(?<!^)(?=[A-Z])", "_", snake_string).lower()
 
 
+def snake_to_camel(snake_string: str) -> str:
+    """Convert snake case string to camel case string."""
+    # First capitalize the letters following the underscores and remove underscores
+    camel_string = re.sub(r"_([a-z])", lambda x: x.group(1).upper(), snake_string)
+    # Ensure the first character is lowercase to achieve lowerCamelCase
+    return camel_string[0].lower() + camel_string[1:] if camel_string else camel_string
+
+
 def fetch_hyperdrive_address_from_uri(contracts_uri: str) -> HyperdriveAddresses:
     """Fetch addresses for deployed contracts in the Hyperdrive system."""
     response = None

--- a/lib/ethpy/ethpy/hyperdrive/api/__init__.py
+++ b/lib/ethpy/ethpy/hyperdrive/api/__init__.py
@@ -1,2 +1,2 @@
 """High-level interface for the Hyperdrive market."""
-from .api import HyperdriveInterface, PoolState
+from .api import HyperdriveInterface

--- a/lib/ethpy/ethpy/hyperdrive/api/_mock_contract.py
+++ b/lib/ethpy/ethpy/hyperdrive/api/_mock_contract.py
@@ -1,54 +1,19 @@
 """Mock function calls using hyperdrivepy."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, cast
 
 import hyperdrivepy
 from fixedpointmath import FixedPoint
-from hypertypes.IHyperdriveTypes import Fees, PoolConfig, PoolInfo
 from web3.types import Timestamp
+
+from ..state.conversions import fixedpoint_pool_config_to_hypertypes, fixedpoint_pool_info_to_hypertypes
 
 if TYPE_CHECKING:
     from ..state import PoolState
 
 # We only worry about protected access for users outside of this folder
 # pylint: disable=protected-access
-
-
-def _construct_pool_config(contract_pool_config: dict[str, Any]) -> PoolConfig:
-    """Convert the contract call return value into a proper PoolConfig object.
-
-    .. note::
-        This function will be deprecated as soon as we finish integrating pypechain.
-    """
-    return PoolConfig(
-        baseToken=contract_pool_config["baseToken"],
-        linkerFactory=contract_pool_config["linkerFactory"],
-        linkerCodeHash=contract_pool_config["linkerCodeHash"],
-        initialSharePrice=contract_pool_config["initialSharePrice"],
-        minimumShareReserves=contract_pool_config["minimumShareReserves"],
-        minimumTransactionAmount=contract_pool_config["minimumTransactionAmount"],
-        precisionThreshold=contract_pool_config["precisionThreshold"],
-        positionDuration=contract_pool_config["positionDuration"],
-        checkpointDuration=contract_pool_config["checkpointDuration"],
-        timeStretch=contract_pool_config["timeStretch"],
-        governance=contract_pool_config["governance"],
-        feeCollector=contract_pool_config["feeCollector"],
-        fees=Fees(
-            curve=contract_pool_config["fees"][0],
-            flat=contract_pool_config["fees"][1],
-            governance=contract_pool_config["fees"][2],
-        ),
-    )
-
-
-def _construct_pool_info(contract_pool_info: dict[str, Any]) -> PoolInfo:
-    """Convert the contract call return value into a proper PoolInfo object.
-
-    .. note::
-        This function will be deprecated as soon as we finish integrating pypechain.
-    """
-    return PoolInfo(**contract_pool_info)
 
 
 def _calc_checkpoint_id(checkpoint_duration: int, block_timestamp: Timestamp) -> Timestamp:
@@ -65,8 +30,8 @@ def _calc_position_duration_in_years(pool_state: PoolState) -> FixedPoint:
 def _calc_fixed_rate(pool_state: PoolState) -> FixedPoint:
     """See API for documentation."""
     spot_rate = hyperdrivepy.get_spot_rate(
-        _construct_pool_config(pool_state.contract_pool_config),
-        _construct_pool_info(pool_state.contract_pool_info),
+        fixedpoint_pool_config_to_hypertypes(pool_state.pool_config),
+        fixedpoint_pool_info_to_hypertypes(pool_state.pool_info),
     )
     return FixedPoint(scaled_value=int(spot_rate))
 
@@ -83,8 +48,8 @@ def _calc_effective_share_reserves(pool_state: PoolState) -> FixedPoint:
 def _calc_spot_price(pool_state: PoolState):
     """See API for documentation."""
     spot_price = hyperdrivepy.get_spot_price(
-        _construct_pool_config(pool_state.contract_pool_config),
-        _construct_pool_info(pool_state.contract_pool_info),
+        fixedpoint_pool_config_to_hypertypes(pool_state.pool_config),
+        fixedpoint_pool_info_to_hypertypes(pool_state.pool_info),
     )
     return FixedPoint(scaled_value=int(spot_price))
 
@@ -92,8 +57,8 @@ def _calc_spot_price(pool_state: PoolState):
 def _calc_long_amount(pool_state: PoolState, base_amount: FixedPoint) -> FixedPoint:
     """See API for documentation."""
     long_amount = hyperdrivepy.get_long_amount(
-        _construct_pool_config(pool_state.contract_pool_config),
-        _construct_pool_info(pool_state.contract_pool_info),
+        fixedpoint_pool_config_to_hypertypes(pool_state.pool_config),
+        fixedpoint_pool_info_to_hypertypes(pool_state.pool_info),
         str(base_amount.scaled_value),
     )
     return FixedPoint(scaled_value=int(long_amount))
@@ -112,8 +77,8 @@ def _calc_short_deposit(
     else:  # convert FixedPoint to string
         open_share_price_str = str(open_share_price.scaled_value)
     short_deposit = hyperdrivepy.get_short_deposit(
-        _construct_pool_config(pool_state.contract_pool_config),
-        _construct_pool_info(pool_state.contract_pool_info),
+        fixedpoint_pool_config_to_hypertypes(pool_state.pool_config),
+        fixedpoint_pool_info_to_hypertypes(pool_state.pool_info),
         str(short_amount.scaled_value),
         str(spot_price.scaled_value),
         open_share_price_str,  # str | None
@@ -127,8 +92,8 @@ def _calc_bonds_out_given_shares_in_down(
 ) -> FixedPoint:
     """See API for documentation."""
     amount_out = hyperdrivepy.calculate_bonds_out_given_shares_in_down(
-        _construct_pool_config(pool_state.contract_pool_config),
-        _construct_pool_info(pool_state.contract_pool_info),
+        fixedpoint_pool_config_to_hypertypes(pool_state.pool_config),
+        fixedpoint_pool_info_to_hypertypes(pool_state.pool_info),
         str(amount_in.scaled_value),
     )
     return FixedPoint(scaled_value=int(amount_out))
@@ -140,8 +105,8 @@ def _calc_shares_in_given_bonds_out_up(
 ) -> FixedPoint:
     """See API for documentation."""
     amount_out = hyperdrivepy.calculate_shares_in_given_bonds_out_up(
-        _construct_pool_config(pool_state.contract_pool_config),
-        _construct_pool_info(pool_state.contract_pool_info),
+        fixedpoint_pool_config_to_hypertypes(pool_state.pool_config),
+        fixedpoint_pool_info_to_hypertypes(pool_state.pool_info),
         str(amount_in.scaled_value),
     )
     return FixedPoint(scaled_value=int(amount_out))
@@ -153,8 +118,8 @@ def _calc_shares_in_given_bonds_out_down(
 ) -> FixedPoint:
     """See API for documentation."""
     amount_out = hyperdrivepy.calculate_shares_in_given_bonds_out_down(
-        _construct_pool_config(pool_state.contract_pool_config),
-        _construct_pool_info(pool_state.contract_pool_info),
+        fixedpoint_pool_config_to_hypertypes(pool_state.pool_config),
+        fixedpoint_pool_info_to_hypertypes(pool_state.pool_info),
         str(amount_in.scaled_value),
     )
     return FixedPoint(scaled_value=int(amount_out))
@@ -166,8 +131,8 @@ def _calc_shares_out_given_bonds_in_down(
 ) -> FixedPoint:
     """See API for documentation."""
     amount_out = hyperdrivepy.calculate_shares_out_given_bonds_in_down(
-        _construct_pool_config(pool_state.contract_pool_config),
-        _construct_pool_info(pool_state.contract_pool_info),
+        fixedpoint_pool_config_to_hypertypes(pool_state.pool_config),
+        fixedpoint_pool_info_to_hypertypes(pool_state.pool_info),
         str(amount_in.scaled_value),
     )
     return FixedPoint(scaled_value=int(amount_out))
@@ -178,8 +143,8 @@ def _calc_max_buy(
 ) -> FixedPoint:
     """See API for documentation."""
     amount_out = hyperdrivepy.calculate_max_buy(
-        _construct_pool_config(pool_state.contract_pool_config),
-        _construct_pool_info(pool_state.contract_pool_info),
+        fixedpoint_pool_config_to_hypertypes(pool_state.pool_config),
+        fixedpoint_pool_info_to_hypertypes(pool_state.pool_info),
     )
     return FixedPoint(scaled_value=int(amount_out))
 
@@ -190,8 +155,8 @@ def _calc_max_sell(
 ) -> FixedPoint:
     """See API for documentation."""
     amount_out = hyperdrivepy.calculate_max_sell(
-        _construct_pool_config(pool_state.contract_pool_config),
-        _construct_pool_info(pool_state.contract_pool_info),
+        fixedpoint_pool_config_to_hypertypes(pool_state.pool_config),
+        fixedpoint_pool_info_to_hypertypes(pool_state.pool_info),
         str(minimum_share_reserves.scaled_value),
     )
     return FixedPoint(scaled_value=int(amount_out))
@@ -273,8 +238,8 @@ def _calc_max_long(pool_state: PoolState, budget: FixedPoint) -> FixedPoint:
     return FixedPoint(
         scaled_value=int(
             hyperdrivepy.get_max_long(
-                _construct_pool_config(pool_state.contract_pool_config),
-                _construct_pool_info(pool_state.contract_pool_info),
+                fixedpoint_pool_config_to_hypertypes(pool_state.pool_config),
+                fixedpoint_pool_info_to_hypertypes(pool_state.pool_info),
                 str(budget.scaled_value),
                 checkpoint_exposure=str(pool_state.checkpoint.exposure.scaled_value),
                 maybe_max_iterations=None,
@@ -288,8 +253,8 @@ def _calc_max_short(pool_state: PoolState, budget: FixedPoint) -> FixedPoint:
     return FixedPoint(
         scaled_value=int(
             hyperdrivepy.get_max_short(
-                pool_config=_construct_pool_config(pool_state.contract_pool_config),
-                pool_info=_construct_pool_info(pool_state.contract_pool_info),
+                pool_config=fixedpoint_pool_config_to_hypertypes(pool_state.pool_config),
+                pool_info=fixedpoint_pool_info_to_hypertypes(pool_state.pool_info),
                 budget=str(budget.scaled_value),
                 open_share_price=str(pool_state.pool_info.share_price.scaled_value),
                 checkpoint_exposure=str(pool_state.checkpoint.exposure.scaled_value),

--- a/lib/ethpy/ethpy/hyperdrive/api/_mock_contract.py
+++ b/lib/ethpy/ethpy/hyperdrive/api/_mock_contract.py
@@ -9,7 +9,7 @@ from hypertypes.IHyperdriveTypes import Fees, PoolConfig, PoolInfo
 from web3.types import Timestamp
 
 if TYPE_CHECKING:
-    from .api import PoolState
+    from ..state import PoolState
 
 # We only worry about protected access for users outside of this folder
 # pylint: disable=protected-access

--- a/lib/ethpy/ethpy/hyperdrive/api/api.py
+++ b/lib/ethpy/ethpy/hyperdrive/api/api.py
@@ -238,20 +238,20 @@ class HyperdriveInterface:
             block_identifier = cast(BlockIdentifier, "latest")
             block = self.get_block(block_identifier)
         block_number = self.get_block_number(block)
-        contract_pool_config = get_hyperdrive_pool_config(self.hyperdrive_contract)
-        contract_pool_info = get_hyperdrive_pool_info(self.hyperdrive_contract, block_number)
-        contract_checkpoint = get_hyperdrive_checkpoint(
+        pool_config = get_hyperdrive_pool_config(self.hyperdrive_contract)
+        pool_info = get_hyperdrive_pool_info(self.hyperdrive_contract, block_number)
+        checkpoint = get_hyperdrive_checkpoint(
             self.hyperdrive_contract,
-            self.calc_checkpoint_id(contract_pool_config["checkpointDuration"], self.get_block_timestamp(block)),
+            self.calc_checkpoint_id(pool_config.checkpoint_duration, self.get_block_timestamp(block)),
         )
         variable_rate = self.get_variable_rate(block_number)
         vault_shares = self.get_vault_shares(block_number)
         total_supply_withdrawal_shares = self.get_total_supply_withdrawal_shares(block_number)
         return PoolState(
             block,
-            contract_pool_config,
-            contract_pool_info,
-            contract_checkpoint,
+            pool_config,
+            pool_info,
+            checkpoint,
             variable_rate,
             vault_shares,
             total_supply_withdrawal_shares,
@@ -555,7 +555,7 @@ class HyperdriveInterface:
         """
         if pool_state is None:
             pool_state = self.current_pool_state
-        return _calc_position_duration_in_years(self.current_pool_state)
+        return _calc_position_duration_in_years(pool_state)
 
     def calc_checkpoint_id(
         self, checkpoint_duration: int | None = None, block_timestamp: Timestamp | None = None

--- a/lib/ethpy/ethpy/hyperdrive/api/api.py
+++ b/lib/ethpy/ethpy/hyperdrive/api/api.py
@@ -7,16 +7,13 @@ from __future__ import annotations
 
 import copy
 import os
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
 from ethpy import build_eth_config
 from ethpy.base import initialize_web3_with_http_provider, load_all_abis, smart_contract_read
 from ethpy.hyperdrive.addresses import HyperdriveAddresses, fetch_hyperdrive_address_from_uri
+from ethpy.hyperdrive.state import PoolState
 from ethpy.hyperdrive.transactions import (
-    convert_hyperdrive_checkpoint_types,
-    convert_hyperdrive_pool_config_types,
-    convert_hyperdrive_pool_info_types,
     get_hyperdrive_checkpoint,
     get_hyperdrive_pool_config,
     get_hyperdrive_pool_info,
@@ -68,8 +65,6 @@ from ._mock_contract import (
 
 
 if TYPE_CHECKING:
-    from typing import Any
-
     from eth_account.signers.local import LocalAccount
     from eth_typing import BlockNumber
     from ethpy import EthConfig
@@ -78,25 +73,6 @@ if TYPE_CHECKING:
     from web3.types import Nonce
 
     from ..receipt_breakdown import ReceiptBreakdown
-
-
-@dataclass
-class PoolState:
-    r"""A collection of stateful variables for deployed Hyperdrive and Yield contracts."""
-    block: BlockData
-    contract_pool_config: dict[str, Any]
-    contract_pool_info: dict[str, Any]
-    contract_checkpoint: dict[str, int]
-    variable_rate: FixedPoint
-    vault_shares: FixedPoint
-    total_supply_withdrawal_shares: FixedPoint
-
-    def __post_init__(self):
-        self.block_number = _get_block_number(self.block)
-        self.block_time = _get_block_time(self.block)
-        self.pool_config = convert_hyperdrive_pool_config_types(self.contract_pool_config)
-        self.pool_info = convert_hyperdrive_pool_info_types(self.contract_pool_info)
-        self.checkpoint = convert_hyperdrive_checkpoint_types(self.contract_checkpoint)
 
 
 class HyperdriveInterface:

--- a/lib/ethpy/ethpy/hyperdrive/api/api_test.py
+++ b/lib/ethpy/ethpy/hyperdrive/api/api_test.py
@@ -17,48 +17,48 @@ from .api import HyperdriveInterface
 class TestHyperdriveInterface:
     """Tests for the HyperdriveInterface api class."""
 
-    #    def test_pool_config(self, local_hyperdrive_pool: DeployedHyperdrivePool):
-    #        """Checks that the Hyperdrive pool_config matches what is returned from the smart contract.
-    #
-    #        All arguments are fixtures.
-    #        """
-    #        uri: URI | None = cast(HTTPProvider, local_hyperdrive_pool.web3.provider).endpoint_uri
-    #        rpc_uri = uri if uri else URI("http://localhost:8545")
-    #        abi_dir = "./packages/hyperdrive/src/abis"
-    #        hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_pool.hyperdrive_contract_addresses
-    #        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri, abi_dir=abi_dir)
-    #        hyperdrive = HyperdriveInterface(eth_config, addresses=hyperdrive_contract_addresses)
-    #        pool_config = smart_contract_read(hyperdrive.hyperdrive_contract, "getPoolConfig")
-    #        assert pool_config == hyperdrive.current_pool_state.contract_pool_config
-    #
-    #    def test_pool_info(self, local_hyperdrive_pool: DeployedHyperdrivePool):
-    #        """Checks that the Hyperdrive pool_info matches what is returned from the smart contract.
-    #
-    #        All arguments are fixtures.
-    #        """
-    #        uri: URI | None = cast(HTTPProvider, local_hyperdrive_pool.web3.provider).endpoint_uri
-    #        rpc_uri = uri if uri else URI("http://localhost:8545")
-    #        abi_dir = "./packages/hyperdrive/src/abis"
-    #        hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_pool.hyperdrive_contract_addresses
-    #        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri, abi_dir=abi_dir)
-    #        hyperdrive = HyperdriveInterface(eth_config, addresses=hyperdrive_contract_addresses)
-    #        pool_info = smart_contract_read(hyperdrive.hyperdrive_contract, "getPoolInfo")
-    #        assert pool_info == hyperdrive.current_pool_state.contract_pool_info
-    #
-    #    def test_checkpoint(self, local_hyperdrive_pool: DeployedHyperdrivePool):
-    #        """Checks that the Hyperdrive checkpoint matches what is returned from the smart contract.
-    #
-    #        All arguments are fixtures.
-    #        """
-    #        uri: URI | None = cast(HTTPProvider, local_hyperdrive_pool.web3.provider).endpoint_uri
-    #        rpc_uri = uri if uri else URI("http://localhost:8545")
-    #        abi_dir = "./packages/hyperdrive/src/abis"
-    #        hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_pool.hyperdrive_contract_addresses
-    #        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri, abi_dir=abi_dir)
-    #        hyperdrive = HyperdriveInterface(eth_config, addresses=hyperdrive_contract_addresses)
-    #        checkpoint_id = hyperdrive.calc_checkpoint_id(block_timestamp=hyperdrive.current_pool_state.block_time)
-    #        checkpoint = smart_contract_read(hyperdrive.hyperdrive_contract, "getCheckpoint", checkpoint_id)
-    #        assert checkpoint == hyperdrive.current_pool_state.contract_checkpoint
+    def test_pool_config(self, local_hyperdrive_pool: DeployedHyperdrivePool):
+        """Checks that the Hyperdrive pool_config matches what is returned from the smart contract.
+
+        All arguments are fixtures.
+        """
+        uri: URI | None = cast(HTTPProvider, local_hyperdrive_pool.web3.provider).endpoint_uri
+        rpc_uri = uri if uri else URI("http://localhost:8545")
+        abi_dir = "./packages/hyperdrive/src/abis"
+        hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_pool.hyperdrive_contract_addresses
+        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri, abi_dir=abi_dir)
+        hyperdrive = HyperdriveInterface(eth_config, addresses=hyperdrive_contract_addresses)
+        pool_config = smart_contract_read(hyperdrive.hyperdrive_contract, "getPoolConfig")
+        assert pool_config == hyperdrive.current_pool_state.contract_pool_config
+
+    def test_pool_info(self, local_hyperdrive_pool: DeployedHyperdrivePool):
+        """Checks that the Hyperdrive pool_info matches what is returned from the smart contract.
+
+        All arguments are fixtures.
+        """
+        uri: URI | None = cast(HTTPProvider, local_hyperdrive_pool.web3.provider).endpoint_uri
+        rpc_uri = uri if uri else URI("http://localhost:8545")
+        abi_dir = "./packages/hyperdrive/src/abis"
+        hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_pool.hyperdrive_contract_addresses
+        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri, abi_dir=abi_dir)
+        hyperdrive = HyperdriveInterface(eth_config, addresses=hyperdrive_contract_addresses)
+        pool_info = smart_contract_read(hyperdrive.hyperdrive_contract, "getPoolInfo")
+        assert pool_info == hyperdrive.current_pool_state.contract_pool_info
+
+    def test_checkpoint(self, local_hyperdrive_pool: DeployedHyperdrivePool):
+        """Checks that the Hyperdrive checkpoint matches what is returned from the smart contract.
+
+        All arguments are fixtures.
+        """
+        uri: URI | None = cast(HTTPProvider, local_hyperdrive_pool.web3.provider).endpoint_uri
+        rpc_uri = uri if uri else URI("http://localhost:8545")
+        abi_dir = "./packages/hyperdrive/src/abis"
+        hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_pool.hyperdrive_contract_addresses
+        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri, abi_dir=abi_dir)
+        hyperdrive = HyperdriveInterface(eth_config, addresses=hyperdrive_contract_addresses)
+        checkpoint_id = hyperdrive.calc_checkpoint_id(block_timestamp=hyperdrive.current_pool_state.block_time)
+        checkpoint = smart_contract_read(hyperdrive.hyperdrive_contract, "getCheckpoint", checkpoint_id)
+        assert checkpoint == hyperdrive.current_pool_state.contract_checkpoint
 
     def test_spot_price_and_fixed_rate(self, local_hyperdrive_pool: DeployedHyperdrivePool):
         """Checks that the Hyperdrive spot price and fixed rate match computing it by hand.
@@ -92,26 +92,24 @@ class TestHyperdriveInterface:
         fixed_rate = (FixedPoint(1) - spot_price) / (spot_price * hyperdrive.calc_position_duration_in_years())
         assert abs(fixed_rate - hyperdrive.calc_fixed_rate()) <= FixedPoint(scaled_value=100)
 
+    def test_misc(self, local_hyperdrive_pool: DeployedHyperdrivePool):
+        """Placeholder for additional tests.
 
-#    def test_misc(self, local_hyperdrive_pool: DeployedHyperdrivePool):
-#        """Placeholder for additional tests.
-#
-#        These are only verifying that the attributes exist and functions can be called.
-#        All arguments are fixtures.
-#        """
-#        uri: URI | None = cast(HTTPProvider, local_hyperdrive_pool.web3.provider).endpoint_uri
-#        rpc_uri = uri if uri else URI("http://localhost:8545")
-#        abi_dir = "./packages/hyperdrive/src/abis"
-#        hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_pool.hyperdrive_contract_addresses
-#        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri, abi_dir=abi_dir)
-#        hyperdrive = HyperdriveInterface(eth_config, addresses=hyperdrive_contract_addresses)
-#        _ = hyperdrive.current_pool_state
-#        _ = hyperdrive.current_pool_state.variable_rate
-#        _ = hyperdrive.current_pool_state.vault_shares
-#        _ = hyperdrive.calc_open_long(FixedPoint(100))
-#        _ = hyperdrive.calc_open_short(FixedPoint(100))
-#        _ = hyperdrive.calc_bonds_given_shares_and_rate(FixedPoint(0.05))
-#        _ = hyperdrive.calc_max_long(FixedPoint(1000))
-#        _ = hyperdrive.calc_max_short(FixedPoint(1000))
-#        # TODO: need an agent address to mock up trades
-#
+        These are only verifying that the attributes exist and functions can be called.
+        All arguments are fixtures.
+        """
+        uri: URI | None = cast(HTTPProvider, local_hyperdrive_pool.web3.provider).endpoint_uri
+        rpc_uri = uri if uri else URI("http://localhost:8545")
+        abi_dir = "./packages/hyperdrive/src/abis"
+        hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_pool.hyperdrive_contract_addresses
+        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri, abi_dir=abi_dir)
+        hyperdrive = HyperdriveInterface(eth_config, addresses=hyperdrive_contract_addresses)
+        _ = hyperdrive.current_pool_state
+        _ = hyperdrive.current_pool_state.variable_rate
+        _ = hyperdrive.current_pool_state.vault_shares
+        _ = hyperdrive.calc_open_long(FixedPoint(100))
+        _ = hyperdrive.calc_open_short(FixedPoint(100))
+        _ = hyperdrive.calc_bonds_given_shares_and_rate(FixedPoint(0.05))
+        _ = hyperdrive.calc_max_long(FixedPoint(1000))
+        _ = hyperdrive.calc_max_short(FixedPoint(1000))
+        # TODO: need an agent address to mock up trades

--- a/lib/ethpy/ethpy/hyperdrive/api/api_test.py
+++ b/lib/ethpy/ethpy/hyperdrive/api/api_test.py
@@ -17,48 +17,48 @@ from .api import HyperdriveInterface
 class TestHyperdriveInterface:
     """Tests for the HyperdriveInterface api class."""
 
-    def test_pool_config(self, local_hyperdrive_pool: DeployedHyperdrivePool):
-        """Checks that the Hyperdrive pool_config matches what is returned from the smart contract.
-
-        All arguments are fixtures.
-        """
-        uri: URI | None = cast(HTTPProvider, local_hyperdrive_pool.web3.provider).endpoint_uri
-        rpc_uri = uri if uri else URI("http://localhost:8545")
-        abi_dir = "./packages/hyperdrive/src/abis"
-        hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_pool.hyperdrive_contract_addresses
-        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri, abi_dir=abi_dir)
-        hyperdrive = HyperdriveInterface(eth_config, addresses=hyperdrive_contract_addresses)
-        pool_config = smart_contract_read(hyperdrive.hyperdrive_contract, "getPoolConfig")
-        assert pool_config == hyperdrive.current_pool_state.contract_pool_config
-
-    def test_pool_info(self, local_hyperdrive_pool: DeployedHyperdrivePool):
-        """Checks that the Hyperdrive pool_info matches what is returned from the smart contract.
-
-        All arguments are fixtures.
-        """
-        uri: URI | None = cast(HTTPProvider, local_hyperdrive_pool.web3.provider).endpoint_uri
-        rpc_uri = uri if uri else URI("http://localhost:8545")
-        abi_dir = "./packages/hyperdrive/src/abis"
-        hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_pool.hyperdrive_contract_addresses
-        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri, abi_dir=abi_dir)
-        hyperdrive = HyperdriveInterface(eth_config, addresses=hyperdrive_contract_addresses)
-        pool_info = smart_contract_read(hyperdrive.hyperdrive_contract, "getPoolInfo")
-        assert pool_info == hyperdrive.current_pool_state.contract_pool_info
-
-    def test_checkpoint(self, local_hyperdrive_pool: DeployedHyperdrivePool):
-        """Checks that the Hyperdrive checkpoint matches what is returned from the smart contract.
-
-        All arguments are fixtures.
-        """
-        uri: URI | None = cast(HTTPProvider, local_hyperdrive_pool.web3.provider).endpoint_uri
-        rpc_uri = uri if uri else URI("http://localhost:8545")
-        abi_dir = "./packages/hyperdrive/src/abis"
-        hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_pool.hyperdrive_contract_addresses
-        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri, abi_dir=abi_dir)
-        hyperdrive = HyperdriveInterface(eth_config, addresses=hyperdrive_contract_addresses)
-        checkpoint_id = hyperdrive.calc_checkpoint_id(block_timestamp=hyperdrive.current_pool_state.block_time)
-        checkpoint = smart_contract_read(hyperdrive.hyperdrive_contract, "getCheckpoint", checkpoint_id)
-        assert checkpoint == hyperdrive.current_pool_state.contract_checkpoint
+    #    def test_pool_config(self, local_hyperdrive_pool: DeployedHyperdrivePool):
+    #        """Checks that the Hyperdrive pool_config matches what is returned from the smart contract.
+    #
+    #        All arguments are fixtures.
+    #        """
+    #        uri: URI | None = cast(HTTPProvider, local_hyperdrive_pool.web3.provider).endpoint_uri
+    #        rpc_uri = uri if uri else URI("http://localhost:8545")
+    #        abi_dir = "./packages/hyperdrive/src/abis"
+    #        hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_pool.hyperdrive_contract_addresses
+    #        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri, abi_dir=abi_dir)
+    #        hyperdrive = HyperdriveInterface(eth_config, addresses=hyperdrive_contract_addresses)
+    #        pool_config = smart_contract_read(hyperdrive.hyperdrive_contract, "getPoolConfig")
+    #        assert pool_config == hyperdrive.current_pool_state.contract_pool_config
+    #
+    #    def test_pool_info(self, local_hyperdrive_pool: DeployedHyperdrivePool):
+    #        """Checks that the Hyperdrive pool_info matches what is returned from the smart contract.
+    #
+    #        All arguments are fixtures.
+    #        """
+    #        uri: URI | None = cast(HTTPProvider, local_hyperdrive_pool.web3.provider).endpoint_uri
+    #        rpc_uri = uri if uri else URI("http://localhost:8545")
+    #        abi_dir = "./packages/hyperdrive/src/abis"
+    #        hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_pool.hyperdrive_contract_addresses
+    #        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri, abi_dir=abi_dir)
+    #        hyperdrive = HyperdriveInterface(eth_config, addresses=hyperdrive_contract_addresses)
+    #        pool_info = smart_contract_read(hyperdrive.hyperdrive_contract, "getPoolInfo")
+    #        assert pool_info == hyperdrive.current_pool_state.contract_pool_info
+    #
+    #    def test_checkpoint(self, local_hyperdrive_pool: DeployedHyperdrivePool):
+    #        """Checks that the Hyperdrive checkpoint matches what is returned from the smart contract.
+    #
+    #        All arguments are fixtures.
+    #        """
+    #        uri: URI | None = cast(HTTPProvider, local_hyperdrive_pool.web3.provider).endpoint_uri
+    #        rpc_uri = uri if uri else URI("http://localhost:8545")
+    #        abi_dir = "./packages/hyperdrive/src/abis"
+    #        hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_pool.hyperdrive_contract_addresses
+    #        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri, abi_dir=abi_dir)
+    #        hyperdrive = HyperdriveInterface(eth_config, addresses=hyperdrive_contract_addresses)
+    #        checkpoint_id = hyperdrive.calc_checkpoint_id(block_timestamp=hyperdrive.current_pool_state.block_time)
+    #        checkpoint = smart_contract_read(hyperdrive.hyperdrive_contract, "getCheckpoint", checkpoint_id)
+    #        assert checkpoint == hyperdrive.current_pool_state.contract_checkpoint
 
     def test_spot_price_and_fixed_rate(self, local_hyperdrive_pool: DeployedHyperdrivePool):
         """Checks that the Hyperdrive spot price and fixed rate match computing it by hand.
@@ -92,24 +92,26 @@ class TestHyperdriveInterface:
         fixed_rate = (FixedPoint(1) - spot_price) / (spot_price * hyperdrive.calc_position_duration_in_years())
         assert abs(fixed_rate - hyperdrive.calc_fixed_rate()) <= FixedPoint(scaled_value=100)
 
-    def test_misc(self, local_hyperdrive_pool: DeployedHyperdrivePool):
-        """Placeholder for additional tests.
 
-        These are only verifying that the attributes exist and functions can be called.
-        All arguments are fixtures.
-        """
-        uri: URI | None = cast(HTTPProvider, local_hyperdrive_pool.web3.provider).endpoint_uri
-        rpc_uri = uri if uri else URI("http://localhost:8545")
-        abi_dir = "./packages/hyperdrive/src/abis"
-        hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_pool.hyperdrive_contract_addresses
-        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri, abi_dir=abi_dir)
-        hyperdrive = HyperdriveInterface(eth_config, addresses=hyperdrive_contract_addresses)
-        _ = hyperdrive.current_pool_state
-        _ = hyperdrive.current_pool_state.variable_rate
-        _ = hyperdrive.current_pool_state.vault_shares
-        _ = hyperdrive.calc_open_long(FixedPoint(100))
-        _ = hyperdrive.calc_open_short(FixedPoint(100))
-        _ = hyperdrive.calc_bonds_given_shares_and_rate(FixedPoint(0.05))
-        _ = hyperdrive.calc_max_long(FixedPoint(1000))
-        _ = hyperdrive.calc_max_short(FixedPoint(1000))
-        # TODO: need an agent address to mock up trades
+#    def test_misc(self, local_hyperdrive_pool: DeployedHyperdrivePool):
+#        """Placeholder for additional tests.
+#
+#        These are only verifying that the attributes exist and functions can be called.
+#        All arguments are fixtures.
+#        """
+#        uri: URI | None = cast(HTTPProvider, local_hyperdrive_pool.web3.provider).endpoint_uri
+#        rpc_uri = uri if uri else URI("http://localhost:8545")
+#        abi_dir = "./packages/hyperdrive/src/abis"
+#        hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_pool.hyperdrive_contract_addresses
+#        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri, abi_dir=abi_dir)
+#        hyperdrive = HyperdriveInterface(eth_config, addresses=hyperdrive_contract_addresses)
+#        _ = hyperdrive.current_pool_state
+#        _ = hyperdrive.current_pool_state.variable_rate
+#        _ = hyperdrive.current_pool_state.vault_shares
+#        _ = hyperdrive.calc_open_long(FixedPoint(100))
+#        _ = hyperdrive.calc_open_short(FixedPoint(100))
+#        _ = hyperdrive.calc_bonds_given_shares_and_rate(FixedPoint(0.05))
+#        _ = hyperdrive.calc_max_long(FixedPoint(1000))
+#        _ = hyperdrive.calc_max_short(FixedPoint(1000))
+#        # TODO: need an agent address to mock up trades
+#

--- a/lib/ethpy/ethpy/hyperdrive/state/__init__.py
+++ b/lib/ethpy/ethpy/hyperdrive/state/__init__.py
@@ -1,0 +1,11 @@
+from .checkpoint import Checkpoint
+from .conversions import (
+    convert_hyperdrive_checkpoint_types,
+    convert_hyperdrive_pool_config_types,
+    convert_hyperdrive_pool_info_types,
+    dataclass_to_dict,
+)
+from .fees import Fees
+from .pool_config import PoolConfig
+from .pool_info import PoolInfo
+from .pool_state import PoolState

--- a/lib/ethpy/ethpy/hyperdrive/state/__init__.py
+++ b/lib/ethpy/ethpy/hyperdrive/state/__init__.py
@@ -1,10 +1,4 @@
 from .checkpoint import Checkpoint
-from .conversions import (
-    convert_hyperdrive_checkpoint_types,
-    convert_hyperdrive_pool_config_types,
-    convert_hyperdrive_pool_info_types,
-    dataclass_to_dict,
-)
 from .fees import Fees
 from .pool_config import PoolConfig
 from .pool_info import PoolInfo

--- a/lib/ethpy/ethpy/hyperdrive/state/__init__.py
+++ b/lib/ethpy/ethpy/hyperdrive/state/__init__.py
@@ -1,3 +1,4 @@
+"""Hyperdrive state classes and conversion helper functions."""
 from .checkpoint import Checkpoint
 from .fees import Fees
 from .pool_config import PoolConfig

--- a/lib/ethpy/ethpy/hyperdrive/state/checkpoint.py
+++ b/lib/ethpy/ethpy/hyperdrive/state/checkpoint.py
@@ -1,0 +1,14 @@
+"""Functions for storing Hyperdrive state."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fixedpointmath import FixedPoint
+
+
+@dataclass
+class Checkpoint:
+    """Checkpoint struct."""
+
+    share_price: FixedPoint
+    exposure: FixedPoint

--- a/lib/ethpy/ethpy/hyperdrive/state/conversions.py
+++ b/lib/ethpy/ethpy/hyperdrive/state/conversions.py
@@ -1,0 +1,91 @@
+"""Functions for converting Hyperdrive state values."""
+from __future__ import annotations
+
+from typing import Any
+
+from ethpy.hyperdrive.addresses import camel_to_snake
+from fixedpointmath import FixedPoint
+
+from .checkpoint import Checkpoint
+from .fees import Fees
+from .pool_config import PoolConfig
+from .pool_info import PoolInfo
+
+
+def dataclass_to_dict(cls: PoolInfo | PoolConfig):
+    out_dict = {}
+    for key, val in cls.__dict__.items():
+        match val:
+            case FixedPoint():
+                out_dict[key] = str(val.scaled_value)
+            case int():
+                out_dict[key] = str(val)
+            case str():
+                out_dict[key] = val
+            case Fees():
+                out_dict[key] = (val.curve, val.flat, val.governance)
+            case _:
+                raise TypeError("Unsupported type.")
+    return out_dict
+
+
+def convert_hyperdrive_pool_config_types(pool_config: dict[str, Any]) -> PoolConfig:
+    """Convert the pool_config types from what solidity returns to FixedPoint
+
+    Arguments
+    ----------
+    pool_config : dict[str, Any]
+        The hyperdrive pool config.
+
+    Returns
+    -------
+    PoolConfig
+        A dataclass containing the Hyperdrive pool config with modified types.
+        This dataclass has the same attributes as the Hyperdrive ABI, with these changes:
+          - The attribute names are converted to snake_case.
+          - FixedPoint types are used if the type was FixedPoint in the underlying contract.
+    """
+    # Adjust the pool_config to use snake case here
+    # Dict comp is a copy
+    pool_config = {camel_to_snake(key): value for key, value in pool_config.items()}
+    fixedpoint_keys = ["initial_share_price", "minimum_share_reserves", "minimum_transaction_amount", "time_stretch"]
+    for key in pool_config:
+        if key in fixedpoint_keys:
+            pool_config[key] = FixedPoint(scaled_value=pool_config[key])
+    pool_config["fees"] = [FixedPoint(scaled_value=fee) for fee in pool_config["fees"]]
+    return PoolConfig(**pool_config)
+
+
+def convert_hyperdrive_pool_info_types(pool_info: dict[str, Any]) -> PoolInfo:
+    """Convert the pool info types from what solidity returns to FixedPoint.
+
+    Arguments
+    ---------
+    pool_info : dict[str, Any]
+        The hyperdrive pool info.
+
+    Returns
+    -------
+    PoolInfo
+        A dataclass containing the Hyperdrive pool info with modified types.
+        This dataclass has the same attributes as the Hyperdrive ABI, with these changes:
+          - The attribute names are converted to snake_case.
+          - FixedPoint types are used if the type was FixedPoint in the underlying contract.
+    """
+    return PoolInfo(**{camel_to_snake(key): FixedPoint(scaled_value=value) for (key, value) in pool_info.items()})
+
+
+def convert_hyperdrive_checkpoint_types(checkpoint: dict[str, int]) -> Checkpoint:
+    """Convert the checkpoint types from what solidity returns to FixedPoint.
+
+    Arguments
+    ---------
+    checkpoint : dict[str, int]
+        A dictionary containing the checkpoint details.
+
+    Returns
+    -------
+    Checkpoint
+        A dataclass containing the checkpoint share_price and exposure fields converted to FixedPoint.
+    """
+    return Checkpoint(**{camel_to_snake(key): FixedPoint(scaled_value=value) for key, value in checkpoint.items()})

--- a/lib/ethpy/ethpy/hyperdrive/state/conversions.py
+++ b/lib/ethpy/ethpy/hyperdrive/state/conversions.py
@@ -1,10 +1,10 @@
 """Functions for converting Hyperdrive state values."""
 from __future__ import annotations
 
+import re
 from dataclasses import asdict
 from typing import Any
 
-from ethpy.hyperdrive.addresses import camel_to_snake, snake_to_camel
 from fixedpointmath import FixedPoint
 from hypertypes.IHyperdriveTypes import Checkpoint as HtCheckpoint
 from hypertypes.IHyperdriveTypes import Fees as HtFees
@@ -15,6 +15,19 @@ from .checkpoint import Checkpoint
 from .fees import Fees
 from .pool_config import PoolConfig
 from .pool_info import PoolInfo
+
+
+def camel_to_snake(snake_string: str) -> str:
+    """Convert camel case string to snake case string."""
+    return re.sub(r"(?<!^)(?=[A-Z])", "_", snake_string).lower()
+
+
+def snake_to_camel(snake_string: str) -> str:
+    """Convert snake case string to camel case string."""
+    # First capitalize the letters following the underscores and remove underscores
+    camel_string = re.sub(r"_([a-z])", lambda x: x.group(1).upper(), snake_string)
+    # Ensure the first character is lowercase to achieve lowerCamelCase
+    return camel_string[0].lower() + camel_string[1:] if camel_string else camel_string
 
 
 def dataclass_to_dict(

--- a/lib/ethpy/ethpy/hyperdrive/state/conversions.py
+++ b/lib/ethpy/ethpy/hyperdrive/state/conversions.py
@@ -33,7 +33,7 @@ def snake_to_camel(snake_string: str) -> str:
 def dataclass_to_dict(
     cls: HtPoolInfo | PoolInfo | HtPoolConfig | PoolConfig | HtCheckpoint | Checkpoint,
 ) -> dict[str, Any]:
-    """Convert a pool state dataclass into a dictionary."""
+    """Convert a state dataclass into a dictionary."""
     out_dict = {}
     for key, val in asdict(cls).items():
         match val:
@@ -55,7 +55,7 @@ def dataclass_to_dict(
 
 
 def contract_pool_config_to_hypertypes(contract_pool_config: dict[str, Any]) -> HtPoolConfig:
-    """Convert the contract call return value into a proper PoolConfig object."""
+    """Convert the contract call returned pool config into a HyperTypes PoolConfig object."""
     return HtPoolConfig(
         baseToken=contract_pool_config["baseToken"],
         linkerFactory=contract_pool_config["linkerFactory"],
@@ -78,7 +78,7 @@ def contract_pool_config_to_hypertypes(contract_pool_config: dict[str, Any]) -> 
 
 
 def hypertypes_pool_config_to_fixedpoint(hypertypes_pool_config: HtPoolConfig) -> PoolConfig:
-    """Convert the pool_config types from what solidity returns to FixedPoint.
+    """Convert the HyperTypes PoolConfig attributes from what Solidity returns to FixedPoint.
 
     Arguments
     ----------
@@ -93,9 +93,7 @@ def hypertypes_pool_config_to_fixedpoint(hypertypes_pool_config: HtPoolConfig) -
           - The attribute names are converted to snake_case.
           - FixedPoint types are used if the type was FixedPoint in the underlying contract.
     """
-    dict_pool_config = {
-        camel_to_snake(key): value for key, value in asdict(hypertypes_pool_config).items()
-    }  # dict comp is a copy
+    dict_pool_config = {camel_to_snake(key): value for key, value in asdict(hypertypes_pool_config).items()}
     fixedpoint_keys = ["initial_share_price", "minimum_share_reserves", "minimum_transaction_amount", "time_stretch"]
     for key in dict_pool_config:
         if key in fixedpoint_keys:
@@ -110,7 +108,7 @@ def hypertypes_pool_config_to_fixedpoint(hypertypes_pool_config: HtPoolConfig) -
 
 
 def fixedpoint_pool_config_to_hypertypes(fixedpoint_pool_config: PoolConfig) -> HtPoolConfig:
-    """Convert the pool_config types from FixedPoint to what the Solidity ABI specifies.
+    """Convert the PoolConfig attribute types from FixedPoint to what the Solidity ABI specifies.
 
     Arguments
     ----------
@@ -120,7 +118,7 @@ def fixedpoint_pool_config_to_hypertypes(fixedpoint_pool_config: PoolConfig) -> 
     Returns
     -------
     hypertypes.IHyperdriveTypes.PoolConfig
-        A dataclass containing the Hyperdrive pool config with types specified by the ABI via Pypechain
+        A dataclass containing the Hyperdrive PoolConfig with types specified by the ABI via Pypechain
     """
     dict_pool_config = {snake_to_camel(key): value for key, value in asdict(fixedpoint_pool_config).items()}
     fixedpoint_keys = ["initialSharePrice", "minimumShareReserves", "minimumTransactionAmount", "timeStretch"]
@@ -155,12 +153,12 @@ def fixedpoint_pool_config_to_hypertypes(fixedpoint_pool_config: PoolConfig) -> 
 
 
 def contract_pool_info_to_hypertypes(contract_pool_info: dict[str, Any]) -> HtPoolInfo:
-    """Convert the contract call return value into a proper PoolInfo object."""
+    """Convert the contract call return value into a HyperTypes PoolInfo object."""
     return HtPoolInfo(**contract_pool_info)
 
 
 def hypertypes_pool_info_to_fixedpoint(hypertypes_pool_info: HtPoolInfo) -> PoolInfo:
-    """Convert the pool info types from what solidity returns to FixedPoint.
+    """Convert the Hypertypes PoolInfo attribute types from what solidity returns to FixedPoint.
 
     Arguments
     ---------
@@ -181,7 +179,7 @@ def hypertypes_pool_info_to_fixedpoint(hypertypes_pool_info: HtPoolInfo) -> Pool
 
 
 def fixedpoint_pool_info_to_hypertypes(fixedpoint_pool_info: PoolInfo) -> HtPoolInfo:
-    """Convert the FixedPoint PoolInfo object to HyperTypes.
+    """Convert the PoolInfo attribute types from FixedPoint to what the Solidity ABI specifies.
 
     Arguments
     ---------
@@ -199,12 +197,12 @@ def fixedpoint_pool_info_to_hypertypes(fixedpoint_pool_info: PoolInfo) -> HtPool
 
 
 def contract_checkpoint_to_hypertypes(contract_checkpoint: dict[str, Any]) -> HtCheckpoint:
-    """Convert the contract call return value into a proper PoolInfo object."""
+    """Convert the contract call return value into a HyperTypes Checkpoint object."""
     return HtCheckpoint(**contract_checkpoint)
 
 
 def hypertypes_checkpoint_to_fixedpoint(hypertypes_checkpoint: HtCheckpoint) -> Checkpoint:
-    """Convert the checkpoint types from what solidity returns to FixedPoint.
+    """Convert the HyperTypes Checkpoint attribute types from what Solidity returns to FixedPoint.
 
     Arguments
     ---------
@@ -222,7 +220,7 @@ def hypertypes_checkpoint_to_fixedpoint(hypertypes_checkpoint: HtCheckpoint) -> 
 
 
 def fixedpoint_checkpoint_to_hypertypes(fixedpoint_checkpoint: Checkpoint) -> HtCheckpoint:
-    """Convert the checkpoint types from FixedPoint to what the Solidity ABI specifies.
+    """Convert the Checkpoint attribute types from FixedPoint to what the Solidity ABI specifies.
 
     Arguments
     ---------

--- a/lib/ethpy/ethpy/hyperdrive/state/conversions.py
+++ b/lib/ethpy/ethpy/hyperdrive/state/conversions.py
@@ -1,10 +1,15 @@
 """Functions for converting Hyperdrive state values."""
 from __future__ import annotations
 
+from dataclasses import asdict
 from typing import Any
 
-from ethpy.hyperdrive.addresses import camel_to_snake
+from ethpy.hyperdrive.addresses import camel_to_snake, snake_to_camel
 from fixedpointmath import FixedPoint
+from hypertypes.IHyperdriveTypes import Checkpoint as HtCheckpoint
+from hypertypes.IHyperdriveTypes import Fees as HtFees
+from hypertypes.IHyperdriveTypes import PoolConfig as HtPoolConfig
+from hypertypes.IHyperdriveTypes import PoolInfo as HtPoolInfo
 
 from .checkpoint import Checkpoint
 from .fees import Fees
@@ -12,9 +17,12 @@ from .pool_config import PoolConfig
 from .pool_info import PoolInfo
 
 
-def dataclass_to_dict(cls: PoolInfo | PoolConfig):
+def dataclass_to_dict(
+    cls: HtPoolInfo | PoolInfo | HtPoolConfig | PoolConfig | HtCheckpoint | Checkpoint,
+) -> dict[str, Any]:
+    """Convert a pool state dataclass into a dictionary."""
     out_dict = {}
-    for key, val in cls.__dict__.items():
+    for key, val in asdict(cls).items():
         match val:
             case FixedPoint():
                 out_dict[key] = str(val.scaled_value)
@@ -23,69 +31,184 @@ def dataclass_to_dict(cls: PoolInfo | PoolConfig):
             case str():
                 out_dict[key] = val
             case Fees():
-                out_dict[key] = (val.curve, val.flat, val.governance)
+                out_dict[key] = (str(val.curve), str(val.flat), str(val.governance))
             case _:
                 raise TypeError("Unsupported type.")
     return out_dict
 
 
-def convert_hyperdrive_pool_config_types(pool_config: dict[str, Any]) -> PoolConfig:
-    """Convert the pool_config types from what solidity returns to FixedPoint
+def contract_pool_config_to_hypertypes(contract_pool_config: dict[str, Any]) -> HtPoolConfig:
+    """Convert the contract call return value into a proper PoolConfig object."""
+    return HtPoolConfig(
+        baseToken=contract_pool_config["baseToken"],
+        linkerFactory=contract_pool_config["linkerFactory"],
+        linkerCodeHash=contract_pool_config["linkerCodeHash"],
+        initialSharePrice=contract_pool_config["initialSharePrice"],
+        minimumShareReserves=contract_pool_config["minimumShareReserves"],
+        minimumTransactionAmount=contract_pool_config["minimumTransactionAmount"],
+        precisionThreshold=contract_pool_config["precisionThreshold"],
+        positionDuration=contract_pool_config["positionDuration"],
+        checkpointDuration=contract_pool_config["checkpointDuration"],
+        timeStretch=contract_pool_config["timeStretch"],
+        governance=contract_pool_config["governance"],
+        feeCollector=contract_pool_config["feeCollector"],
+        fees=HtFees(
+            curve=contract_pool_config["fees"][0],
+            flat=contract_pool_config["fees"][1],
+            governance=contract_pool_config["fees"][2],
+        ),
+    )
+
+
+def hypertypes_pool_config_to_fixedpoint(hypertypes_pool_config: HtPoolConfig) -> PoolConfig:
+    """Convert the pool_config types from what solidity returns to FixedPoint.
 
     Arguments
     ----------
-    pool_config : dict[str, Any]
+    pool_config : hypertypes.IHyperdriveTypes.PoolConfig
         The hyperdrive pool config.
 
     Returns
     -------
-    PoolConfig
+    ethpy.hyperdrive.state.PoolConfig
         A dataclass containing the Hyperdrive pool config with modified types.
         This dataclass has the same attributes as the Hyperdrive ABI, with these changes:
           - The attribute names are converted to snake_case.
           - FixedPoint types are used if the type was FixedPoint in the underlying contract.
     """
-    # Adjust the pool_config to use snake case here
-    # Dict comp is a copy
-    pool_config = {camel_to_snake(key): value for key, value in pool_config.items()}
+    dict_pool_config = {
+        camel_to_snake(key): value for key, value in asdict(hypertypes_pool_config).items()
+    }  # dict comp is a copy
     fixedpoint_keys = ["initial_share_price", "minimum_share_reserves", "minimum_transaction_amount", "time_stretch"]
-    for key in pool_config:
+    for key in dict_pool_config:
         if key in fixedpoint_keys:
-            pool_config[key] = FixedPoint(scaled_value=pool_config[key])
-    pool_config["fees"] = [FixedPoint(scaled_value=fee) for fee in pool_config["fees"]]
-    return PoolConfig(**pool_config)
+            dict_pool_config[key] = FixedPoint(scaled_value=dict_pool_config[key])
+        elif key == "fees":
+            dict_pool_config[key] = [FixedPoint(scaled_value=fee) for fee in dict_pool_config[key]]
+    return PoolConfig(**dict_pool_config)
 
 
-def convert_hyperdrive_pool_info_types(pool_info: dict[str, Any]) -> PoolInfo:
+def fixedpoint_pool_config_to_hypertypes(fixedpoint_pool_config: PoolConfig) -> HtPoolConfig:
+    """Convert the pool_config types from FixedPoint to what the Solidity ABI specifies.
+
+    Arguments
+    ----------
+    pool_config : ethpy.hyperdrive.state.PoolConfig
+        The Hyperdrive pool config in FixedPoint format.
+
+    Returns
+    -------
+    hypertypes.IHyperdriveTypes.PoolConfig
+        A dataclass containing the Hyperdrive pool config with types specified by the ABI via Pypechain
+    """
+    dict_pool_config = {snake_to_camel(key): value for key, value in asdict(fixedpoint_pool_config).items()}
+    fixedpoint_keys = ["initial_share_price", "minimum_share_reserves", "minimum_transaction_amount", "time_stretch"]
+    for key in dict_pool_config:
+        if key in fixedpoint_keys:
+            dict_pool_config[key] = dict_pool_config[key].scaled_value
+        elif key == "fees":
+            dict_pool_config[key] = [fee.scaled_value for fee in dict_pool_config[key]]
+    return HtPoolConfig(
+        baseToken=dict_pool_config["baseToken"],
+        linkerFactory=dict_pool_config["linkerFactory"],
+        linkerCodeHash=dict_pool_config["linkerCodeHash"],
+        initialSharePrice=dict_pool_config["initialSharePrice"],
+        minimumShareReserves=dict_pool_config["minimumShareReserves"],
+        minimumTransactionAmount=dict_pool_config["minimumTransactionAmount"],
+        precisionThreshold=dict_pool_config["precisionThreshold"],
+        positionDuration=dict_pool_config["positionDuration"],
+        checkpointDuration=dict_pool_config["checkpointDuration"],
+        timeStretch=dict_pool_config["timeStretch"],
+        governance=dict_pool_config["governance"],
+        feeCollector=dict_pool_config["feeCollector"],
+        fees=HtFees(
+            curve=dict_pool_config["fees"][0],
+            flat=dict_pool_config["fees"][1],
+            governance=dict_pool_config["fees"][2],
+        ),
+    )
+
+
+def contract_pool_info_to_hypertypes(contract_pool_info: dict[str, Any]) -> HtPoolInfo:
+    """Convert the contract call return value into a proper PoolInfo object."""
+    return HtPoolInfo(**contract_pool_info)
+
+
+def hypertypes_pool_info_to_fixedpoint(hypertypes_pool_info: HtPoolInfo) -> PoolInfo:
     """Convert the pool info types from what solidity returns to FixedPoint.
 
     Arguments
     ---------
-    pool_info : dict[str, Any]
+    pool_info : hypertypes.IHyperdriveTypes.PoolInfo
         The hyperdrive pool info.
 
     Returns
     -------
-    PoolInfo
+    ethpy.hyperdrive.state.PoolInfo
         A dataclass containing the Hyperdrive pool info with modified types.
         This dataclass has the same attributes as the Hyperdrive ABI, with these changes:
           - The attribute names are converted to snake_case.
           - FixedPoint types are used if the type was FixedPoint in the underlying contract.
     """
-    return PoolInfo(**{camel_to_snake(key): FixedPoint(scaled_value=value) for (key, value) in pool_info.items()})
+    return PoolInfo(
+        **{camel_to_snake(key): FixedPoint(scaled_value=value) for (key, value) in asdict(hypertypes_pool_info).items()}
+    )
 
 
-def convert_hyperdrive_checkpoint_types(checkpoint: dict[str, int]) -> Checkpoint:
+def fixedpoint_pool_info_to_hypertypes(fixedpoint_pool_info: PoolInfo) -> HtPoolInfo:
+    """Convert the FixedPoint PoolInfo object to HyperTypes.
+
+    Arguments
+    ---------
+    pool_info : ethpy.hyperdrive.state.PoolInfo
+        The hyperdrive pool info.
+
+    Returns
+    -------
+    hypertypes.IHyperdriveTypes.PoolInfo
+        A dataclass containing the Hyperdrive pool info with derived types from Pypechain.
+    """
+    return HtPoolInfo(
+        **{snake_to_camel(key): value.scaled_value for (key, value) in asdict(fixedpoint_pool_info).items()}
+    )
+
+
+def contract_checkpoint_to_hypertypes(contract_checkpoint: dict[str, Any]) -> HtCheckpoint:
+    """Convert the contract call return value into a proper PoolInfo object."""
+    return HtCheckpoint(**contract_checkpoint)
+
+
+def hypertypes_checkpoint_to_fixedpoint(hypertypes_checkpoint: HtCheckpoint) -> Checkpoint:
     """Convert the checkpoint types from what solidity returns to FixedPoint.
 
     Arguments
     ---------
-    checkpoint : dict[str, int]
-        A dictionary containing the checkpoint details.
+    checkpoint : hypertypes.IHyperdriveTypes.Checkpoint
+        A checkpoint object with sharePrice and exposure fields with derived types from Pypechain.
 
     Returns
     -------
-    Checkpoint
+    ethpy.hyperdrive.state.Checkpoint
         A dataclass containing the checkpoint share_price and exposure fields converted to FixedPoint.
     """
-    return Checkpoint(**{camel_to_snake(key): FixedPoint(scaled_value=value) for key, value in checkpoint.items()})
+    return Checkpoint(
+        **{camel_to_snake(key): FixedPoint(scaled_value=value) for key, value in asdict(hypertypes_checkpoint).items()}
+    )
+
+
+def fixedpoint_checkpoint_to_hypertypes(fixedpoint_checkpoint: Checkpoint) -> HtCheckpoint:
+    """Convert the checkpoint types from FixedPoint to what the Solidity ABI specifies.
+
+    Arguments
+    ---------
+    checkpoint : ethpy.hyperdrive.state.Checkpoint
+        A checkpoint object with FixedPoint values.
+
+    Returns
+    -------
+    hypertypes.IHyperdriveTypes.Checkpoint
+        A dataclass containing the checkpoint share_price and exposure fields converted to integers.
+    """
+    return HtCheckpoint(
+        **{snake_to_camel(key): value.scaled_value for key, value in asdict(fixedpoint_checkpoint).items()}
+    )

--- a/lib/ethpy/ethpy/hyperdrive/state/conversions_test.py
+++ b/lib/ethpy/ethpy/hyperdrive/state/conversions_test.py
@@ -1,0 +1,59 @@
+"""Tests for hyperdrive/state/conversions.py"""
+from __future__ import annotations
+
+from typing import cast
+
+from eth_typing import URI
+from ethpy import EthConfig
+from ethpy.base.transactions import smart_contract_read
+from ethpy.hyperdrive.addresses import HyperdriveAddresses
+from ethpy.hyperdrive.api import HyperdriveInterface
+from ethpy.hyperdrive.deploy import DeployedHyperdrivePool
+from hypertypes.IHyperdriveTypes import Checkpoint as HtCheckpoint
+from hypertypes.IHyperdriveTypes import PoolConfig as HtPoolConfig
+from hypertypes.IHyperdriveTypes import PoolInfo as HtPoolInfo
+from web3 import HTTPProvider
+
+from .conversions import (
+    contract_checkpoint_to_hypertypes,
+    contract_pool_config_to_hypertypes,
+    contract_pool_info_to_hypertypes,
+)
+
+
+class TestHyperdriveInterface:
+    """Tests for the HyperdriveInterface api class."""
+
+    def test_contract_pool_config_to_hypertypes(self, local_hyperdrive_pool: DeployedHyperdrivePool):
+        uri: URI | None = cast(HTTPProvider, local_hyperdrive_pool.web3.provider).endpoint_uri
+        rpc_uri = uri if uri else URI("http://localhost:8545")
+        abi_dir = "./packages/hyperdrive/src/abis"
+        hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_pool.hyperdrive_contract_addresses
+        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri, abi_dir=abi_dir)
+        hyperdrive = HyperdriveInterface(eth_config, addresses=hyperdrive_contract_addresses)
+        pool_config = smart_contract_read(hyperdrive.hyperdrive_contract, "getPoolConfig")
+        hypertypes_pool_config = contract_pool_config_to_hypertypes(pool_config)
+        assert isinstance(hypertypes_pool_config, HtPoolConfig)
+
+    def test_contract_pool_info_to_hypertypes(self, local_hyperdrive_pool: DeployedHyperdrivePool):
+        uri: URI | None = cast(HTTPProvider, local_hyperdrive_pool.web3.provider).endpoint_uri
+        rpc_uri = uri if uri else URI("http://localhost:8545")
+        abi_dir = "./packages/hyperdrive/src/abis"
+        hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_pool.hyperdrive_contract_addresses
+        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri, abi_dir=abi_dir)
+        hyperdrive = HyperdriveInterface(eth_config, addresses=hyperdrive_contract_addresses)
+        pool_info = smart_contract_read(hyperdrive.hyperdrive_contract, "getPoolInfo")
+        hypertypes_pool_info = contract_pool_info_to_hypertypes(pool_info)
+        assert isinstance(hypertypes_pool_info, HtPoolInfo)
+
+    def test_contract_checkpoint_to_hypertypes(self, local_hyperdrive_pool: DeployedHyperdrivePool):
+        uri: URI | None = cast(HTTPProvider, local_hyperdrive_pool.web3.provider).endpoint_uri
+        rpc_uri = uri if uri else URI("http://localhost:8545")
+        abi_dir = "./packages/hyperdrive/src/abis"
+        hyperdrive_contract_addresses: HyperdriveAddresses = local_hyperdrive_pool.hyperdrive_contract_addresses
+        eth_config = EthConfig(artifacts_uri="not used", rpc_uri=rpc_uri, abi_dir=abi_dir)
+        hyperdrive = HyperdriveInterface(eth_config, addresses=hyperdrive_contract_addresses)
+        block_timestamp = hyperdrive.get_block_timestamp(hyperdrive.get_current_block())
+        checkpoint = smart_contract_read(hyperdrive.hyperdrive_contract, "getCheckpoint", block_timestamp)
+        hypertypes_checkpoint = contract_checkpoint_to_hypertypes(checkpoint)
+        assert isinstance(hypertypes_checkpoint, HtCheckpoint)

--- a/lib/ethpy/ethpy/hyperdrive/state/conversions_test.py
+++ b/lib/ethpy/ethpy/hyperdrive/state/conversions_test.py
@@ -25,6 +25,7 @@ class TestHyperdriveInterface:
     """Tests for the HyperdriveInterface api class."""
 
     def test_contract_pool_config_to_hypertypes(self, local_hyperdrive_pool: DeployedHyperdrivePool):
+        """Test the type conversion from a smart contract read call to Pypechain output."""
         uri: URI | None = cast(HTTPProvider, local_hyperdrive_pool.web3.provider).endpoint_uri
         rpc_uri = uri if uri else URI("http://localhost:8545")
         abi_dir = "./packages/hyperdrive/src/abis"
@@ -36,6 +37,7 @@ class TestHyperdriveInterface:
         assert isinstance(hypertypes_pool_config, HtPoolConfig)
 
     def test_contract_pool_info_to_hypertypes(self, local_hyperdrive_pool: DeployedHyperdrivePool):
+        """Test the type conversion from a smart contract read call to Pypechain output."""
         uri: URI | None = cast(HTTPProvider, local_hyperdrive_pool.web3.provider).endpoint_uri
         rpc_uri = uri if uri else URI("http://localhost:8545")
         abi_dir = "./packages/hyperdrive/src/abis"
@@ -47,6 +49,7 @@ class TestHyperdriveInterface:
         assert isinstance(hypertypes_pool_info, HtPoolInfo)
 
     def test_contract_checkpoint_to_hypertypes(self, local_hyperdrive_pool: DeployedHyperdrivePool):
+        """Test the type conversion from a smart contract read call to Pypechain output."""
         uri: URI | None = cast(HTTPProvider, local_hyperdrive_pool.web3.provider).endpoint_uri
         rpc_uri = uri if uri else URI("http://localhost:8545")
         abi_dir = "./packages/hyperdrive/src/abis"

--- a/lib/ethpy/ethpy/hyperdrive/state/fees.py
+++ b/lib/ethpy/ethpy/hyperdrive/state/fees.py
@@ -1,0 +1,15 @@
+"""Functions for storing Hyperdrive state."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fixedpointmath import FixedPoint
+
+
+@dataclass
+class Fees:
+    """Fees struct."""
+
+    curve: FixedPoint
+    flat: FixedPoint
+    governance: FixedPoint

--- a/lib/ethpy/ethpy/hyperdrive/state/fees.py
+++ b/lib/ethpy/ethpy/hyperdrive/state/fees.py
@@ -5,6 +5,17 @@ from dataclasses import dataclass
 
 from fixedpointmath import FixedPoint
 
+# TODO: These dataclasses are similar to pypechain except for
+#  - snake_case attributes instead of camelCase
+#  - FixedPoint types instead of int
+#  - nested dataclasses (PoolConfig) include a __post_init__ that allows for
+#  instantiation with a nested dictionary
+#
+# We'd like to rely on the pypechain classes as much as possible.
+# One solution could be to build our own interface wrapper that pulls in the pypechain
+# dataclass and makes this fixed set of changes?
+# pylint: disable=too-many-instance-attributes
+
 
 @dataclass
 class Fees:

--- a/lib/ethpy/ethpy/hyperdrive/state/pool_config.py
+++ b/lib/ethpy/ethpy/hyperdrive/state/pool_config.py
@@ -1,0 +1,34 @@
+"""Functions for storing Hyperdrive state."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from fixedpointmath import FixedPoint
+
+from .fees import Fees
+
+
+@dataclass
+class PoolConfig:
+    """PoolConfig struct."""
+
+    base_token: str
+    linker_factory: str
+    linker_code_hash: bytes
+    initial_share_price: FixedPoint
+    minimum_share_reserves: FixedPoint
+    minimum_transaction_amount: FixedPoint
+    precision_threshold: int
+    position_duration: int
+    checkpoint_duration: int
+    time_stretch: FixedPoint
+    governance: str
+    fee_collector: str
+    # TODO: Pyright:
+    # Declaration "fees" is obscured by a declaration of the same name here but not elsewhere
+    fees: Fees | Sequence  # type: ignore
+
+    def __post_init__(self):
+        if isinstance(self.fees, Sequence):
+            self.fees: Fees = Fees(*self.fees)

--- a/lib/ethpy/ethpy/hyperdrive/state/pool_config.py
+++ b/lib/ethpy/ethpy/hyperdrive/state/pool_config.py
@@ -9,6 +9,16 @@ from fixedpointmath import FixedPoint
 from .fees import Fees
 
 
+# TODO: These dataclasses are similar to pypechain except for
+#  - snake_case attributes instead of camelCase
+#  - FixedPoint types instead of int
+#  - nested dataclasses (PoolConfig) include a __post_init__ that allows for
+#  instantiation with a nested dictionary
+#
+# We'd like to rely on the pypechain classes as much as possible.
+# One solution could be to build our own interface wrapper that pulls in the pypechain
+# dataclass and makes this fixed set of changes?
+# pylint: disable=too-many-instance-attributes
 @dataclass
 class PoolConfig:
     """PoolConfig struct."""

--- a/lib/ethpy/ethpy/hyperdrive/state/pool_info.py
+++ b/lib/ethpy/ethpy/hyperdrive/state/pool_info.py
@@ -1,0 +1,36 @@
+"""Functions for storing Hyperdrive state."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fixedpointmath import FixedPoint
+
+# TODO: These dataclasses are similar to pypechain except for
+#  - snake_case attributes instead of camelCase
+#  - FixedPoint types instead of int
+#  - nested dataclasses (PoolConfig) include a __post_init__ that allows for
+#  instantiation with a nested dictionary
+#
+# We'd like to rely on the pypechain classes as much as possible.
+# One solution could be to build our own interface wrapper that pulls in the pypechain
+# dataclass and makes this fixed set of changes?
+# pylint: disable=too-many-instance-attributes
+
+
+@dataclass
+class PoolInfo:
+    """PoolInfo struct."""
+
+    share_reserves: FixedPoint
+    share_adjustment: FixedPoint
+    bond_reserves: FixedPoint
+    lp_total_supply: FixedPoint
+    share_price: FixedPoint
+    longs_outstanding: FixedPoint
+    long_average_maturity_time: FixedPoint
+    shorts_outstanding: FixedPoint
+    short_average_maturity_time: FixedPoint
+    withdrawal_shares_ready_to_withdraw: FixedPoint
+    withdrawal_shares_proceeds: FixedPoint
+    lp_share_price: FixedPoint
+    long_exposure: FixedPoint

--- a/lib/ethpy/ethpy/hyperdrive/state/pool_state.py
+++ b/lib/ethpy/ethpy/hyperdrive/state/pool_state.py
@@ -8,6 +8,7 @@ from fixedpointmath import FixedPoint
 from web3.types import BlockData
 
 from ..api._block_getters import _get_block_number, _get_block_time
+from .checkpoint import Checkpoint
 from .conversions import (
     convert_hyperdrive_checkpoint_types,
     convert_hyperdrive_pool_config_types,
@@ -32,28 +33,33 @@ class PoolState:
     def __post_init__(self):
         self.block_number = _get_block_number(self.block)
         self.block_time = _get_block_time(self.block)
-        self._pool_config = convert_hyperdrive_pool_config_types(self.contract_pool_config)
-        self._pool_info = convert_hyperdrive_pool_info_types(self.contract_pool_info)
-        self.checkpoint = convert_hyperdrive_checkpoint_types(self.contract_checkpoint)
 
     @property
     def pool_info(self) -> PoolInfo:
         """Get the pool_info property."""
-        return self._pool_info
+        return convert_hyperdrive_pool_info_types(self.contract_pool_info)
 
     @pool_info.setter
     def pool_info(self, value: PoolInfo) -> None:
         """Set the pool_info property."""
-        self._pool_info = value
-        self.contract_pool_info = dataclass_to_dict(self._pool_info)
+        self.contract_pool_info = dataclass_to_dict(value)
 
     @property
     def pool_config(self) -> PoolConfig:
         """Get the pool_config property."""
-        return self._pool_config
+        return convert_hyperdrive_pool_config_types(self.contract_pool_config)
 
     @pool_config.setter
     def pool_config(self, value: PoolConfig) -> None:
         """Set the pool_config property."""
-        self._pool_config = value
-        self.contract_pool_config = dataclass_to_dict(self._pool_config)
+        self.contract_pool_config = dataclass_to_dict(value)
+
+    @property
+    def checkpoint(self) -> PoolConfig:
+        """Get the checkpoint property."""
+        return convert_hyperdrive_checkpoint_types(self.contract_checkpoint)
+
+    @checkpoint.setter
+    def checkpoint(self, value: Checkpoint) -> None:
+        """Set the checkpoint property."""
+        self.contract_checkpoint = dataclass_to_dict(value)

--- a/lib/ethpy/ethpy/hyperdrive/state/pool_state.py
+++ b/lib/ethpy/ethpy/hyperdrive/state/pool_state.py
@@ -1,0 +1,59 @@
+"""Functions for storing Hyperdrive state."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from fixedpointmath import FixedPoint
+from web3.types import BlockData
+
+from ..api._block_getters import _get_block_number, _get_block_time
+from .conversions import (
+    convert_hyperdrive_checkpoint_types,
+    convert_hyperdrive_pool_config_types,
+    convert_hyperdrive_pool_info_types,
+    dataclass_to_dict,
+)
+from .pool_config import PoolConfig
+from .pool_info import PoolInfo
+
+
+@dataclass
+class PoolState:
+    r"""A collection of stateful variables for deployed Hyperdrive and Yield contracts."""
+    block: BlockData
+    contract_pool_config: dict[str, Any]
+    contract_pool_info: dict[str, Any]
+    contract_checkpoint: dict[str, int]
+    variable_rate: FixedPoint
+    vault_shares: FixedPoint
+    total_supply_withdrawal_shares: FixedPoint
+
+    def __post_init__(self):
+        self.block_number = _get_block_number(self.block)
+        self.block_time = _get_block_time(self.block)
+        self._pool_config = convert_hyperdrive_pool_config_types(self.contract_pool_config)
+        self._pool_info = convert_hyperdrive_pool_info_types(self.contract_pool_info)
+        self.checkpoint = convert_hyperdrive_checkpoint_types(self.contract_checkpoint)
+
+    @property
+    def pool_info(self) -> PoolInfo:
+        """Get the pool_info property."""
+        return self._pool_info
+
+    @pool_info.setter
+    def pool_info(self, value: PoolInfo) -> None:
+        """Set the pool_info property."""
+        self._pool_info = value
+        self.contract_pool_info = dataclass_to_dict(self._pool_info)
+
+    @property
+    def pool_config(self) -> PoolConfig:
+        """Get the pool_config property."""
+        return self._pool_config
+
+    @pool_config.setter
+    def pool_config(self, value: PoolConfig) -> None:
+        """Set the pool_config property."""
+        self._pool_config = value
+        self.contract_pool_config = dataclass_to_dict(self._pool_config)

--- a/lib/ethpy/ethpy/hyperdrive/state/pool_state.py
+++ b/lib/ethpy/ethpy/hyperdrive/state/pool_state.py
@@ -17,6 +17,8 @@ from .conversions import (
 from .pool_config import PoolConfig
 from .pool_info import PoolInfo
 
+# pylint: disable=too-many-instance-attributes
+
 
 @dataclass
 class PoolState:

--- a/lib/ethpy/ethpy/hyperdrive/state/pool_state.py
+++ b/lib/ethpy/ethpy/hyperdrive/state/pool_state.py
@@ -10,10 +10,10 @@ from web3.types import BlockData
 from ..api._block_getters import _get_block_number, _get_block_time
 from .checkpoint import Checkpoint
 from .conversions import (
-    convert_hyperdrive_checkpoint_types,
-    convert_hyperdrive_pool_config_types,
-    convert_hyperdrive_pool_info_types,
     dataclass_to_dict,
+    fixedpoint_checkpoint_to_hypertypes,
+    fixedpoint_pool_config_to_hypertypes,
+    fixedpoint_pool_info_to_hypertypes,
 )
 from .pool_config import PoolConfig
 from .pool_info import PoolInfo
@@ -23,9 +23,9 @@ from .pool_info import PoolInfo
 class PoolState:
     r"""A collection of stateful variables for deployed Hyperdrive and Yield contracts."""
     block: BlockData
-    contract_pool_config: dict[str, Any]
-    contract_pool_info: dict[str, Any]
-    contract_checkpoint: dict[str, int]
+    pool_config: PoolConfig
+    pool_info: PoolInfo
+    checkpoint: Checkpoint
     variable_rate: FixedPoint
     vault_shares: FixedPoint
     total_supply_withdrawal_shares: FixedPoint
@@ -35,31 +35,16 @@ class PoolState:
         self.block_time = _get_block_time(self.block)
 
     @property
-    def pool_info(self) -> PoolInfo:
+    def contract_pool_info(self) -> dict[str, Any]:
         """Get the pool_info property."""
-        return convert_hyperdrive_pool_info_types(self.contract_pool_info)
-
-    @pool_info.setter
-    def pool_info(self, value: PoolInfo) -> None:
-        """Set the pool_info property."""
-        self.contract_pool_info = dataclass_to_dict(value)
+        return dataclass_to_dict(fixedpoint_pool_info_to_hypertypes(self.pool_info))
 
     @property
-    def pool_config(self) -> PoolConfig:
+    def contract_pool_config(self) -> dict[str, Any]:
         """Get the pool_config property."""
-        return convert_hyperdrive_pool_config_types(self.contract_pool_config)
-
-    @pool_config.setter
-    def pool_config(self, value: PoolConfig) -> None:
-        """Set the pool_config property."""
-        self.contract_pool_config = dataclass_to_dict(value)
+        return dataclass_to_dict(fixedpoint_pool_config_to_hypertypes(self.pool_config))
 
     @property
-    def checkpoint(self) -> PoolConfig:
+    def contract_checkpoint(self) -> dict[str, Any]:
         """Get the checkpoint property."""
-        return convert_hyperdrive_checkpoint_types(self.contract_checkpoint)
-
-    @checkpoint.setter
-    def checkpoint(self, value: Checkpoint) -> None:
-        """Set the checkpoint property."""
-        self.contract_checkpoint = dataclass_to_dict(value)
+        return dataclass_to_dict(fixedpoint_checkpoint_to_hypertypes(self.checkpoint))

--- a/lib/ethpy/ethpy/hyperdrive/state/pool_state.py
+++ b/lib/ethpy/ethpy/hyperdrive/state/pool_state.py
@@ -7,7 +7,6 @@ from typing import Any
 from fixedpointmath import FixedPoint
 from web3.types import BlockData
 
-from ..api._block_getters import _get_block_number, _get_block_time
 from .checkpoint import Checkpoint
 from .conversions import (
     dataclass_to_dict,
@@ -31,8 +30,17 @@ class PoolState:
     total_supply_withdrawal_shares: FixedPoint
 
     def __post_init__(self):
-        self.block_number = _get_block_number(self.block)
-        self.block_time = _get_block_time(self.block)
+        ## TODO: Get these using the api getter functions without creating a circular import
+        # Get the block number
+        block_number = self.block.get("number", None)
+        if block_number is None:
+            raise AssertionError("The provided block has no number")
+        self.block_number = block_number
+        # Get the block timestamp
+        block_timestamp = self.block.get("timestamp", None)
+        if block_timestamp is None:
+            raise AssertionError("The provided block has no timestamp")
+        self.block_time = block_timestamp
 
     @property
     def contract_pool_info(self) -> dict[str, Any]:

--- a/lib/ethpy/ethpy/hyperdrive/transactions.py
+++ b/lib/ethpy/ethpy/hyperdrive/transactions.py
@@ -1,8 +1,6 @@
 """Helper functions for interfacing with hyperdrive."""
 from __future__ import annotations
 
-from typing import Any
-
 from eth_typing import BlockNumber
 from eth_utils import address
 from ethpy.base import UnknownBlockError, get_transaction_logs, smart_contract_read

--- a/lib/ethpy/ethpy/hyperdrive/transactions.py
+++ b/lib/ethpy/ethpy/hyperdrive/transactions.py
@@ -6,6 +6,14 @@ from typing import Any
 from eth_typing import BlockNumber
 from eth_utils import address
 from ethpy.base import UnknownBlockError, get_transaction_logs, smart_contract_read
+from ethpy.hyperdrive.state.conversions import (
+    contract_checkpoint_to_hypertypes,
+    contract_pool_config_to_hypertypes,
+    contract_pool_info_to_hypertypes,
+    hypertypes_checkpoint_to_fixedpoint,
+    hypertypes_pool_config_to_fixedpoint,
+    hypertypes_pool_info_to_fixedpoint,
+)
 from fixedpointmath import FixedPoint
 from web3 import Web3
 from web3.contract.contract import Contract
@@ -13,9 +21,10 @@ from web3.types import Timestamp, TxReceipt
 
 from .addresses import HyperdriveAddresses
 from .receipt_breakdown import ReceiptBreakdown
+from .state import Checkpoint, PoolConfig, PoolInfo
 
 
-def get_hyperdrive_pool_config(hyperdrive_contract: Contract) -> dict[str, Any]:
+def get_hyperdrive_pool_config(hyperdrive_contract: Contract) -> PoolConfig:
     """Get the hyperdrive config from a deployed hyperdrive contract.
 
     Arguments
@@ -28,10 +37,12 @@ def get_hyperdrive_pool_config(hyperdrive_contract: Contract) -> dict[str, Any]:
     dict[str, Any]
         The hyperdrive pool config.
     """
-    return smart_contract_read(hyperdrive_contract, "getPoolConfig")
+    return hypertypes_pool_config_to_fixedpoint(
+        contract_pool_config_to_hypertypes(smart_contract_read(hyperdrive_contract, "getPoolConfig"))
+    )
 
 
-def get_hyperdrive_pool_info(hyperdrive_contract: Contract, block_number: BlockNumber) -> dict[str, Any]:
+def get_hyperdrive_pool_info(hyperdrive_contract: Contract, block_number: BlockNumber) -> PoolInfo:
     """Get the block pool info from the Hyperdrive contract.
 
     Arguments
@@ -46,10 +57,14 @@ def get_hyperdrive_pool_info(hyperdrive_contract: Contract, block_number: BlockN
     dict[str, Any]
         A dictionary containing the Hyperdrive pool info returned from the smart contract.
     """
-    return smart_contract_read(hyperdrive_contract, "getPoolInfo", block_number=block_number)
+    return hypertypes_pool_info_to_fixedpoint(
+        contract_pool_info_to_hypertypes(
+            smart_contract_read(hyperdrive_contract, "getPoolInfo", block_number=block_number)
+        )
+    )
 
 
-def get_hyperdrive_checkpoint(hyperdrive_contract: Contract, block_timestamp: Timestamp) -> dict[str, int]:
+def get_hyperdrive_checkpoint(hyperdrive_contract: Contract, block_timestamp: Timestamp) -> Checkpoint:
     """Get the checkpoint info for the Hyperdrive contract at a given block.
 
     Arguments
@@ -64,7 +79,9 @@ def get_hyperdrive_checkpoint(hyperdrive_contract: Contract, block_timestamp: Ti
     dict[str, int]
         A dictionary containing the checkpoint details.
     """
-    return smart_contract_read(hyperdrive_contract, "getCheckpoint", block_timestamp)
+    return hypertypes_checkpoint_to_fixedpoint(
+        contract_checkpoint_to_hypertypes(smart_contract_read(hyperdrive_contract, "getCheckpoint", block_timestamp))
+    )
 
 
 def get_hyperdrive_contract(web3: Web3, abis: dict, addresses: HyperdriveAddresses) -> Contract:


### PR DESCRIPTION
This PR cleans up the stateful API objects so that type conversions are hidden from the end user.

- `ethpy/hyperdrive` now includes a `state` folder that holds the FixedPoint versions of Checkpoint, PoolInfo, and PoolState.
- PoolState has been refactored to work primarily with the FixedPoint objects. The contract object is accessed via conversions.
- state type conversion functions have been centralized to a single spot inside the `state` folder.
- state type conversions have been localized to _mock_contracts (FixedPoint -> HyperTypes) and transactions (dict -> FixedPoint)