### PR TITLE
mark tests

### DIFF
--- a/lib/agent0/agent0/hyperdrive/interactive/interactive_hyperdrive_test.py
+++ b/lib/agent0/agent0/hyperdrive/interactive/interactive_hyperdrive_test.py
@@ -35,6 +35,7 @@ class TestInteractiveHyperdrive:
 
         return chain
 
+    @pytest.mark.anvil
     def _ensure_db_wallet_matches_agent_wallet(
         self,
         interactive_hyperdrive: InteractiveHyperdrive,
@@ -86,9 +87,9 @@ class TestInteractiveHyperdrive:
     # Lots of things to test
     # pylint: disable=too-many-locals
     # pylint: disable=too-many-statements
+    @pytest.mark.anvil
     def test_funding_and_trades(self, chain):
         """Tests interactive hyperdrive end to end"""
-
         # Parameters for pool initialization. If empty, defaults to default values, allows for custom values if needed
         initial_pool_config = InteractiveHyperdrive.Config()
         # Launches 2 pools on the same local chain
@@ -189,6 +190,7 @@ class TestInteractiveHyperdrive:
         assert hyperdrive_agent0.wallet.withdraw_shares == FixedPoint(0)
         self._ensure_db_wallet_matches_agent_wallet(interactive_hyperdrive, hyperdrive_agent0.wallet)
 
+    @pytest.mark.anvil
     def test_advance_time(self, chain):
         """Tests interactive hyperdrive end to end"""
         # We need the underlying hyperdrive interface here to test time

--- a/lib/agent0/agent0/hyperdrive/policies/random_test.py
+++ b/lib/agent0/agent0/hyperdrive/policies/random_test.py
@@ -5,6 +5,7 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, cast
 
+import pytest
 from eth_typing import URI
 from ethpy import EthConfig
 from fixedpointmath import FixedPoint
@@ -31,6 +32,7 @@ if TYPE_CHECKING:
 class TestRandomPolicy:
     """Tests pipeline from bots making trades to viewing the trades in the db"""
 
+    @pytest.mark.anvil
     def test_random_policy(
         self,
         local_hyperdrive_pool: DeployedHyperdrivePool,
@@ -96,6 +98,7 @@ class TestRandomPolicy:
         for _ in range(10):
             _ = asyncio.run(async_execute_agent_trades(hyperdrive, agent_accounts, liquidate))
 
+    @pytest.mark.anvil
     def test_random_policy_trades(
         self,
         local_hyperdrive_pool: DeployedHyperdrivePool,

--- a/lib/agent0/tests/target_rate_test.py
+++ b/lib/agent0/tests/target_rate_test.py
@@ -20,6 +20,7 @@ from fixedpointmath import FixedPoint
 from web3 import HTTPProvider
 
 
+@pytest.mark.anvil
 @pytest.mark.parametrize("delta", [-1e5, 1e5])
 def test_hit_target_rate(local_hyperdrive_pool: DeployedHyperdrivePool, delta: float):
     """Ensure bot can hit target rate."""

--- a/lib/chainsync/chainsync/db/base/interface_test.py
+++ b/lib/chainsync/chainsync/db/base/interface_test.py
@@ -32,6 +32,7 @@ def test_drop_table(dummy_session):
 class TestAddrToUsernameInterface:
     """Testing postgres interface for usermap table"""
 
+    @pytest.mark.docker
     def test_get_addr_to_username(self, db_session):
         """Testing retrieval of usernames via interface"""
         username_1 = "a"
@@ -52,6 +53,7 @@ class TestAddrToUsernameInterface:
         np.testing.assert_array_equal(user_map_df["username"], ["a", "a", "a", "b", "b", "c"])
         np.testing.assert_array_equal(user_map_df["address"], ["1", "2", "3", "4", "5", "6"])
 
+    @pytest.mark.docker
     def test_get_query_address(self, db_session):
         """Testing querying by address of addr_to_username via interface"""
         username_1 = "a"
@@ -72,6 +74,7 @@ class TestAddrToUsernameInterface:
         user_map_df = get_addr_to_username(db_session, address="5")
         np.testing.assert_array_equal(user_map_df["username"], ["b"])
 
+    @pytest.mark.docker
     def test_addr_to_username_insertion_error(self, db_session):
         """Testing insertion conflicts of addr_to_username via interface"""
         username_1 = "a"
@@ -105,6 +108,7 @@ class TestAddrToUsernameInterface:
         np.testing.assert_array_equal(user_map_df["username"], ["a", "a", "a", "a"])
         np.testing.assert_array_equal(user_map_df["address"], ["1", "2", "3", "5"])
 
+    @pytest.mark.docker
     def test_addr_to_username_force_insertion(self, db_session):
         """Testing force insertion of addr_to_username via interface"""
         username_1 = "a"
@@ -128,6 +132,7 @@ class TestAddrToUsernameInterface:
 class TestUserToUsernameInterface:
     """Testing postgres interface for usermap table"""
 
+    @pytest.mark.docker
     def test_get_user_to_username(self, db_session):
         """Testing retrieval of usernames via interface"""
         user_1 = "1"
@@ -148,6 +153,7 @@ class TestUserToUsernameInterface:
         np.testing.assert_array_equal(user_map_df["username"], ["a", "b", "c"])
         np.testing.assert_array_equal(user_map_df["user"], ["1", "2", "2"])
 
+    @pytest.mark.docker
     def test_get_query_username(self, db_session):
         """Testing querying by username of username_to_user via interface"""
         user_1 = "1"
@@ -168,6 +174,7 @@ class TestUserToUsernameInterface:
         user_map_df = get_username_to_user(db_session, username="c")
         np.testing.assert_array_equal(user_map_df["user"], ["2"])
 
+    @pytest.mark.docker
     def test_username_to_user_insertion_error(self, db_session):
         """Testing insertion conflicts of username_to_user via interface"""
         user_1 = "1"
@@ -207,6 +214,7 @@ class TestUserToUsernameInterface:
         np.testing.assert_array_equal(user_map_df["username"], ["a", "b", "c"])
         np.testing.assert_array_equal(user_map_df["user"], ["1", "2", "2"])
 
+    @pytest.mark.docker
     def test_addr_to_username_force_insertion(self, db_session):
         """Testing force insertion of addr_to_username via interface"""
         user_1 = "1"

--- a/lib/chainsync/chainsync/db/base/schema_test.py
+++ b/lib/chainsync/chainsync/db/base/schema_test.py
@@ -1,10 +1,13 @@
 """CRUD tests for UserMap"""
+import pytest
+
 from .schema import AddrToUsername, UsernameToUser
 
 
 class TestAddrToUsernameTable:
     """CRUD tests for AddrToUsername table"""
 
+    @pytest.mark.docker
     def test_create_addr_to_username(self, db_session):
         """Create and entry"""
         user_map = AddrToUsername(address="1", username="a")
@@ -15,6 +18,7 @@ class TestAddrToUsernameTable:
         assert retrieved_map is not None
         assert retrieved_map.username == "a"
 
+    @pytest.mark.docker
     def test_update_addr_to_username(self, db_session):
         """Update an entry"""
         user_map = AddrToUsername(address="1", username="a")
@@ -27,6 +31,7 @@ class TestAddrToUsernameTable:
         updated_map = db_session.query(AddrToUsername).filter_by(address="1").first()
         assert updated_map.username == "b"
 
+    @pytest.mark.docker
     def test_delete_addr_to_username(self, db_session):
         """Delete an entry"""
         user_map = AddrToUsername(address="1", username="a")
@@ -43,6 +48,7 @@ class TestAddrToUsernameTable:
 class TestUsernameToUserTable:
     """CRUD tests for UsernameToUser table"""
 
+    @pytest.mark.docker
     def test_create_username_to_user(self, db_session):
         """Create and entry"""
         user_map = UsernameToUser(username="a", user="1")
@@ -53,6 +59,7 @@ class TestUsernameToUserTable:
         assert retrieved_map is not None
         assert retrieved_map.user == "1"
 
+    @pytest.mark.docker
     def test_update_username_to_user(self, db_session):
         """Update an entry"""
         user_map = UsernameToUser(username="a", user="1")
@@ -65,6 +72,7 @@ class TestUsernameToUserTable:
         updated_map = db_session.query(UsernameToUser).filter_by(username="a").first()
         assert updated_map.user == "2"
 
+    @pytest.mark.docker
     def test_delete_username_to_user(self, db_session):
         """Delete an entry"""
         user_map = UsernameToUser(username="a", user="1")

--- a/lib/chainsync/chainsync/db/hyperdrive/export_data_test.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/export_data_test.py
@@ -2,6 +2,8 @@
 from decimal import Decimal
 from tempfile import TemporaryDirectory
 
+import pytest
+
 from .export_data import export_db_to_file, import_to_pandas
 from .interface import add_pool_config, get_pool_config
 from .schema import PoolConfig
@@ -11,6 +13,7 @@ from .schema import PoolConfig
 class TestExportImportData:
     """Testing export and import data for precision"""
 
+    @pytest.mark.docker
     def test_export_import(self, db_session):
         """Testing retrieval of transaction via interface"""
         # Write data to database

--- a/lib/chainsync/chainsync/db/hyperdrive/interface_test.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/interface_test.py
@@ -4,8 +4,9 @@ from decimal import Decimal
 
 import numpy as np
 import pytest
-from chainsync.db.base import get_latest_block_number_from_table
 from ethpy.hyperdrive import BASE_TOKEN_SYMBOL
+
+from chainsync.db.base import get_latest_block_number_from_table
 
 from .interface import (
     add_checkpoint_infos,
@@ -31,6 +32,7 @@ from .schema import CheckpointInfo, CurrentWallet, HyperdriveTransaction, PoolCo
 class TestTransactionInterface:
     """Testing postgres interface for transaction table"""
 
+    @pytest.mark.docker
     def test_latest_block_number(self, db_session):
         """Testing retrieval of transaction via interface"""
         transaction_1 = HyperdriveTransaction(block_number=1, transaction_hash="a", event_value=Decimal("3.0"))
@@ -46,6 +48,7 @@ class TestTransactionInterface:
         latest_block_number = get_latest_block_number_from_table(HyperdriveTransaction, db_session)
         assert latest_block_number == 3
 
+    @pytest.mark.docker
     def test_get_transactions(self, db_session):
         """Testing retrieval of transactions via interface"""
         transaction_1 = HyperdriveTransaction(block_number=0, transaction_hash="a", event_value=Decimal("3.1"))
@@ -56,6 +59,7 @@ class TestTransactionInterface:
         transactions_df = get_transactions(db_session)
         np.testing.assert_array_equal(transactions_df["event_value"], [3.1, 3.2, 3.3])
 
+    @pytest.mark.docker
     def test_block_query_transactions(self, db_session):
         """Testing querying by block number of transactions via interface"""
         transaction_1 = HyperdriveTransaction(block_number=0, transaction_hash="a", event_value=Decimal("3.1"))
@@ -82,6 +86,7 @@ class TestTransactionInterface:
 class TestCheckpointInterface:
     """Testing postgres interface for checkpoint table"""
 
+    @pytest.mark.docker
     def test_latest_block_number(self, db_session):
         """Testing retrieval of checkpoint via interface"""
         checkpoint_1 = CheckpointInfo(block_number=1, timestamp=datetime.now())
@@ -98,6 +103,7 @@ class TestCheckpointInterface:
         latest_block_number = get_latest_block_number_from_table(CheckpointInfo, db_session)
         assert latest_block_number == 3
 
+    @pytest.mark.docker
     def test_get_checkpoints(self, db_session):
         """Testing retrieval of checkpoints via interface"""
         date_1 = datetime(1945, 8, 6)
@@ -113,6 +119,7 @@ class TestCheckpointInterface:
             checkpoints_df["timestamp"].dt.to_pydatetime(), np.array([date_1, date_2, date_3])
         )
 
+    @pytest.mark.docker
     def test_block_query_checkpoints(self, db_session):
         """Testing querying by block number of checkpoints via interface"""
         checkpoint_1 = CheckpointInfo(block_number=0, timestamp=datetime.now(), share_price=Decimal("3.1"))
@@ -139,6 +146,7 @@ class TestCheckpointInterface:
 class TestPoolConfigInterface:
     """Testing postgres interface for poolconfig table"""
 
+    @pytest.mark.docker
     def test_get_pool_config(self, db_session):
         """Testing retrieval of pool config via interface"""
         pool_config_1 = PoolConfig(contract_address="0", initial_share_price=Decimal("3.2"))
@@ -155,6 +163,7 @@ class TestPoolConfigInterface:
         assert len(pool_config_df_2) == 2
         np.testing.assert_array_equal(pool_config_df_2["initial_share_price"], np.array([3.2, 3.4]))
 
+    @pytest.mark.docker
     def test_primary_id_query_pool_config(self, db_session):
         """Testing retrieval of pool config via interface"""
         pool_config = PoolConfig(contract_address="0", initial_share_price=Decimal("3.2"))
@@ -167,6 +176,7 @@ class TestPoolConfigInterface:
         pool_config_df_2 = get_pool_config(db_session, contract_address="1")
         assert len(pool_config_df_2) == 0
 
+    @pytest.mark.docker
     def test_pool_config_verify(self, db_session):
         """Testing retrieval of pool config via interface"""
         pool_config_1 = PoolConfig(contract_address="0", initial_share_price=Decimal("3.2"))
@@ -191,6 +201,7 @@ class TestPoolConfigInterface:
 class TestPoolInfoInterface:
     """Testing postgres interface for poolinfo table"""
 
+    @pytest.mark.docker
     def test_latest_block_number(self, db_session):
         """Testing latest block number call"""
         timestamp_1 = datetime.fromtimestamp(1628472000)
@@ -209,6 +220,7 @@ class TestPoolInfoInterface:
         latest_block_number = get_latest_block_number_from_pool_info_table(db_session)
         assert latest_block_number == 3
 
+    @pytest.mark.docker
     def test_get_pool_info(self, db_session):
         """Testing retrieval of pool info via interface"""
         timestamp_1 = datetime.fromtimestamp(1628472000)
@@ -224,6 +236,7 @@ class TestPoolInfoInterface:
             pool_info_df["timestamp"].dt.to_pydatetime(), np.array([timestamp_1, timestamp_2, timestamp_3])
         )
 
+    @pytest.mark.docker
     def test_block_query_pool_info(self, db_session):
         """Testing retrieval of pool info via interface"""
         timestamp_1 = datetime.fromtimestamp(1628472000)
@@ -252,6 +265,7 @@ class TestPoolInfoInterface:
 class TestWalletDeltaInterface:
     """Testing postgres interface for walletinfo table"""
 
+    @pytest.mark.docker
     def test_latest_block_number(self, db_session):
         """Testing retrieval of wallet info via interface"""
         wallet_delta_1 = WalletDelta(block_number=1, transaction_hash="a", delta=Decimal("3.0"))
@@ -264,6 +278,7 @@ class TestWalletDeltaInterface:
         latest_block_number = get_latest_block_number_from_table(WalletDelta, db_session)
         assert latest_block_number == 3
 
+    @pytest.mark.docker
     def test_get_wallet_delta(self, db_session):
         """Testing retrievals of walletinfo via interface"""
         wallet_delta_1 = WalletDelta(block_number=0, transaction_hash="a", delta=Decimal("3.1"))
@@ -275,6 +290,7 @@ class TestWalletDeltaInterface:
         wallet_delta_df = get_wallet_deltas(db_session, return_timestamp=False)
         np.testing.assert_array_equal(wallet_delta_df["delta"], np.array([3.1, 3.2, 3.3]))
 
+    @pytest.mark.docker
     def test_block_query_wallet_delta(self, db_session):
         """Testing querying by block number of wallet info via interface"""
         wallet_delta_1 = WalletDelta(block_number=0, transaction_hash="a", delta=Decimal("3.1"))
@@ -292,6 +308,7 @@ class TestWalletDeltaInterface:
         wallet_delta_df = get_wallet_deltas(db_session, start_block=1, end_block=-1, return_timestamp=False)
         np.testing.assert_array_equal(wallet_delta_df["delta"], np.array([3.2]))
 
+    @pytest.mark.docker
     def test_get_agents(self, db_session):
         """Testing helper function to get current wallet values"""
         wallet_delta_1 = WalletDelta(block_number=0, transaction_hash="a", wallet_address="addr_1")
@@ -307,6 +324,7 @@ class TestWalletDeltaInterface:
 class TestCurrentWalletInterface:
     """Testing postgres interface for CurrentWallet table"""
 
+    @pytest.mark.docker
     def test_latest_block_number(self, db_session):
         """Testing retrieval of wallet info via interface"""
         wallet_info_1 = CurrentWallet(block_number=1, value=Decimal("3.0"))
@@ -319,6 +337,7 @@ class TestCurrentWalletInterface:
         latest_block_number = get_latest_block_number_from_table(CurrentWallet, db_session)
         assert latest_block_number == 3
 
+    @pytest.mark.docker
     def test_get_current_wallet(self, db_session):
         """Testing retrieval of walletinfo via interface"""
         wallet_info_1 = CurrentWallet(block_number=0, wallet_address="a", value=Decimal("3.1"))
@@ -330,6 +349,7 @@ class TestCurrentWalletInterface:
         wallet_info_df = wallet_info_df.sort_values(by=["value"])
         np.testing.assert_array_equal(wallet_info_df["value"], np.array([3.1, 3.2, 3.3]))
 
+    @pytest.mark.docker
     def test_block_query_wallet_info(self, db_session):
         """Testing querying by block number of wallet info via interface"""
         wallet_info_1 = CurrentWallet(block_number=0, wallet_address="a", value=Decimal("3.1"))
@@ -343,6 +363,7 @@ class TestCurrentWalletInterface:
         wallet_info_df = wallet_info_df.sort_values(by=["value"])
         np.testing.assert_array_equal(wallet_info_df["value"], np.array([3.1, 3.2]))
 
+    @pytest.mark.docker
     def test_current_wallet_info(self, db_session):
         """Testing helper function to get current wallet values"""
         wallet_info_1 = CurrentWallet(

--- a/lib/chainsync/chainsync/db/hyperdrive/schema_test.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/schema_test.py
@@ -2,6 +2,8 @@
 from datetime import datetime
 from decimal import Decimal
 
+import pytest
+
 from .schema import CheckpointInfo, HyperdriveTransaction, PoolConfig, PoolInfo, WalletDelta
 
 # These tests are using fixtures defined in conftest.py
@@ -10,6 +12,7 @@ from .schema import CheckpointInfo, HyperdriveTransaction, PoolConfig, PoolInfo,
 class TestTransactionTable:
     """CRUD tests for transaction table"""
 
+    @pytest.mark.docker
     def test_create_transaction(self, db_session):
         """Create and entry"""
         transaction = HyperdriveTransaction(block_number=1, transaction_hash="a", event_value=Decimal("3.2"))
@@ -21,6 +24,7 @@ class TestTransactionTable:
         # event_value retrieved from postgres is in Decimal, cast to float
         assert float(retrieved_transaction.event_value) == 3.2
 
+    @pytest.mark.docker
     def test_update_transaction(self, db_session):
         """Update an entry"""
         transaction = HyperdriveTransaction(block_number=1, transaction_hash="a", event_value=Decimal("3.2"))
@@ -34,6 +38,7 @@ class TestTransactionTable:
         # event_value retrieved from postgres is in Decimal, cast to float
         assert float(updated_transaction.event_value) == 5.0
 
+    @pytest.mark.docker
     def test_delete_transaction(self, db_session):
         """Delete an entry"""
         transaction = HyperdriveTransaction(block_number=1, transaction_hash="a", event_value=Decimal("3.2"))
@@ -50,6 +55,7 @@ class TestTransactionTable:
 class TestCheckpointTable:
     """CRUD tests for checkpoint table"""
 
+    @pytest.mark.docker
     def test_create_checkpoint(self, db_session):
         """Create and entry"""
         timestamp = datetime.now()
@@ -61,6 +67,7 @@ class TestCheckpointTable:
         assert retrieved_checkpoint is not None
         assert retrieved_checkpoint.timestamp == timestamp
 
+    @pytest.mark.docker
     def test_update_checkpoint(self, db_session):
         """Update an entry"""
         timestamp = datetime.now()
@@ -74,6 +81,7 @@ class TestCheckpointTable:
         updated_checkpoint = db_session.query(CheckpointInfo).filter_by(block_number=1).first()
         assert updated_checkpoint.share_price == 5.0
 
+    @pytest.mark.docker
     def test_delete_checkpoint(self, db_session):
         """Delete an entry"""
         timestamp = datetime.now()
@@ -91,6 +99,7 @@ class TestCheckpointTable:
 class TestPoolConfigTable:
     """CRUD tests for poolconfig table"""
 
+    @pytest.mark.docker
     def test_create_pool_config(self, db_session):
         """Create and entry"""
         pool_config = PoolConfig(contract_address="0", initial_share_price=Decimal("3.2"))
@@ -101,6 +110,7 @@ class TestPoolConfigTable:
         assert retrieved_pool_config is not None
         assert float(retrieved_pool_config.initial_share_price) == 3.2
 
+    @pytest.mark.docker
     def test_delete_pool_config(self, db_session):
         """Delete an entry"""
         pool_config = PoolConfig(contract_address="0", initial_share_price=Decimal("3.2"))
@@ -117,6 +127,7 @@ class TestPoolConfigTable:
 class TestPoolInfoTable:
     """CRUD tests for poolinfo table"""
 
+    @pytest.mark.docker
     def test_create_pool_info(self, db_session):
         """Create and entry"""
         timestamp = datetime.fromtimestamp(1628472000)
@@ -128,6 +139,7 @@ class TestPoolInfoTable:
         assert retrieved_pool_info is not None
         assert retrieved_pool_info.timestamp == timestamp
 
+    @pytest.mark.docker
     def test_update_pool_info(self, db_session):
         """Update an entry"""
         timestamp = datetime.fromtimestamp(1628472000)
@@ -143,6 +155,7 @@ class TestPoolInfoTable:
         updated_pool_info = db_session.query(PoolInfo).filter_by(block_number=1).first()
         assert updated_pool_info.timestamp == new_timestamp
 
+    @pytest.mark.docker
     def test_delete_pool_info(self, db_session):
         """Delete an entry"""
         timestamp = datetime.fromtimestamp(1628472000)
@@ -160,6 +173,7 @@ class TestPoolInfoTable:
 class TestWalletDeltaTable:
     """CRUD tests for WalletDelta table"""
 
+    @pytest.mark.docker
     def test_create_wallet_delta(self, db_session):
         """Create and entry"""
         wallet_delta = WalletDelta(block_number=1, transaction_hash="a", delta=Decimal("3.2"))
@@ -171,6 +185,7 @@ class TestWalletDeltaTable:
         # tokenValue retrieved from postgres is in Decimal, cast to float
         assert float(retrieved_wallet_delta.delta) == 3.2
 
+    @pytest.mark.docker
     def test_update_wallet_delta(self, db_session):
         """Update an entry"""
         wallet_delta = WalletDelta(block_number=1, transaction_hash="a", delta=Decimal("3.2"))
@@ -182,6 +197,7 @@ class TestWalletDeltaTable:
         # delta retrieved from postgres is in Decimal, cast to float
         assert float(updated_wallet_delta.delta) == 5.0
 
+    @pytest.mark.docker
     def test_delete_wallet_delta(self, db_session):
         """Delete an entry"""
         wallet_delta = WalletDelta(block_number=1, transaction_hash="a", delta=Decimal("3.2"))

--- a/lib/hypertypes/pyproject.toml
+++ b/lib/hypertypes/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 
 [project.optional-dependencies]
 with-dependencies = ["hypertypes[base]"]
-base = ["web3", "pypechain"]
+base = ["web3", "pypechain", "multimethod"]
 
 [build-system]
 requires = ["flit_core>=3.2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,10 @@ minversion = "6.0"
 addopts = ["--tb=short"]
 norecursedirs = ".git examples hyperdrive_solidity"
 python_files = "*_test.py test_*.py"
-
+markers = [
+    "anvil: tests using anvil (deselect with '-m \"not anvil\"')",
+    "docker: tests using docker (deselect with '-m \"not docker\"')",
+]
 
 [tool.pylint.format]
 max-line-length = "120"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@
 -e lib/hypertypes[base]
 --find-links="packages/hyperdrivepy"
 hyperdrivepy
+multimethod

--- a/tests/bot_load_state_test.py
+++ b/tests/bot_load_state_test.py
@@ -6,6 +6,13 @@ import os
 from dataclasses import dataclass
 from typing import cast
 
+import pytest
+from agent0 import build_account_key_config_from_agent_config
+from agent0.base import MarketType, Trade
+from agent0.base.config import AgentConfig, EnvironmentConfig
+from agent0.hyperdrive.exec import run_agents
+from agent0.hyperdrive.policies import HyperdrivePolicy
+from agent0.hyperdrive.state import HyperdriveActionType, HyperdriveMarketAction, HyperdriveWallet
 from chainsync.exec import acquire_data, data_analysis
 from eth_typing import URI
 from ethpy import EthConfig
@@ -16,13 +23,6 @@ from fixedpointmath import FixedPoint
 from numpy.random._generator import Generator as NumpyGenerator
 from sqlalchemy.orm import Session
 from web3 import HTTPProvider
-
-from agent0 import build_account_key_config_from_agent_config
-from agent0.base import MarketType, Trade
-from agent0.base.config import AgentConfig, EnvironmentConfig
-from agent0.hyperdrive.exec import run_agents
-from agent0.hyperdrive.policies import HyperdrivePolicy
-from agent0.hyperdrive.state import HyperdriveActionType, HyperdriveMarketAction, HyperdriveWallet
 
 
 class WalletTestPolicy(HyperdrivePolicy):
@@ -127,6 +127,7 @@ class TestBotToDb:
 
     # TODO split this up into different functions that work with tests
     # pylint: disable=too-many-locals, too-many-statements
+    @pytest.mark.anvil
     def test_bot_to_db(
         self,
         local_hyperdrive_pool: DeployedHyperdrivePool,

--- a/tests/bot_to_db_test.py
+++ b/tests/bot_to_db_test.py
@@ -8,6 +8,11 @@ from typing import Type, cast
 
 import numpy as np
 import pandas as pd
+import pytest
+from agent0 import build_account_key_config_from_agent_config
+from agent0.base.config import AgentConfig, EnvironmentConfig
+from agent0.hyperdrive.exec import run_agents
+from agent0.test_utils import CycleTradesPolicy
 from chainsync.db.hyperdrive.interface import (
     get_current_wallet,
     get_pool_analysis,
@@ -28,11 +33,6 @@ from fixedpointmath import FixedPoint
 from sqlalchemy.orm import Session
 from web3 import HTTPProvider
 
-from agent0 import build_account_key_config_from_agent_config
-from agent0.base.config import AgentConfig, EnvironmentConfig
-from agent0.hyperdrive.exec import run_agents
-from agent0.test_utils import CycleTradesPolicy
-
 
 def _to_unscaled_decimal(fp_val: FixedPoint) -> Decimal:
     return Decimal(str(fp_val))
@@ -43,6 +43,7 @@ class TestBotToDb:
 
     # TODO split this up into different functions that work with tests
     # pylint: disable=too-many-locals, too-many-statements
+    @pytest.mark.anvil
     def test_bot_to_db(
         self,
         local_hyperdrive_pool: DeployedHyperdrivePool,

--- a/tests/bot_wallet_test.py
+++ b/tests/bot_wallet_test.py
@@ -6,6 +6,13 @@ import os
 from dataclasses import dataclass
 from typing import cast
 
+import pytest
+from agent0 import build_account_key_config_from_agent_config
+from agent0.base import MarketType, Trade
+from agent0.base.config import AgentConfig, EnvironmentConfig
+from agent0.hyperdrive.exec import run_agents
+from agent0.hyperdrive.policies import HyperdrivePolicy
+from agent0.hyperdrive.state import HyperdriveActionType, HyperdriveMarketAction, HyperdriveWallet
 from eth_typing import URI
 from ethpy import EthConfig
 from ethpy.hyperdrive import AssetIdPrefix, encode_asset_id
@@ -15,13 +22,6 @@ from ethpy.test_fixtures.local_chain import DeployedHyperdrivePool
 from fixedpointmath import FixedPoint
 from numpy.random._generator import Generator as NumpyGenerator
 from web3 import HTTPProvider
-
-from agent0 import build_account_key_config_from_agent_config
-from agent0.base import MarketType, Trade
-from agent0.base.config import AgentConfig, EnvironmentConfig
-from agent0.hyperdrive.exec import run_agents
-from agent0.hyperdrive.policies import HyperdrivePolicy
-from agent0.hyperdrive.state import HyperdriveActionType, HyperdriveMarketAction, HyperdriveWallet
 
 
 def ensure_agent_wallet_is_correct(wallet: HyperdriveWallet, hyperdrive: HyperdriveInterface) -> None:
@@ -228,6 +228,7 @@ class TestWalletAgainstChain:
 
     # TODO split this up into different functions that work with tests
     # pylint: disable=too-many-locals, too-many-statements
+    @pytest.mark.anvil
     def test_wallet_against_chain(
         self,
         local_hyperdrive_pool: DeployedHyperdrivePool,

--- a/tests/invalid_balance_trade_test.py
+++ b/tests/invalid_balance_trade_test.py
@@ -5,6 +5,13 @@ import logging
 import os
 from typing import TYPE_CHECKING, Type, cast
 
+import pytest
+from agent0 import build_account_key_config_from_agent_config
+from agent0.base import MarketType, Trade
+from agent0.base.config import AgentConfig, EnvironmentConfig
+from agent0.hyperdrive.exec import run_agents
+from agent0.hyperdrive.policies import HyperdrivePolicy
+from agent0.hyperdrive.state import HyperdriveActionType, HyperdriveMarketAction, HyperdriveWallet
 from eth_typing import URI
 from ethpy import EthConfig
 from ethpy.base.errors import ContractCallException
@@ -12,13 +19,6 @@ from fixedpointmath import FixedPoint
 from numpy.random._generator import Generator as NumpyGenerator
 from web3 import HTTPProvider
 from web3.exceptions import ContractLogicError, ContractPanicError
-
-from agent0 import build_account_key_config_from_agent_config
-from agent0.base import MarketType, Trade
-from agent0.base.config import AgentConfig, EnvironmentConfig
-from agent0.hyperdrive.exec import run_agents
-from agent0.hyperdrive.policies import HyperdrivePolicy
-from agent0.hyperdrive.state import HyperdriveActionType, HyperdriveMarketAction, HyperdriveWallet
 
 if TYPE_CHECKING:
     from ethpy.hyperdrive import HyperdriveAddresses
@@ -508,6 +508,7 @@ class InvalidRedeemWithdrawFromNonZero(HyperdrivePolicy):
 class TestInvalidTrades:
     """Tests pipeline from bots making trades to viewing the trades in the db"""
 
+    @pytest.mark.anvil
     def _build_and_run_with_funded_bot(self, hyperdrive_pool: DeployedHyperdrivePool, policy: Type[HyperdrivePolicy]):
         # Run this test with develop mode on
         os.environ["DEVELOP"] = "true"
@@ -610,6 +611,7 @@ class TestInvalidTrades:
         # If this reaches this point, the agent was successful, which means this test should fail
         assert False, "Agent was successful with known invalid trade"
 
+    @pytest.mark.anvil
     def test_not_enough_base(
         self,
         local_hyperdrive_pool: DeployedHyperdrivePool,
@@ -629,6 +631,7 @@ class TestInvalidTrades:
             assert isinstance(exc.orig_exception, ContractLogicError)
             assert exc.orig_exception.args[0] == "execution reverted: TRANSFER_FROM_FAILED"
 
+    @pytest.mark.anvil
     def test_invalid_remove_liquidity_from_zero(
         self,
         local_hyperdrive_pool: DeployedHyperdrivePool,
@@ -650,6 +653,7 @@ class TestInvalidTrades:
                 exc.orig_exception.args[0] == "Panic error 0x11: Arithmetic operation results in underflow or overflow."
             )
 
+    @pytest.mark.anvil
     def test_invalid_close_long_from_zero(
         self,
         local_hyperdrive_pool: DeployedHyperdrivePool,
@@ -672,6 +676,7 @@ class TestInvalidTrades:
                 exc.orig_exception.args[0] == "Panic error 0x11: Arithmetic operation results in underflow or overflow."
             )
 
+    @pytest.mark.anvil
     def test_invalid_close_short_from_zero(
         self,
         local_hyperdrive_pool: DeployedHyperdrivePool,
@@ -694,6 +699,7 @@ class TestInvalidTrades:
                 exc.orig_exception.args[0] == "Panic error 0x11: Arithmetic operation results in underflow or overflow."
             )
 
+    @pytest.mark.anvil
     def test_invalid_redeem_withdraw_share_from_zero(
         self,
         local_hyperdrive_pool: DeployedHyperdrivePool,
@@ -712,6 +718,7 @@ class TestInvalidTrades:
             assert "balance of " in exc.args[0]
             assert exc.args[1] == "Preview call for redeem withdrawal shares returned 0 for non-zero input trade amount"
 
+    @pytest.mark.anvil
     def test_invalid_remove_liquidity_from_nonzero(
         self,
         local_hyperdrive_pool: DeployedHyperdrivePool,
@@ -733,6 +740,7 @@ class TestInvalidTrades:
                 exc.orig_exception.args[0] == "Panic error 0x11: Arithmetic operation results in underflow or overflow."
             )
 
+    @pytest.mark.anvil
     def test_invalid_close_long_from_nonzero(
         self,
         local_hyperdrive_pool: DeployedHyperdrivePool,
@@ -754,6 +762,7 @@ class TestInvalidTrades:
                 exc.orig_exception.args[0] == "Panic error 0x11: Arithmetic operation results in underflow or overflow."
             )
 
+    @pytest.mark.anvil
     def test_invalid_close_short_from_nonzero(
         self,
         local_hyperdrive_pool: DeployedHyperdrivePool,
@@ -775,6 +784,7 @@ class TestInvalidTrades:
                 exc.orig_exception.args[0] == "Panic error 0x11: Arithmetic operation results in underflow or overflow."
             )
 
+    @pytest.mark.anvil
     def test_invalid_redeem_withdraw_from_nonzero(
         self,
         local_hyperdrive_pool: DeployedHyperdrivePool,
@@ -793,6 +803,7 @@ class TestInvalidTrades:
             assert "balance of " in exc.args[0]
             assert exc.args[1] == "Preview call for redeem withdrawal shares returned 0 for non-zero input trade amount"
 
+    @pytest.mark.anvil
     def test_invalid_redeem_withdraw_in_pool(
         self,
         local_hyperdrive_pool: DeployedHyperdrivePool,

--- a/tests/local_chain_test.py
+++ b/tests/local_chain_test.py
@@ -1,4 +1,5 @@
 """Tests bringing up local chain"""
+import pytest
 
 
 class TestLocalChain:
@@ -6,6 +7,7 @@ class TestLocalChain:
 
     # This is using 2 fixtures. Since hyperdrive_contract_address depends on local_chain, we need both here
     # This is due to adding test fixtures through imports
+    @pytest.mark.anvil
     def test_hyperdrive_init_and_deploy(self, local_chain: str, local_hyperdrive_pool: dict):
         """Create and entry"""
         print(local_chain)

--- a/tests/multi_trade_per_block_test.py
+++ b/tests/multi_trade_per_block_test.py
@@ -6,6 +6,13 @@ import os
 from typing import TYPE_CHECKING, cast
 
 import pandas as pd
+import pytest
+from agent0 import build_account_key_config_from_agent_config
+from agent0.base import MarketType, Trade
+from agent0.base.config import AgentConfig, EnvironmentConfig
+from agent0.hyperdrive.exec import run_agents
+from agent0.hyperdrive.policies import HyperdrivePolicy
+from agent0.hyperdrive.state import HyperdriveActionType, HyperdriveMarketAction, HyperdriveWallet
 from chainsync.db.hyperdrive.interface import get_ticker, get_transactions, get_wallet_deltas
 from chainsync.exec import acquire_data, data_analysis
 from eth_typing import URI
@@ -14,13 +21,6 @@ from fixedpointmath import FixedPoint
 from numpy.random._generator import Generator as NumpyGenerator
 from sqlalchemy.orm import Session
 from web3 import HTTPProvider
-
-from agent0 import build_account_key_config_from_agent_config
-from agent0.base import MarketType, Trade
-from agent0.base.config import AgentConfig, EnvironmentConfig
-from agent0.hyperdrive.exec import run_agents
-from agent0.hyperdrive.policies import HyperdrivePolicy
-from agent0.hyperdrive.state import HyperdriveActionType, HyperdriveMarketAction, HyperdriveWallet
 
 if TYPE_CHECKING:
     from ethpy.hyperdrive import HyperdriveAddresses
@@ -109,6 +109,7 @@ class TestMultiTradePerBlock:
 
     # TODO split this up into different functions that work with tests
     # pylint: disable=too-many-locals, too-many-statements
+    @pytest.mark.docker
     def test_multi_trade_per_block(
         self,
         local_hyperdrive_pool: DeployedHyperdrivePool,

--- a/tests/slippage_warning_test.py
+++ b/tests/slippage_warning_test.py
@@ -5,16 +5,16 @@ import logging
 import os
 from typing import TYPE_CHECKING, Type, cast
 
+import pytest
+from agent0 import build_account_key_config_from_agent_config
+from agent0.base.config import AgentConfig, EnvironmentConfig
+from agent0.hyperdrive.exec import run_agents
+from agent0.test_utils import CycleTradesPolicy
 from eth_typing import URI
 from ethpy import EthConfig
 from ethpy.base.errors import ContractCallException
 from fixedpointmath import FixedPoint
 from web3 import HTTPProvider
-
-from agent0 import build_account_key_config_from_agent_config
-from agent0.base.config import AgentConfig, EnvironmentConfig
-from agent0.hyperdrive.exec import run_agents
-from agent0.test_utils import CycleTradesPolicy
 
 if TYPE_CHECKING:
     from ethpy.hyperdrive import HyperdriveAddresses
@@ -26,6 +26,7 @@ class TestSlippageWarning:
 
     # TODO split this up into different functions that work with tests
     # pylint: disable=too-many-locals, too-many-statements
+    @pytest.mark.docker
     def test_slippage_warning(
         self,
         local_hyperdrive_pool: DeployedHyperdrivePool,


### PR DESCRIPTION
run subsets of tests with `python -m 'anvil or docker'` or exclude tests with `python -m 'not anvil'`. these are useful for debugging certain features, like fixtures which make docker faster.