### PR TITLE
check postgres status

### DIFF
--- a/lib/chainsync/chainsync/db/base/interface.py
+++ b/lib/chainsync/chainsync/db/base/interface.py
@@ -59,7 +59,7 @@ def drop_table(session: Session, table_name: str) -> None:
 
 
 def initialize_engine(postgres_config: PostgresConfig | None = None, ensure_database_created: bool = False) -> Engine:
-    """Initializes the postgres engine from config
+    """Initialize the postgres engine from config.
 
     Returns
     -------


### PR DESCRIPTION
instead of `time.sleep(3)` check the status of the postgres container by trying to connect to it.
- fix typehints, and lint docstrings.
- short test like lib/chainsync/chainsync/db/hyperdrive/interface_test.py is 30% faster: 6.73s to 4.69s (nice!)