### PR TITLE
update docstring style guide

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -4,5 +4,6 @@
 - Follow [the PEP8 styleguide](https://peps.python.org/pep-0008/).
   - The only exception: we use a maximum character limit of 120 characters per line.
   - [Black](https://pypi.org/project/black/) and [Pylint](https://pylint.readthedocs.io/en/latest/index.html) will enforce this.
-- Write docstrings in [Numpy format](https://numpydoc.readthedocs.io/en/latest/format.html).
-  - The only exception: we use "Arguments" instead of "Parameters" in docstrings.
+- Write docstrings in [Numpy format](https://numpydoc.readthedocs.io/en/latest/format.html), with a few tweaks:
+  - Use "Arguments" instead of "Parameters".
+  - Don't use space before `:` in the type specification. Sphinx and VSCode render it the same, and it's closer to the signature.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,13 +49,10 @@ exclude = [".venv", ".vscode", "docs"]
 select = ["A", "D", "I", "N", "PL"]
 
 # We ignore the following rules:
-# D203 : 1 blank line required before class docstring (incompatible with D211: no blank lines before class docstring)
-# D213 : multi-line-summary-second-line (incompatible with D212: multi-line summary should start at the first line)
-# D415 : First line should end with a period, question mark, or exclamation point (in period-only D400)
-# D416 : section-name-ends-in-colon (numpy style guide doesn't use colons after sections, i.e. Parameters)
-# PLR0913 : Too many arguments to function call (X > 5)
-# PLR0915 : Too many statements (X > 50)
-# PLR0912 : Too many branches (X > 12)
+# D203: 1 blank line required before class docstring (incompatible with D211: no blank lines before class docstring)
+# D213: multi-line-summary-second-line (incompatible with D212: multi-line summary should start at the first line)
+# D415: First line should end with a period, question mark, or exclamation point (in period-only D400)
+# D416: section-name-ends-in-colon (numpy style guide doesn't use colons after sections, i.e. Parameters)
 ignore = ["D203", "D213", "D415", "D416"]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.

--- a/tests/bot_load_state_test.py
+++ b/tests/bot_load_state_test.py
@@ -72,7 +72,7 @@ class WalletTestPolicy(HyperdrivePolicy):
         ---------
         interface: HyperdriveInterface
             The trading market interface.
-        wallet : HyperdriveWallet
+        wallet: HyperdriveWallet
             The agent's wallet.
 
         Returns

--- a/tests/invalid_balance_trade_test.py
+++ b/tests/invalid_balance_trade_test.py
@@ -56,7 +56,7 @@ class InvalidRemoveLiquidityFromZero(HyperdrivePolicy):
         ---------
         interface: HyperdriveInterface
             The trading market interface.
-        wallet : HyperdriveWallet
+        wallet: HyperdriveWallet
             The agent's wallet.
 
         Returns
@@ -106,7 +106,7 @@ class InvalidCloseLongFromZero(HyperdrivePolicy):
         ---------
         interface: HyperdriveInterface
             The trading market interface.
-        wallet : HyperdriveWallet
+        wallet: HyperdriveWallet
             The agent's wallet.
 
         Returns
@@ -158,7 +158,7 @@ class InvalidCloseShortFromZero(HyperdrivePolicy):
         ---------
         interface: HyperdriveInterface
             The trading market interface.
-        wallet : HyperdriveWallet
+        wallet: HyperdriveWallet
             The agent's wallet.
 
         Returns
@@ -210,7 +210,7 @@ class InvalidRedeemWithdrawFromZero(HyperdrivePolicy):
         ---------
         interface: HyperdriveInterface
             The trading market interface.
-        wallet : HyperdriveWallet
+        wallet: HyperdriveWallet
             The agent's wallet.
 
         Returns
@@ -262,7 +262,7 @@ class InvalidRemoveLiquidityFromNonZero(HyperdrivePolicy):
         ---------
         interface: HyperdriveInterface
             The trading market interface.
-        wallet : HyperdriveWallet
+        wallet: HyperdriveWallet
             The agent's wallet.
 
         Returns
@@ -330,7 +330,7 @@ class InvalidCloseLongFromNonZero(HyperdrivePolicy):
         ---------
         interface: HyperdriveInterface
             The trading market interface.
-        wallet : HyperdriveWallet
+        wallet: HyperdriveWallet
             The agent's wallet.
 
         Returns
@@ -403,7 +403,7 @@ class InvalidCloseShortFromNonZero(HyperdrivePolicy):
         ---------
         interface: HyperdriveInterface
             The trading market interface.
-        wallet : HyperdriveWallet
+        wallet: HyperdriveWallet
             The agent's wallet.
 
         Returns
@@ -476,7 +476,7 @@ class InvalidRedeemWithdrawInPool(HyperdrivePolicy):
         ---------
         interface: HyperdriveInterface
             The trading market interface.
-        wallet : HyperdriveWallet
+        wallet: HyperdriveWallet
             The agent's wallet.
 
         Returns
@@ -577,7 +577,7 @@ class InvalidRedeemWithdrawFromNonZero(HyperdrivePolicy):
         ---------
         interface: HyperdriveInterface
             The trading market interface.
-        wallet : Wallet
+        wallet: Wallet
             The agent's wallet.
 
         Returns


### PR DESCRIPTION
Don't use space before `:` in the type specification. Sphinx and VSCode render it the same, and it's closer to the signature.