### PR TITLE
Test speedup and cleanup

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -7,7 +7,7 @@ import os
 
 import pytest
 from chainsync.test_fixtures import database_engine, db_api, db_session, dummy_session, psql_docker
-from ethpy.test_fixtures import local_chain, local_hyperdrive_pool
+from ethpy.test_fixtures import init_local_hyperdrive_pool, local_chain, local_hyperdrive_pool
 
 from agent0.test_utils import cycle_trade_policy
 
@@ -56,6 +56,7 @@ __all__ = [
     "dummy_session",
     "psql_docker",
     "local_chain",
+    "init_local_hyperdrive_pool",
     "local_hyperdrive_pool",
     "cycle_trade_policy",
 ]

--- a/conftest.py
+++ b/conftest.py
@@ -6,9 +6,10 @@
 import os
 
 import pytest
-from agent0.test_utils import cycle_trade_policy
 from chainsync.test_fixtures import database_engine, db_api, db_session, dummy_session, psql_docker
 from ethpy.test_fixtures import local_chain, local_hyperdrive_pool
+
+from agent0.test_utils import cycle_trade_policy
 
 # Hack to allow for vscode debugger to throw exception immediately
 # instead of allowing pytest to catch the exception and report

--- a/lib/agent0/agent0/hyperdrive/exec/run_agents.py
+++ b/lib/agent0/agent0/hyperdrive/exec/run_agents.py
@@ -6,7 +6,6 @@ import logging
 import os
 import random
 import time
-import warnings
 
 import pandas as pd
 from chainsync.db.api import balance_of, register_username
@@ -74,7 +73,6 @@ def run_agents(
     # set sane logging defaults to avoid spam from dependencies
     logging.getLogger("urllib3").setLevel(logging.WARNING)
     logging.getLogger("web3").setLevel(logging.WARNING)
-    warnings.filterwarnings("ignore", category=UserWarning, module="web3.contract.base_contract")
     # defaults to looking for eth_config env
     if eth_config is None:
         eth_config = build_eth_config()

--- a/lib/agent0/tests/target_rate_test.py
+++ b/lib/agent0/tests/target_rate_test.py
@@ -3,14 +3,9 @@ from __future__ import annotations
 
 import logging
 import os
-import warnings
 from typing import cast
 
 import pytest
-from agent0 import build_account_key_config_from_agent_config
-from agent0.base.config import AgentConfig, EnvironmentConfig
-from agent0.hyperdrive.exec import run_agents
-from agent0.hyperdrive.policies.zoo import Zoo
 from eth_typing import URI
 from ethpy import EthConfig
 from ethpy.hyperdrive.addresses import HyperdriveAddresses
@@ -19,12 +14,16 @@ from ethpy.test_fixtures.local_chain import DeployedHyperdrivePool
 from fixedpointmath import FixedPoint
 from web3 import HTTPProvider
 
+from agent0 import build_account_key_config_from_agent_config
+from agent0.base.config import AgentConfig, EnvironmentConfig
+from agent0.hyperdrive.exec import run_agents
+from agent0.hyperdrive.policies.zoo import Zoo
+
 
 @pytest.mark.anvil
 @pytest.mark.parametrize("delta", [-1e5, 1e5])
 def test_hit_target_rate(local_hyperdrive_pool: DeployedHyperdrivePool, delta: float):
     """Ensure bot can hit target rate."""
-    warnings.filterwarnings("ignore", category=UserWarning, module="web3.contract.base_contract")
     # Run this test with develop mode on
     os.environ["DEVELOP"] = "true"
     # Get hyperdrive chain info

--- a/lib/chainsync/chainsync/db/api/api_interface.py
+++ b/lib/chainsync/chainsync/db/api/api_interface.py
@@ -1,6 +1,7 @@
 """Python api interface for calling the flask server"""
 import logging
 import time
+import warnings
 from http import HTTPStatus
 from io import StringIO
 
@@ -62,5 +63,9 @@ def balance_of(api_uri: str, wallet_addrs: list[str]) -> pd.DataFrame:
     # before returning
     # We explicitly set dtype to False to keep everything in string format
     # to avoid loss of precision
-    data = pd.read_json(StringIO(result.json()["data"]), dtype=False)
+    # For some reason, pandas internally is throwing a warning about datetimes here,
+    # we ignore
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        data = pd.read_json(StringIO(result.json()["data"]), dtype=False)
     return data

--- a/lib/chainsync/chainsync/db/hyperdrive/interface_test.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/interface_test.py
@@ -4,9 +4,8 @@ from decimal import Decimal
 
 import numpy as np
 import pytest
-from ethpy.hyperdrive import BASE_TOKEN_SYMBOL
-
 from chainsync.db.base import get_latest_block_number_from_table
+from ethpy.hyperdrive import BASE_TOKEN_SYMBOL
 
 from .interface import (
     add_checkpoint_infos,
@@ -116,7 +115,7 @@ class TestCheckpointInterface:
 
         checkpoints_df = get_checkpoint_info(db_session)
         np.testing.assert_array_equal(
-            checkpoints_df["timestamp"].dt.to_pydatetime(), np.array([date_1, date_2, date_3])
+            np.array(checkpoints_df["timestamp"].values), np.array([date_1, date_2, date_3]).astype("datetime64[ns]")
         )
 
     @pytest.mark.docker
@@ -233,7 +232,8 @@ class TestPoolInfoInterface:
 
         pool_info_df = get_pool_info(db_session)
         np.testing.assert_array_equal(
-            pool_info_df["timestamp"].dt.to_pydatetime(), np.array([timestamp_1, timestamp_2, timestamp_3])
+            np.array(pool_info_df["timestamp"].values),
+            np.array([timestamp_1, timestamp_2, timestamp_3]).astype("datetime64[ns]"),
         )
 
     @pytest.mark.docker
@@ -248,18 +248,24 @@ class TestPoolInfoInterface:
         add_pool_infos([pool_info_1, pool_info_2, pool_info_3], db_session)
         pool_info_df = get_pool_info(db_session, start_block=1)
         np.testing.assert_array_equal(
-            pool_info_df["timestamp"].dt.to_pydatetime(), np.array([timestamp_2, timestamp_3])
+            np.array(pool_info_df["timestamp"].values), np.array([timestamp_2, timestamp_3]).astype("datetime64[ns]")
         )
         pool_info_df = get_pool_info(db_session, start_block=-1)
-        np.testing.assert_array_equal(pool_info_df["timestamp"].dt.to_pydatetime(), np.array([timestamp_3]))
+        np.testing.assert_array_equal(
+            np.array(pool_info_df["timestamp"].values), np.array([timestamp_3]).astype("datetime64[ns]")
+        )
         pool_info_df = get_pool_info(db_session, end_block=1)
-        np.testing.assert_array_equal(pool_info_df["timestamp"].dt.to_pydatetime(), np.array([timestamp_1]))
+        np.testing.assert_array_equal(
+            np.array(pool_info_df["timestamp"].values), np.array([timestamp_1]).astype("datetime64[ns]")
+        )
         pool_info_df = get_pool_info(db_session, end_block=-1)
         np.testing.assert_array_equal(
-            pool_info_df["timestamp"].dt.to_pydatetime(), np.array([timestamp_1, timestamp_2])
+            np.array(pool_info_df["timestamp"].values), np.array([timestamp_1, timestamp_2]).astype("datetime64[ns]")
         )
         pool_info_df = get_pool_info(db_session, start_block=1, end_block=-1)
-        np.testing.assert_array_equal(pool_info_df["timestamp"].dt.to_pydatetime(), np.array([timestamp_2]))
+        np.testing.assert_array_equal(
+            np.array(pool_info_df["timestamp"].values), np.array([timestamp_2]).astype("datetime64[ns]")
+        )
 
 
 class TestWalletDeltaInterface:

--- a/lib/chainsync/chainsync/exec/acquire_data.py
+++ b/lib/chainsync/chainsync/exec/acquire_data.py
@@ -3,13 +3,6 @@ from __future__ import annotations
 
 import logging
 import time
-import warnings
-
-from eth_typing import BlockNumber
-from ethpy import EthConfig
-from ethpy.hyperdrive import HyperdriveAddresses
-from ethpy.hyperdrive.api import HyperdriveInterface
-from sqlalchemy.orm import Session
 
 from chainsync.db.base import initialize_session
 from chainsync.db.hyperdrive import (
@@ -17,10 +10,13 @@ from chainsync.db.hyperdrive import (
     get_latest_block_number_from_pool_info_table,
     init_data_chain_to_db,
 )
+from eth_typing import BlockNumber
+from ethpy import EthConfig
+from ethpy.hyperdrive import HyperdriveAddresses
+from ethpy.hyperdrive.api import HyperdriveInterface
+from sqlalchemy.orm import Session
 
 _SLEEP_AMOUNT = 1
-
-warnings.filterwarnings("ignore", category=UserWarning, module="web3.contract.base_contract")
 
 
 # Lots of arguments

--- a/lib/chainsync/chainsync/test_fixtures/db_session.py
+++ b/lib/chainsync/chainsync/test_fixtures/db_session.py
@@ -9,14 +9,13 @@ from typing import Iterator
 
 import docker
 import pytest
+from chainsync import PostgresConfig
+from chainsync.db.base import Base, initialize_engine
 from docker.errors import APIError, DockerException, NotFound
 from docker.models.containers import Container
 from pytest_postgresql.janitor import DatabaseJanitor
 from sqlalchemy import Engine
 from sqlalchemy.orm import Session, sessionmaker
-
-from chainsync import PostgresConfig
-from chainsync.db.base import Base, initialize_engine
 
 TEST_POSTGRES_NAME = "postgres_test"
 
@@ -168,7 +167,7 @@ def db_session(database_engine: Engine) -> Iterator[Session]:  # pylint: disable
     Base.metadata.drop_all(database_engine)  # drop tables
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def db_api(psql_docker: PostgresConfig) -> Iterator[str]:  # pylint: disable=redefined-outer-name
     """Launch a process for the db api.
 

--- a/lib/ethpy/ethpy/base/receipts.py
+++ b/lib/ethpy/ethpy/base/receipts.py
@@ -1,6 +1,7 @@
 """Utilities for handling transaction receipts"""
 from __future__ import annotations
 
+import warnings
 from typing import Any, Sequence, cast
 
 from web3 import Web3
@@ -76,6 +77,10 @@ def get_event_object(
         if event_signature_hex == receipt_event_signature_hex and name is not None:
             # Decode matching log
             contract_event = contract.events[name]()
-            event_data: EventData = contract_event.process_receipt(tx_receipt)[0]
+            # TODO web3 is throwing a warning on mismatched ABI for events here, fix
+            # https://github.com/delvtech/agent0/issues/1130
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                event_data: EventData = contract_event.process_receipt(tx_receipt)[0]
             return event_data, event
     return (None, None)

--- a/lib/ethpy/ethpy/hyperdrive/deploy.py
+++ b/lib/ethpy/ethpy/hyperdrive/deploy.py
@@ -1,8 +1,8 @@
 """Helper functions for deploying Hyperdrive contracts."""
 from __future__ import annotations
 
-from dataclasses import dataclass, fields, is_dataclass
-from typing import Any
+from dataclasses import fields, is_dataclass
+from typing import Any, NamedTuple
 
 from eth_account.account import Account
 from eth_account.signers.local import LocalAccount
@@ -24,8 +24,7 @@ from .addresses import HyperdriveAddresses
 # pylint: disable=too-many-locals
 
 
-@dataclass
-class DeployedHyperdrivePool:
+class DeployedHyperdrivePool(NamedTuple):
     """Collection of attributes associated with a locally deployed chain with a Hyperdrive pool."""
 
     web3: Web3

--- a/lib/ethpy/ethpy/hyperdrive/deploy.py
+++ b/lib/ethpy/ethpy/hyperdrive/deploy.py
@@ -7,15 +7,14 @@ from typing import Any, NamedTuple
 from eth_account.account import Account
 from eth_account.signers.local import LocalAccount
 from eth_typing import ChecksumAddress
+from ethpy.base import get_transaction_logs, initialize_web3_with_http_provider, load_all_abis, smart_contract_transact
+from ethpy.base.contract import deploy_contract
 from fixedpointmath import FixedPoint
 from hypertypes import Fees, PoolConfig
 from web3 import Web3
 from web3.constants import ADDRESS_ZERO
 from web3.contract.contract import Contract
 from web3.types import TxReceipt
-
-from ethpy.base import get_transaction_logs, initialize_web3_with_http_provider, load_all_abis, smart_contract_transact
-from ethpy.base.contract import deploy_contract
 
 from .addresses import HyperdriveAddresses
 
@@ -34,6 +33,7 @@ class DeployedHyperdrivePool(NamedTuple):
     hyperdrive_contract: Contract
     hyperdrive_factory_contract: Contract
     base_token_contract: Contract
+    deploy_block_number: int
 
 
 def deploy_hyperdrive_from_factory(
@@ -84,6 +84,8 @@ def deploy_hyperdrive_from_factory(
                 Web3 contract instance for the hyperdrive factory contract.
             base_token_contract: Contract
                 Web3 contract instance for the base token contract.
+            deploy_block_number: int
+                The block number hyperdrive was deployed at.
     """
     # Contract calls use the web3.py interface
     web3 = initialize_web3_with_http_provider(rpc_uri, reset_provider=False)
@@ -128,6 +130,7 @@ def deploy_hyperdrive_from_factory(
             factory_contract,
         )
     )
+    # Get block number when hyperdrive was deployed
     return DeployedHyperdrivePool(
         web3,
         deploy_account=deploy_account,
@@ -140,6 +143,7 @@ def deploy_hyperdrive_from_factory(
         hyperdrive_contract=web3.eth.contract(address=hyperdrive_checksum_address, abi=abis["IERC4626Hyperdrive"]),
         hyperdrive_factory_contract=factory_contract,
         base_token_contract=base_token_contract,
+        deploy_block_number=web3.eth.block_number,
     )
 
 

--- a/lib/ethpy/ethpy/hyperdrive/deploy.py
+++ b/lib/ethpy/ethpy/hyperdrive/deploy.py
@@ -1,8 +1,8 @@
 """Helper functions for deploying Hyperdrive contracts."""
 from __future__ import annotations
 
-from dataclasses import fields, is_dataclass
-from typing import Any, NamedTuple
+from dataclasses import dataclass, fields, is_dataclass
+from typing import Any
 
 from eth_account.account import Account
 from eth_account.signers.local import LocalAccount
@@ -24,7 +24,8 @@ from .addresses import HyperdriveAddresses
 # pylint: disable=too-many-locals
 
 
-class DeployedHyperdrivePool(NamedTuple):
+@dataclass
+class DeployedHyperdrivePool:
     """Collection of attributes associated with a locally deployed chain with a Hyperdrive pool."""
 
     web3: Web3

--- a/lib/ethpy/ethpy/test_fixtures/__init__.py
+++ b/lib/ethpy/ethpy/test_fixtures/__init__.py
@@ -1,2 +1,2 @@
 """Test fixtures for ethpy"""
-from .local_chain import local_chain, local_hyperdrive_pool
+from .local_chain import init_local_hyperdrive_pool, local_chain, local_hyperdrive_pool

--- a/lib/ethpy/ethpy/test_fixtures/local_chain.py
+++ b/lib/ethpy/ethpy/test_fixtures/local_chain.py
@@ -97,9 +97,7 @@ def init_local_hyperdrive_pool(
             The snapshot id to reset to.
         """
         # Loads the previous snapshot
-        print(_w3.eth.block_number)
         _ = _w3.provider.make_request(method=RPCEndpoint("evm_revert"), params=[snapshot_id])
-        print(_w3.eth.block_number)
 
     return out, snapshot, reset
 

--- a/lib/ethpy/ethpy/test_fixtures/local_chain.py
+++ b/lib/ethpy/ethpy/test_fixtures/local_chain.py
@@ -6,11 +6,10 @@ import time
 from typing import Iterator
 
 import pytest
+from ethpy.hyperdrive import DeployedHyperdrivePool, deploy_hyperdrive_from_factory
 from fixedpointmath import FixedPoint
 from hypertypes import Fees, PoolConfig
 from web3.constants import ADDRESS_ZERO
-
-from ethpy.hyperdrive import DeployedHyperdrivePool, deploy_hyperdrive_from_factory
 
 
 def launch_local_chain(anvil_port: int = 9999, host: str = "127.0.0.1"):
@@ -40,9 +39,10 @@ def launch_local_chain(anvil_port: int = 9999, host: str = "127.0.0.1"):
     anvil_process.kill()  # Kill anvil process at end
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def local_chain() -> Iterator[str]:
     """Fixture representing a local anvil chain.
+    This fixture is session scoped, so each test will deploy its own pool for testing.
 
     Yields
     ------

--- a/tests/bot_load_state_test.py
+++ b/tests/bot_load_state_test.py
@@ -7,12 +7,6 @@ from dataclasses import dataclass
 from typing import cast
 
 import pytest
-from agent0 import build_account_key_config_from_agent_config
-from agent0.base import MarketType, Trade
-from agent0.base.config import AgentConfig, EnvironmentConfig
-from agent0.hyperdrive.exec import run_agents
-from agent0.hyperdrive.policies import HyperdrivePolicy
-from agent0.hyperdrive.state import HyperdriveActionType, HyperdriveMarketAction, HyperdriveWallet
 from chainsync.exec import acquire_data, data_analysis
 from eth_typing import URI
 from ethpy import EthConfig
@@ -23,6 +17,13 @@ from fixedpointmath import FixedPoint
 from numpy.random._generator import Generator as NumpyGenerator
 from sqlalchemy.orm import Session
 from web3 import HTTPProvider
+
+from agent0 import build_account_key_config_from_agent_config
+from agent0.base import MarketType, Trade
+from agent0.base.config import AgentConfig, EnvironmentConfig
+from agent0.hyperdrive.exec import run_agents
+from agent0.hyperdrive.policies import HyperdrivePolicy
+from agent0.hyperdrive.state import HyperdriveActionType, HyperdriveMarketAction, HyperdriveWallet
 
 
 class WalletTestPolicy(HyperdrivePolicy):
@@ -205,7 +206,7 @@ class TestBotToDb:
 
         # Run acquire data to get data from chain to db
         acquire_data(
-            start_block=10,  # First 9 blocks are deploying hyperdrive, ignore
+            start_block=local_hyperdrive_pool.deploy_block_number,  # We only want to get data past the deploy block
             eth_config=eth_config,
             db_session=db_session,
             contract_addresses=hyperdrive_contract_addresses,
@@ -215,7 +216,7 @@ class TestBotToDb:
 
         # Run data analysis to calculate various analysis values
         data_analysis(
-            start_block=10,  # First 9 blocks are deploying hyperdrive, ignore
+            start_block=local_hyperdrive_pool.deploy_block_number,  # We only want to get data past the deploy block
             eth_config=eth_config,
             db_session=db_session,
             contract_addresses=hyperdrive_contract_addresses,

--- a/tests/bot_to_db_test.py
+++ b/tests/bot_to_db_test.py
@@ -180,8 +180,6 @@ class TestBotToDb:
         # 8. addLiquidity of 11111 base
         # 9. openLong of 22222 base
         # 10. openShort of 33333 bonds
-        # 11. removeLiquidity of all LP tokens
-        # The last trade here won't show up in the database, due to data lag of one block
 
         # Test db entries are what we expect
         # We don't coerce to float because we want exact values in decimal

--- a/tests/bot_to_db_test.py
+++ b/tests/bot_to_db_test.py
@@ -9,10 +9,6 @@ from typing import Type, cast
 import numpy as np
 import pandas as pd
 import pytest
-from agent0 import build_account_key_config_from_agent_config
-from agent0.base.config import AgentConfig, EnvironmentConfig
-from agent0.hyperdrive.exec import run_agents
-from agent0.test_utils import CycleTradesPolicy
 from chainsync.db.hyperdrive.interface import (
     get_current_wallet,
     get_pool_analysis,
@@ -32,6 +28,11 @@ from ethpy.test_fixtures.local_chain import DeployedHyperdrivePool
 from fixedpointmath import FixedPoint
 from sqlalchemy.orm import Session
 from web3 import HTTPProvider
+
+from agent0 import build_account_key_config_from_agent_config
+from agent0.base.config import AgentConfig, EnvironmentConfig
+from agent0.hyperdrive.exec import run_agents
+from agent0.test_utils import CycleTradesPolicy
 
 
 def _to_unscaled_decimal(fp_val: FixedPoint) -> Decimal:
@@ -107,7 +108,7 @@ class TestBotToDb:
 
         # Run acquire data to get data from chain to db
         acquire_data(
-            start_block=10,  # First 9 blocks are deploying hyperdrive, ignore
+            start_block=local_hyperdrive_pool.deploy_block_number,  # We only want to get data past the deploy block
             eth_config=eth_config,
             db_session=db_session,
             contract_addresses=hyperdrive_contract_addresses,
@@ -117,7 +118,7 @@ class TestBotToDb:
 
         # Run data analysis to calculate various analysis values
         data_analysis(
-            start_block=10,  # First 9 blocks are deploying hyperdrive, ignore
+            start_block=local_hyperdrive_pool.deploy_block_number,  # We only want to get data past the deploy block
             eth_config=eth_config,
             db_session=db_session,
             contract_addresses=hyperdrive_contract_addresses,
@@ -149,7 +150,7 @@ class TestBotToDb:
 
         # Run acquire data to get data from chain to db
         acquire_data(
-            start_block=10,  # First 9 blocks are deploying hyperdrive, ignore
+            start_block=local_hyperdrive_pool.deploy_block_number,  # We only want to get data past the deploy block
             eth_config=eth_config,
             db_session=db_session,
             contract_addresses=hyperdrive_contract_addresses,
@@ -159,7 +160,7 @@ class TestBotToDb:
 
         # Run data analysis to calculate various analysis values
         data_analysis(
-            start_block=10,  # First 9 blocks are deploying hyperdrive, ignore
+            start_block=local_hyperdrive_pool.deploy_block_number,
             eth_config=eth_config,
             db_session=db_session,
             contract_addresses=hyperdrive_contract_addresses,

--- a/tests/invalid_balance_trade_test.py
+++ b/tests/invalid_balance_trade_test.py
@@ -654,8 +654,9 @@ class InvalidRedeemWithdrawFromNonZero(HyperdrivePolicy):
 class TestInvalidTrades:
     """Test pipeline from bots making trades to viewing the trades in the db."""
 
-    @pytest.mark.anvil
-    def _build_and_run_with_funded_bot(self, hyperdrive_pool: DeployedHyperdrivePool, policy: Type[HyperdrivePolicy]):
+    def _build_and_run_with_funded_bot(
+        self, in_hyperdrive_pool: DeployedHyperdrivePool, in_policy: Type[HyperdrivePolicy]
+    ):
         # Run this test with develop mode on
         os.environ["DEVELOP"] = "true"
 
@@ -672,19 +673,19 @@ class TestInvalidTrades:
         )
 
         # Get hyperdrive chain info
-        rpc_uri: URI | None = cast(HTTPProvider, hyperdrive_pool.web3.provider).endpoint_uri
+        rpc_uri: URI | None = cast(HTTPProvider, in_hyperdrive_pool.web3.provider).endpoint_uri
         assert rpc_uri is not None
-        hyperdrive_contract_addresses: HyperdriveAddresses = hyperdrive_pool.hyperdrive_contract_addresses
+        hyperdrive_contract_addresses: HyperdriveAddresses = in_hyperdrive_pool.hyperdrive_contract_addresses
 
         # Build agent config
         agent_config: list[AgentConfig] = [
             AgentConfig(
-                policy=policy,
+                policy=in_policy,
                 number_of_agents=1,
                 slippage_tolerance=None,
                 base_budget_wei=FixedPoint("1_000_000").scaled_value,  # 1 million base
                 eth_budget_wei=FixedPoint("100").scaled_value,  # 100 base
-                policy_config=policy.Config(),
+                policy_config=in_policy.Config(),
             ),
         ]
         account_key_config = build_account_key_config_from_agent_config(agent_config)
@@ -706,7 +707,7 @@ class TestInvalidTrades:
         assert False, "Agent was successful with known invalid trade"
 
     def _build_and_run_with_non_funded_bot(
-        self, hyperdrive_pool: DeployedHyperdrivePool, policy: Type[HyperdrivePolicy]
+        self, in_hyperdrive_pool: DeployedHyperdrivePool, in_policy: Type[HyperdrivePolicy]
     ):
         # Run this test with develop mode on
         os.environ["DEVELOP"] = "true"
@@ -724,19 +725,19 @@ class TestInvalidTrades:
         )
 
         # Get hyperdrive chain info
-        rpc_uri: URI | None = cast(HTTPProvider, hyperdrive_pool.web3.provider).endpoint_uri
+        rpc_uri: URI | None = cast(HTTPProvider, in_hyperdrive_pool.web3.provider).endpoint_uri
         assert rpc_uri is not None
-        hyperdrive_contract_addresses: HyperdriveAddresses = hyperdrive_pool.hyperdrive_contract_addresses
+        hyperdrive_contract_addresses: HyperdriveAddresses = in_hyperdrive_pool.hyperdrive_contract_addresses
 
         # Build agent config
         agent_config: list[AgentConfig] = [
             AgentConfig(
-                policy=policy,
+                policy=in_policy,
                 number_of_agents=1,
                 slippage_tolerance=None,
                 base_budget_wei=FixedPoint("10").scaled_value,  # 10 base
                 eth_budget_wei=FixedPoint("100").scaled_value,  # 100 base
-                policy_config=policy.Config(),
+                policy_config=in_policy.Config(),
             ),
         ]
         account_key_config = build_account_key_config_from_agent_config(agent_config)
@@ -765,7 +766,6 @@ class TestInvalidTrades:
         """Tests when making a trade with not enough base in wallet."""
         try:
             self._build_and_run_with_non_funded_bot(local_hyperdrive_pool, InvalidRemoveLiquidityFromNonZero)
-
         except ContractCallException as exc:
             # Expected error due to illegal trade
             # We do add an argument for invalid balance to the args, so check for that here
@@ -785,7 +785,6 @@ class TestInvalidTrades:
         """Test making a invalid remove liquidity with zero lp tokens."""
         try:
             self._build_and_run_with_funded_bot(local_hyperdrive_pool, InvalidRemoveLiquidityFromZero)
-
         except ContractCallException as exc:
             # Expected error due to illegal trade
             # We do add an argument for invalid balance to the args, so check for that here
@@ -807,7 +806,6 @@ class TestInvalidTrades:
         """Test making a invalid close long with zero long tokens."""
         try:
             self._build_and_run_with_funded_bot(local_hyperdrive_pool, InvalidCloseLongFromZero)
-
         except ContractCallException as exc:
             # Expected error due to illegal trade
             # We do add an argument for invalid balance to the args, so check for that here
@@ -830,7 +828,6 @@ class TestInvalidTrades:
         """Test making a invalid close long with zero long tokens."""
         try:
             self._build_and_run_with_funded_bot(local_hyperdrive_pool, InvalidCloseShortFromZero)
-
         except ContractCallException as exc:
             # Expected error due to illegal trade
             # We do add an argument for invalid balance to the args, so check for that here
@@ -853,7 +850,6 @@ class TestInvalidTrades:
         """Test making a invalid redeem withdrawal shares with zero withdrawal tokens."""
         try:
             self._build_and_run_with_funded_bot(local_hyperdrive_pool, InvalidRedeemWithdrawFromZero)
-
         # This is catching a value error, since this transaction is actually valid on the chain
         # We're explicitly catching this and throwing a value error in redeem withdraw shares
         except ValueError as exc:
@@ -872,7 +868,6 @@ class TestInvalidTrades:
         """Test making a invalid remove liquidity trade with nonzero lp tokens."""
         try:
             self._build_and_run_with_funded_bot(local_hyperdrive_pool, InvalidRemoveLiquidityFromNonZero)
-
         except ContractCallException as exc:
             # Expected error due to illegal trade
             # We do add an argument for invalid balance to the args, so check for that here
@@ -894,7 +889,6 @@ class TestInvalidTrades:
         """Test when making a invalid close long with nonzero long tokens."""
         try:
             self._build_and_run_with_funded_bot(local_hyperdrive_pool, InvalidCloseLongFromNonZero)
-
         except ContractCallException as exc:
             # Expected error due to illegal trade
             # We do add an argument for invalid balance to the args, so check for that here
@@ -916,7 +910,6 @@ class TestInvalidTrades:
         """Test making a invalid close short with nonzero short tokens."""
         try:
             self._build_and_run_with_funded_bot(local_hyperdrive_pool, InvalidCloseShortFromNonZero)
-
         except ContractCallException as exc:
             # Expected error due to illegal trade
             # We do add an argument for invalid balance to the args, so check for that here
@@ -938,7 +931,6 @@ class TestInvalidTrades:
         """Test making a invalid close short with nonzero short tokens."""
         try:
             self._build_and_run_with_funded_bot(local_hyperdrive_pool, InvalidRedeemWithdrawFromNonZero)
-
         # This is catching a value error, since this transaction is actually valid on the chain
         # We're explicitly catching this and throwing a value error in redeem withdraw shares
         except ValueError as exc:
@@ -957,7 +949,6 @@ class TestInvalidTrades:
         """Test making a invalid close short with nonzero short tokens."""
         try:
             self._build_and_run_with_funded_bot(local_hyperdrive_pool, InvalidRedeemWithdrawInPool)
-
         # This is catching a value error, since this transaction is actually valid on the chain
         # We're explicitly catching this and throwing a value error in redeem withdraw shares
         except ValueError as exc:

--- a/tests/multi_trade_per_block_test.py
+++ b/tests/multi_trade_per_block_test.py
@@ -7,12 +7,6 @@ from typing import TYPE_CHECKING, cast
 
 import pandas as pd
 import pytest
-from agent0 import build_account_key_config_from_agent_config
-from agent0.base import MarketType, Trade
-from agent0.base.config import AgentConfig, EnvironmentConfig
-from agent0.hyperdrive.exec import run_agents
-from agent0.hyperdrive.policies import HyperdrivePolicy
-from agent0.hyperdrive.state import HyperdriveActionType, HyperdriveMarketAction, HyperdriveWallet
 from chainsync.db.hyperdrive.interface import get_ticker, get_transactions, get_wallet_deltas
 from chainsync.exec import acquire_data, data_analysis
 from eth_typing import URI
@@ -21,6 +15,13 @@ from fixedpointmath import FixedPoint
 from numpy.random._generator import Generator as NumpyGenerator
 from sqlalchemy.orm import Session
 from web3 import HTTPProvider
+
+from agent0 import build_account_key_config_from_agent_config
+from agent0.base import MarketType, Trade
+from agent0.base.config import AgentConfig, EnvironmentConfig
+from agent0.hyperdrive.exec import run_agents
+from agent0.hyperdrive.policies import HyperdrivePolicy
+from agent0.hyperdrive.state import HyperdriveActionType, HyperdriveMarketAction, HyperdriveWallet
 
 if TYPE_CHECKING:
     from ethpy.hyperdrive import HyperdriveAddresses
@@ -191,7 +192,7 @@ class TestMultiTradePerBlock:
 
         # Run acquire data to get data from chain to db
         acquire_data(
-            start_block=10,  # First 9 blocks are deploying hyperdrive, ignore
+            start_block=local_hyperdrive_pool.deploy_block_number,  # We only want to get data past the deploy block
             eth_config=eth_config,
             db_session=db_session,
             contract_addresses=hyperdrive_contract_addresses,
@@ -201,7 +202,7 @@ class TestMultiTradePerBlock:
 
         # Run data analysis to calculate various analysis values
         data_analysis(
-            start_block=10,  # First 9 blocks are deploying hyperdrive, ignore
+            start_block=local_hyperdrive_pool.deploy_block_number,  # We only want to get data past the deploy block
             eth_config=eth_config,
             db_session=db_session,
             contract_addresses=hyperdrive_contract_addresses,


### PR DESCRIPTION
Tests now launch one session level local chain and pool, then uses `evm_snapshot` and `evm_revert` for different tests. Also cleans up warnings in tests