### PR TITLE
allow private key to be passed to interactive agent

### DIFF
--- a/lib/agent0/agent0/hyperdrive/interactive/interactive_hyperdrive.py
+++ b/lib/agent0/agent0/hyperdrive/interactive/interactive_hyperdrive.py
@@ -62,6 +62,9 @@ from .event_types import (
 from .interactive_hyperdrive_agent import InteractiveHyperdriveAgent
 from .interactive_hyperdrive_policy import InteractiveHyperdrivePolicy
 
+# Is very thorough module.
+# pylint: disable=too-many-lines
+
 # In order to support both scripts and jupyter notebooks with underlying async functions,
 # we use the nest_asyncio package so that we can execute asyncio.run within a running event loop.
 nest_asyncio.apply()
@@ -407,6 +410,8 @@ class InteractiveHyperdrive:
             An optional policy to attach to this agent.
         policy_config: HyperdrivePolicy, optional
             The configuration for the attached policy.
+        private_key: str, optional
+            The private key of the associated account. Default is auto-generated.
 
         Returns
         -------

--- a/lib/agent0/agent0/hyperdrive/interactive/interactive_hyperdrive.py
+++ b/lib/agent0/agent0/hyperdrive/interactive/interactive_hyperdrive.py
@@ -391,6 +391,7 @@ class InteractiveHyperdrive:
         name: str | None = None,
         policy: Type[HyperdrivePolicy] | None = None,
         policy_config: HyperdrivePolicy.Config | None = None,
+        private_key: str | None = None,
     ) -> InteractiveHyperdriveAgent:
         """Initializes an agent with initial funding and a logical name.
 
@@ -421,7 +422,13 @@ class InteractiveHyperdrive:
         if eth is None:
             eth = FixedPoint(10)
         out_agent = InteractiveHyperdriveAgent(
-            base=base, eth=eth, name=name, pool=self, policy=policy, policy_config=policy_config
+            base=base,
+            eth=eth,
+            name=name,
+            pool=self,
+            policy=policy,
+            policy_config=policy_config,
+            private_key=private_key,
         )
         self._pool_agents.append(out_agent)
         return out_agent
@@ -720,9 +727,10 @@ class InteractiveHyperdrive:
         name: str | None,
         policy: Type[HyperdrivePolicy] | None,
         policy_config: HyperdrivePolicy.Config | None,
+        private_key: str | None = None,
     ) -> HyperdriveAgent:
         # pylint: disable=too-many-arguments
-        agent_private_key = make_private_key()
+        agent_private_key = make_private_key() if private_key is None else private_key
         # Setting the budget to 0 here, `_add_funds` will take care of updating the wallet
         agent = HyperdriveAgent(
             Account().from_key(agent_private_key),

--- a/lib/agent0/agent0/hyperdrive/interactive/interactive_hyperdrive_agent.py
+++ b/lib/agent0/agent0/hyperdrive/interactive/interactive_hyperdrive_agent.py
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
         AddLiquidity,
         CloseLong,
         CloseShort,
-        CreateCheckpoint,
         OpenLong,
         OpenShort,
         RedeemWithdrawalShares,

--- a/lib/agent0/agent0/hyperdrive/interactive/interactive_hyperdrive_agent.py
+++ b/lib/agent0/agent0/hyperdrive/interactive/interactive_hyperdrive_agent.py
@@ -44,6 +44,7 @@ class InteractiveHyperdriveAgent:
         pool: InteractiveHyperdrive,
         policy: Type[HyperdrivePolicy] | None,
         policy_config: HyperdrivePolicy.Config | None,
+        private_key: str | None = None,
     ) -> None:
         """Constructor for the interactive hyperdrive agent.
         NOTE: this constructor shouldn't be called directly, but rather from InteractiveHyperdrive's
@@ -65,7 +66,7 @@ class InteractiveHyperdriveAgent:
         # pylint: disable=too-many-arguments
         self._pool = pool
         self.name = name
-        self.agent = self._pool._init_agent(base, eth, name, policy, policy_config)
+        self.agent = self._pool._init_agent(base, eth, name, policy, policy_config, private_key)
 
     @property
     def wallet(self) -> HyperdriveWallet:

--- a/lib/agent0/agent0/hyperdrive/interactive/interactive_hyperdrive_agent.py
+++ b/lib/agent0/agent0/hyperdrive/interactive/interactive_hyperdrive_agent.py
@@ -62,6 +62,8 @@ class InteractiveHyperdriveAgent:
             The pool object that this agent belongs to.
         policy: HyperdrivePolicy | None
             An optional policy to attach to this agent.
+        private_key: str | None, optional
+            The private key of the associated account. Default is auto-generated.
         """
         # pylint: disable=too-many-arguments
         self._pool = pool

--- a/lib/agent0/agent0/hyperdrive/interactive/interactive_hyperdrive_test.py
+++ b/lib/agent0/agent0/hyperdrive/interactive/interactive_hyperdrive_test.py
@@ -418,7 +418,7 @@ class TestInteractiveHyperdrive:
         assert larry.wallet.address.hex().startswith(pubkey.lower())  # deployer public key
 
     @pytest.mark.anvil
-    def test_remove_all_liquidity(self, chain: LocalChain):
+    def test_remove_deployer_liquidity(self, chain: LocalChain):
         config = InteractiveHyperdrive.Config(
             initial_liquidity=FixedPoint(100),
         )
@@ -426,8 +426,7 @@ class TestInteractiveHyperdrive:
         privkey = chain.get_deployer_account_private_key()  # anvil account 0
         larry = interactive_hyperdrive.init_agent(base=FixedPoint(100_000), name="larry", private_key=privkey)
         # Ideally this would hold the accurate number of LP tokens, but the amount from initialization isn't
-        # included in acquire_data. Instead, we hack some coins into his wallet
+        # included in acquire_data. Instead, we hack some coins into his wallet, to avoid error checks.
         larry.wallet.lp_tokens = FixedPoint(100)
-        # share_price = interactive_hyperdrive.hyperdrive_interface.current_pool_state.pool_info.share_price
-        # larry_lp_shares = FixedPoint(1/share_price)
+        # I don't know how many shares he actually has, so I'm guessing here.
         larry.remove_liquidity(shares=FixedPoint(5))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,6 @@ minversion = "6.0"
 addopts = ["--tb=short"]
 norecursedirs = ".git examples hyperdrive_solidity"
 python_files = "*_test.py test_*.py"
-markers = [
-    "anvil: tests using anvil (deselect with '-m \"not anvil\"')",
-    "docker: tests using docker (deselect with '-m \"not docker\"')",
-]
 
 [tool.pylint.format]
 max-line-length = "120"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    anvil: tests using anvil (deselect with '-m "not anvil"')
+    docker: tests using docker (deselect with '-m "not docker"')


### PR DESCRIPTION
attempt to account for 100% of liquidity in a pool

since some liquidity is deployed in the deployAndInitialize call. I found the minimum to be 20 in my test.

idea is for it to show up like this:
```
config = InteractiveHyperdrive.Config()
config.initial_liquidity = FixedPoint(11)
interactive_hyperdrive = InteractiveHyperdrive(chain, config)
privkey = chain.get_deployer_account_private_key()  # anvil account 0
pubkey = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
larry = interactive_hyperdrive.init_agent(base=FixedPoint(100_000), name="larry", private_key=privkey)
assert larry.wallet.address.hex().startswith(pubkey.lower())  # deployer public key
current_wallet = interactive_hyperdrive.get_current_wallet()
current_wallet
```
but no LP position shows up in `current_wallet`