### PR TITLE
Custom exceptions subclasses from Exception instead of BaseException

### DIFF
--- a/lib/agent0/agent0/hyperdrive/crash_report/crash_report.py
+++ b/lib/agent0/agent0/hyperdrive/crash_report/crash_report.py
@@ -51,7 +51,7 @@ def setup_hyperdrive_crash_report_logging(log_format_string: str | None = None) 
 # pylint: disable=too-many-statements
 # pylint: disable=too-many-branches
 def build_crash_trade_result(
-    exception: BaseException,
+    exception: Exception,
     interface: HyperdriveInterface,
     agent: HyperdriveAgent | None = None,
     trade_object: Trade[HyperdriveMarketAction] | None = None,
@@ -61,7 +61,7 @@ def build_crash_trade_result(
 
     Arguments
     ---------
-    exception: BaseException
+    exception: Exception
         The exception that was thrown
     interface: HyperdriveInterface
         An interface for Hyperdrive with contracts deployed on any chain with an RPC url.
@@ -293,8 +293,6 @@ def log_hyperdrive_crash_report(
         dump_obj["anvil_dump_state"] = None  # type: ignore
         logging_crash_report = json.loads(json.dumps(dump_obj, indent=2, cls=ExtendedJSONEncoder))
         log_rollbar_exception(trade_result.exception, log_level, logging_crash_report, env_details)
-        if trade_result.orig_exception:
-            log_rollbar_exception(trade_result.orig_exception, log_level, logging_crash_report, env_details)
 
 
 def _hyperdrive_wallet_to_dict(wallet: HyperdriveWallet | None) -> dict[str, Any]:

--- a/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
+++ b/lib/agent0/agent0/hyperdrive/exec/execute_agent_trades.py
@@ -70,6 +70,8 @@ async def async_execute_single_agent_trade(
         DEFAULT_READ_RETRY_COUNT, None, interface.web3.eth.get_transaction_count, agent.checksum_address
     )
 
+    # We expect the type here to be BaseException (due to the return type of asyncio.gather),
+    # but the underlying exception should be subclassed from Exception.
     # TODO preliminary search shows async tasks has very low overhead:
     # https://stackoverflow.com/questions/55761652/what-is-the-overhead-of-an-asyncio-task
     # However, should probably test what the limit number of trades an agent can make in one block
@@ -100,7 +102,7 @@ async def async_execute_single_agent_trade(
     # as long as the transaction went through.
     trade_results = []
     for result, trade_object in zip(wallet_deltas_or_exception, trades):
-        if isinstance(result, BaseException):
+        if isinstance(result, Exception):
             trade_result = build_crash_trade_result(result, interface, agent, trade_object)
         else:
             assert isinstance(result, tuple)

--- a/lib/agent0/agent0/hyperdrive/exec/get_agent_accounts.py
+++ b/lib/agent0/agent0/hyperdrive/exec/get_agent_accounts.py
@@ -125,12 +125,14 @@ async def set_max_approval(
             )
             for agent in agents_left
         ]
+        # We expect the type here to be BaseException (due to the return type of asyncio.gather),
+        # but the underlying exception should be subclassed from Exception.
         gather_results: list[TxReceipt | BaseException] = await asyncio.gather(*approval_calls, return_exceptions=True)
 
         # Rebuild accounts_left list if the result errored out for next iteration
         out_agents_left = []
         for agent, result in zip(agents_left, gather_results):
-            if isinstance(result, BaseException):
+            if isinstance(result, Exception):
                 out_agents_left.append(agent)
                 logging.warning(
                     "Retry attempt %s out of %s: Base approval failed with exception %s",

--- a/lib/agent0/agent0/hyperdrive/state/trade_result.py
+++ b/lib/agent0/agent0/hyperdrive/state/trade_result.py
@@ -34,7 +34,7 @@ class TradeResult:
         The status of the trade
     agent: HyperdriveAgent
         The agent that was executing the trade
-    exception: BaseException | None
+    exception: Exception | None
         The exception that was thrown
     pool_config: dict[str, Any]
         The configuration of the pool
@@ -61,8 +61,8 @@ class TradeResult:
     # These fields are typically set as human readable versions
     block_number: int | None = None
     block_timestamp: int | None = None
-    exception: BaseException | None = None
-    orig_exception: BaseException | None = None
+    exception: Exception | None = None
+    orig_exception: Exception | None = None
     pool_config: dict[str, Any] | None = None
     pool_info: dict[str, Any] | None = None
     checkpoint_info: dict[str, Any] | None = None

--- a/lib/ethpy/ethpy/base/errors/errors.py
+++ b/lib/ethpy/ethpy/base/errors/errors.py
@@ -19,8 +19,7 @@ class ContractCallType(Enum):
     READ = "read"
 
 
-# TODO python docs say we should subclass from Exception, not BaseException, fix
-class ContractCallException(BaseException):
+class ContractCallException(Exception):
     """Custom contract call exception wrapper that contains additional information on the function call"""
 
     # We'd like to pass in these optional kwargs to this exception
@@ -30,7 +29,7 @@ class ContractCallException(BaseException):
         *args,
         # Explicitly passing these arguments as kwargs to allow for multiple `args` to be passed in
         # similar for other types of exceptions
-        orig_exception: BaseException | None = None,
+        orig_exception: Exception | None = None,
         contract_call_type: ContractCallType | None = None,
         function_name_or_signature: str | None = None,
         fn_args: tuple | None = None,

--- a/lib/hyperlogs/hyperlogs/json_encoder.py
+++ b/lib/hyperlogs/hyperlogs/json_encoder.py
@@ -52,7 +52,7 @@ class ExtendedJSONEncoder(json.JSONEncoder):
             return str(o)
         if isinstance(o, TracebackType):
             return format_tb(o)
-        if isinstance(o, BaseException):
+        if isinstance(o, Exception):
             return repr(o)
         if isinstance(o, Enum):
             return o.name

--- a/lib/hyperlogs/hyperlogs/rollbar_utilities.py
+++ b/lib/hyperlogs/hyperlogs/rollbar_utilities.py
@@ -69,12 +69,12 @@ def log_rollbar_message(message: str, log_level: int, payload: dict, extra_data:
     rollbar.report_message(message, log_level_name, payload_data=payload, extra_data=extra_data)
 
 
-def log_rollbar_exception(exception: BaseException, log_level: int, payload: dict, extra_data: dict | None = None):
+def log_rollbar_exception(exception: Exception, log_level: int, payload: dict, extra_data: dict | None = None):
     """Logs an exception to the rollbar service.
 
     Arguments
     ---------
-    exception: BaseException
+    exception: Exception
         The exception to log.
     log_level: int
         The logging level enum value.


### PR DESCRIPTION
Fixes an issue where rollbar wasn't logging custom exceptions (due to subclassing from `BaseException` instead of `Exception`). Python suggests to subclass from `Exception` instead of `BaseException`: https://docs.python.org/3/library/exceptions.html#:~:text=The%20built%2Din%20exception%20classes,subclasses%2C%20and%20not%20from%20BaseException%20.