### PR TITLE
Use pypechain's new deploy method

### DIFF
--- a/lib/agent0/agent0/hyperdrive/exec/fund_agents.py
+++ b/lib/agent0/agent0/hyperdrive/exec/fund_agents.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 
 from eth_account.account import Account
 from ethpy import EthConfig
@@ -12,11 +11,11 @@ from ethpy.base import (
     async_smart_contract_transact,
     get_account_balance,
     initialize_web3_with_http_provider,
-    load_abi_from_file,
     retry_call,
 )
 from ethpy.hyperdrive import HyperdriveAddresses
 from hyperlogs import setup_logging
+from hypertypes.types import ERC20MintableContract
 from web3.types import Nonce, TxReceipt
 
 from agent0 import AccountKeyConfig
@@ -56,15 +55,7 @@ async def async_fund_agents(
     ]
 
     web3 = initialize_web3_with_http_provider(eth_config.rpc_uri, reset_provider=False)
-    abi_file_loc = os.path.join(
-        os.path.join(eth_config.abi_dir, "ERC20Mintable.sol"),
-        "ERC20Mintable.json",
-    )
-    base_contract_abi = load_abi_from_file(abi_file_loc)
-
-    base_token_contract = web3.eth.contract(
-        abi=base_contract_abi, address=web3.to_checksum_address(contract_addresses.base_token)
-    )
+    base_token_contract = ERC20MintableContract.factory(web3)(web3.to_checksum_address(contract_addresses.base_token))
 
     # Check for balances
     total_agent_eth_budget = sum((int(budget) for budget in account_key_config.AGENT_ETH_BUDGETS))

--- a/lib/agent0/agent0/hyperdrive/interactive/interactive_hyperdrive.py
+++ b/lib/agent0/agent0/hyperdrive/interactive/interactive_hyperdrive.py
@@ -34,7 +34,7 @@ from eth_utils.address import to_checksum_address
 from ethpy import EthConfig
 from ethpy.base import set_anvil_account_balance, smart_contract_transact
 from ethpy.hyperdrive import BASE_TOKEN_SYMBOL, DeployedHyperdrivePool, ReceiptBreakdown, deploy_hyperdrive_from_factory
-from ethpy.hyperdrive.interface import HyperdriveInterface
+from ethpy.hyperdrive.interface import HyperdriveReadWriteInterface
 from fixedpointmath import FixedPoint
 from hypertypes import Fees, PoolConfig
 from numpy.random._generator import Generator
@@ -201,7 +201,7 @@ class InteractiveHyperdrive:
         )
         # Deploys a hyperdrive factory + pool on the chain
         self._deployed_hyperdrive = self._deploy_hyperdrive(config, chain)
-        self.hyperdrive_interface = HyperdriveInterface(
+        self.hyperdrive_interface = HyperdriveReadWriteInterface(
             self.eth_config,
             self._deployed_hyperdrive.hyperdrive_contract_addresses,
             web3=chain._web3,
@@ -520,7 +520,7 @@ class InteractiveHyperdrive:
         Returns
         -------
         InteractiveHyperdriveAgent
-            An object that contains the HyperdriveInterface, Agents,
+            An object that contains the HyperdriveReadWriteInterface, Agents,
             and provides access to the interactive Hyperdrive API.
         """
         # pylint: disable=too-many-arguments

--- a/lib/agent0/agent0/hyperdrive/interactive/interactive_hyperdrive.py
+++ b/lib/agent0/agent0/hyperdrive/interactive/interactive_hyperdrive.py
@@ -34,7 +34,7 @@ from eth_utils.address import to_checksum_address
 from ethpy import EthConfig
 from ethpy.base import set_anvil_account_balance, smart_contract_transact
 from ethpy.hyperdrive import BASE_TOKEN_SYMBOL, DeployedHyperdrivePool, ReceiptBreakdown, deploy_hyperdrive_from_factory
-from ethpy.hyperdrive.interface import HyperdriveReadWriteInterface
+from ethpy.hyperdrive.interface import HyperdriveInterface
 from fixedpointmath import FixedPoint
 from hypertypes import Fees, PoolConfig
 from numpy.random._generator import Generator
@@ -200,8 +200,8 @@ class InteractiveHyperdrive:
             preview_before_trade=config.preview_before_trade,
         )
         # Deploys a hyperdrive factory + pool on the chain
-        self._deployed_hyperdrive = self._deploy_hyperdrive(config, chain, self.eth_config.abi_dir)
-        self.hyperdrive_interface = HyperdriveReadWriteInterface(
+        self._deployed_hyperdrive = self._deploy_hyperdrive(config, chain)
+        self.hyperdrive_interface = HyperdriveInterface(
             self.eth_config,
             self._deployed_hyperdrive.hyperdrive_contract_addresses,
             web3=chain._web3,
@@ -406,7 +406,7 @@ class InteractiveHyperdrive:
             other._deployed_hyperdrive.hyperdrive_contract.address,
         )
 
-    def _deploy_hyperdrive(self, config: Config, chain: Chain, abi_dir) -> DeployedHyperdrivePool:
+    def _deploy_hyperdrive(self, config: Config, chain: Chain) -> DeployedHyperdrivePool:
         # sanity check (also for type checking), should get set in __post_init__
         assert config.time_stretch is not None
 
@@ -520,7 +520,7 @@ class InteractiveHyperdrive:
         Returns
         -------
         InteractiveHyperdriveAgent
-            An object that contains the HyperdriveReadWriteInterface, Agents,
+            An object that contains the HyperdriveInterface, Agents,
             and provides access to the interactive Hyperdrive API.
         """
         # pylint: disable=too-many-arguments

--- a/lib/agent0/agent0/hyperdrive/interactive/interactive_hyperdrive.py
+++ b/lib/agent0/agent0/hyperdrive/interactive/interactive_hyperdrive.py
@@ -432,7 +432,6 @@ class InteractiveHyperdrive:
 
         return deploy_hyperdrive_from_factory(
             chain.rpc_uri,
-            abi_dir,
             chain.get_deployer_account_private_key(),
             config.initial_liquidity,
             config.initial_variable_rate,

--- a/lib/ethpy/ethpy/hyperdrive/deploy.py
+++ b/lib/ethpy/ethpy/hyperdrive/deploy.py
@@ -19,6 +19,7 @@ from hypertypes.types import (
     ERC4626Target0DeployerContract,
     ERC4626Target1DeployerContract,
     ForwarderFactoryContract,
+    IERC4626HyperdriveContract,
     MockERC4626Contract,
 )
 from hypertypes.types.ERC4626HyperdriveFactoryTypes import FactoryConfig
@@ -142,7 +143,7 @@ def deploy_hyperdrive_from_factory(
             mock_hyperdrive=hyperdrive_checksum_address,
             mock_hyperdrive_math=None,
         ),
-        hyperdrive_contract=web3.eth.contract(address=hyperdrive_checksum_address, abi=abis["IERC4626Hyperdrive"]),
+        hyperdrive_contract=IERC4626HyperdriveContract.factory(web3)(hyperdrive_checksum_address),
         hyperdrive_factory_contract=factory_contract,
         base_token_contract=base_token_contract,
         deploy_block_number=web3.eth.block_number,

--- a/lib/ethpy/ethpy/hyperdrive/deploy.py
+++ b/lib/ethpy/ethpy/hyperdrive/deploy.py
@@ -205,19 +205,21 @@ def _deploy_hyperdrive_factory(
     (base_token_contract, factory_token_contract, pool_contract_address): tuple[Contract, Contract, ChecksumAddress]
         Containing the deployed base token, factory, and the pool contracts/addresses.
     """
-    erc20args = ERC20MintableContract.ConstructorArgs("Base", "BASE", 18, ADDRESS_ZERO, False)
+    erc20args = ERC20MintableContract.ConstructorArgs(
+        name="Base", symbol="BASE", decimals=18, admin=ADDRESS_ZERO, isCompetitionMode_=False
+    )
     base_token_contract = ERC20MintableContract.deploy(w3=web3, account=deploy_account_addr, constructorArgs=erc20args)
 
     pool = MockERC4626Contract.deploy(
         w3=web3,
         account=deploy_account_addr,
         constructorArgs=MockERC4626Contract.ConstructorArgs(
-            base_token_contract.address,
-            "Delvnet Yield Source",
-            "DELV",
-            initial_variable_rate.scaled_value,
-            ADDRESS_ZERO,
-            False,
+            asset=base_token_contract.address,
+            name="Delvnet Yield Source",
+            symbol="DELV",
+            initialRate=initial_variable_rate.scaled_value,
+            admin=ADDRESS_ZERO,
+            isCompetitionMode=False,
         ),
     )
 
@@ -347,7 +349,12 @@ def _deploy_and_initialize_hyperdrive_pool(
     """
     # TODO: pypechiain - consolidate structs so we don't get poolconfig mismatch errors
     tx = factory_contract.functions.deployAndInitialize(
-        pool_config, initial_liquidity.scaled_value, initial_fixed_rate.scaled_value, bytes(0), [], pool_contract_addr  # type: ignore
+        pool_config,  # type: ignore
+        initial_liquidity.scaled_value,
+        initial_fixed_rate.scaled_value,
+        bytes(0),
+        [],
+        pool_contract_addr,
     ).build_transaction()
     signed_tx = deploy_account.sign_transaction(tx)
     tx_hash = web3.eth.send_raw_transaction(signed_tx)

--- a/lib/ethpy/ethpy/hyperdrive/deploy.py
+++ b/lib/ethpy/ethpy/hyperdrive/deploy.py
@@ -348,17 +348,25 @@ def _deploy_and_initialize_hyperdrive_pool(
         The deployed hyperdrive contract address.
     """
     # TODO: pypechiain - consolidate structs so we don't get poolconfig mismatch errors
-    tx = factory_contract.functions.deployAndInitialize(
+    deploy_and_init_function = factory_contract.functions.deployAndInitialize(
         pool_config,  # type: ignore
         initial_liquidity.scaled_value,
         initial_fixed_rate.scaled_value,
         bytes(0),
         [],
         pool_contract_addr,
-    ).build_transaction()
-    signed_tx = deploy_account.sign_transaction(tx)
-    tx_hash = web3.eth.send_raw_transaction(signed_tx)
-    tx_receipt = web3.eth.wait_for_transaction_receipt(tx_hash)
+    )
+
+    function_name = deploy_and_init_function.fn_name
+    function_args = deploy_and_init_function.args
+
+    tx_receipt = smart_contract_transact(
+        web3,
+        factory_contract,
+        deploy_account,
+        function_name,
+        *function_args,
+    )
 
     logs = get_transaction_logs(factory_contract, tx_receipt)
     hyperdrive_address: str | None = None

--- a/lib/ethpy/ethpy/test_fixtures/local_chain.py
+++ b/lib/ethpy/ethpy/test_fixtures/local_chain.py
@@ -144,7 +144,6 @@ def launch_local_hyperdrive_pool(
     deployer_private_key: str = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
     # ABI folder should contain JSON and Bytecode files for the following contracts:
     # ERC20Mintable, MockERC4626, ForwarderFactory, ERC4626HyperdriveDeployer, ERC4626HyperdriveFactory
-    abi_folder = "packages/hyperdrive/src/abis/"
     # Factory initialization parameters
     initial_variable_rate = FixedPoint("0.05")
     curve_fee = FixedPoint("0.1")  # 10%

--- a/lib/ethpy/ethpy/test_fixtures/local_chain.py
+++ b/lib/ethpy/ethpy/test_fixtures/local_chain.py
@@ -184,7 +184,6 @@ def launch_local_hyperdrive_pool(
     )
     return deploy_hyperdrive_from_factory(
         local_chain_uri,
-        abi_folder,
         deployer_private_key,
         initial_liquidity,
         initial_variable_rate,

--- a/lib/hypertypes/hypertypes/types/ERC20MintableContract.py
+++ b/lib/hypertypes/hypertypes/types/ERC20MintableContract.py
@@ -2333,7 +2333,13 @@ class ERC20MintableContract(Contract):
 
         """
 
-        return super().constructor(name, symbol, decimals, admin, isCompetitionMode_)
+        return super().constructor(
+            dataclass_to_tuple(name),
+            dataclass_to_tuple(symbol),
+            dataclass_to_tuple(decimals),
+            dataclass_to_tuple(admin),
+            dataclass_to_tuple(isCompetitionMode_),
+        )
 
     @classmethod
     def deploy(cls, w3: Web3, account: LocalAccount | ChecksumAddress, constructorArgs: ConstructorArgs) -> Self:

--- a/lib/hypertypes/hypertypes/types/ERC4626HyperdriveFactoryContract.py
+++ b/lib/hypertypes/hypertypes/types/ERC4626HyperdriveFactoryContract.py
@@ -2073,7 +2073,7 @@ class ERC4626HyperdriveFactoryContract(Contract):
 
         """
 
-        return super().constructor(factoryConfig, sweepTargets)
+        return super().constructor(dataclass_to_tuple(factoryConfig), dataclass_to_tuple(sweepTargets))
 
     @classmethod
     def deploy(cls, w3: Web3, account: LocalAccount | ChecksumAddress, constructorArgs: ConstructorArgs) -> Self:

--- a/lib/hypertypes/hypertypes/types/MockERC4626Contract.py
+++ b/lib/hypertypes/hypertypes/types/MockERC4626Contract.py
@@ -3146,7 +3146,14 @@ class MockERC4626Contract(Contract):
 
         """
 
-        return super().constructor(asset, name, symbol, initialRate, admin, isCompetitionMode)
+        return super().constructor(
+            dataclass_to_tuple(asset),
+            dataclass_to_tuple(name),
+            dataclass_to_tuple(symbol),
+            dataclass_to_tuple(initialRate),
+            dataclass_to_tuple(admin),
+            dataclass_to_tuple(isCompetitionMode),
+        )
 
     @classmethod
     def deploy(cls, w3: Web3, account: LocalAccount | ChecksumAddress, constructorArgs: ConstructorArgs) -> Self:


### PR DESCRIPTION
Use this instead of `deploy_contract`, which is now no longer used.  We can delete it or leave it since its still a utility that ethpy could provide.

I've also totally removed the dependency of `abi_dir` in eth_config throughout the repo... I think.  I'm not taking the final step of removing that either in this PR in case there is some use case I don't know about.