### PR TITLE
Changes for path independence check

### DIFF
--- a/lib/agent0/agent0/hyperdrive/interactive/chain.py
+++ b/lib/agent0/agent0/hyperdrive/interactive/chain.py
@@ -110,6 +110,14 @@ class Chain:
         if "result" not in response:
             raise KeyError("Response did not have a result.")
 
+    def _set_block_timestamp_interval(self, timestamp_interval: int) -> None:
+        response = self._web3.provider.make_request(
+            method=RPCEndpoint("anvil_setBlockTimestampInterval"), params=[timestamp_interval]
+        )
+        # ensure response is valid
+        if "result" not in response:
+            raise KeyError("Response did not have a result.")
+
     # pylint: disable=too-many-branches
     def advance_time(
         self, time_delta: int | timedelta, create_checkpoints: bool = True
@@ -434,7 +442,7 @@ class LocalChain(Chain):
         """
 
         block_time: int | None = None
-        block_timestamp_interval: int | None = None
+        block_timestamp_interval: int | None = 12
         chain_port: int = 10_000
         transaction_block_keeper: int = 10_000
 
@@ -475,8 +483,7 @@ class LocalChain(Chain):
         super().__init__(f"http://127.0.0.1:{str(config.chain_port)}", config)
 
         if config.block_timestamp_interval is not None:
-            # TODO make RPC call for setting block timestamp
-            raise NotImplementedError("Block timestamp interval not implemented yet")
+            self._set_block_timestamp_interval(config.block_timestamp_interval)
 
         # TODO hack, wait for chain to init
         time.sleep(1)

--- a/lib/agent0/agent0/interactive_fuzz/fuzz_path_independence.py
+++ b/lib/agent0/agent0/interactive_fuzz/fuzz_path_independence.py
@@ -85,7 +85,9 @@ def fuzz_path_independence(
         Defaults to False.
     """
     log_filename = ".logging/fuzz_path_independence.log"
-    chain, random_seed, rng, interactive_hyperdrive = setup_fuzz(log_filename, chain_config, log_to_stdout, fees=False)
+    chain, random_seed, rng, interactive_hyperdrive = setup_fuzz(
+        log_filename, chain_config, log_to_stdout, fees=False, var_interest=FixedPoint(0)
+    )
 
     # Generate a list of agents that execute random trades
     trade_list = generate_trade_list(num_trades, rng, interactive_hyperdrive)

--- a/lib/agent0/agent0/interactive_fuzz/fuzz_path_independence.py
+++ b/lib/agent0/agent0/interactive_fuzz/fuzz_path_independence.py
@@ -84,6 +84,7 @@ def fuzz_path_independence(
         If True, log to stdout in addition to a file.
         Defaults to False.
     """
+    # pylint: disable=too-many-statements
     log_filename = ".logging/fuzz_path_independence.log"
     chain, random_seed, rng, interactive_hyperdrive = setup_fuzz(
         log_filename, chain_config, log_to_stdout, fees=False, var_interest=FixedPoint(0)

--- a/lib/agent0/agent0/interactive_fuzz/helpers/setup_fuzz.py
+++ b/lib/agent0/agent0/interactive_fuzz/helpers/setup_fuzz.py
@@ -14,6 +14,7 @@ def setup_fuzz(
     chain_config: LocalChain.Config | None = None,
     log_to_stdout: bool = False,
     fees=True,
+    var_interest=None,
 ) -> tuple[LocalChain, int, Generator, InteractiveHyperdrive]:
     """Setup the fuzz experiment.
 
@@ -29,6 +30,9 @@ def setup_fuzz(
         Defaults to False.
     fees: bool, optional
         If False, will turn off fees when deploying hyperdrive. Defaults to True.
+    var_interest: FixedPoint | None, optional
+        The variable interest rate. Defaults to using the default variable interest rate
+        defined in interactive hyperdrive.
 
     Returns
     -------
@@ -67,6 +71,9 @@ def setup_fuzz(
         initial_pool_config.max_curve_fee = FixedPoint(0)
         initial_pool_config.max_flat_fee = FixedPoint(0)
         initial_pool_config.max_governance_lp_fee = FixedPoint(0)
+
+    if var_interest is not None:
+        initial_pool_config.initial_variable_rate = var_interest
 
     interactive_hyperdrive = InteractiveHyperdrive(chain, initial_pool_config)
 

--- a/lib/ethpy/ethpy/hyperdrive/interface/read_interface.py
+++ b/lib/ethpy/ethpy/hyperdrive/interface/read_interface.py
@@ -651,7 +651,7 @@ class HyperdriveReadInterface:
             which represents the time of the last checkpoint.
         """
         if checkpoint_duration is None:
-            checkpoint_duration = self.current_pool_state.pool_config.checkpoint_duration
+            checkpoint_duration = self.pool_config.checkpoint_duration
         if block_timestamp is None:
             block_timestamp = self.current_pool_state.block_time
         return _calc_checkpoint_id(checkpoint_duration, block_timestamp)


### PR DESCRIPTION
1. Adding assertions that closing trades in path independence happen on the same checkpoint
2. Adding block timestamp interval to interactive hyperdrive that forces the time between mined blocks (previously using system time). Setting this to be the default, with 12 seconds per mined block.
3. Adding option to set variable interest in `setup_fuzz`, and setting it to 0 for path independence test.