### PR TITLE
Fuzz logging fixes

### DIFF
--- a/lib/agent0/agent0/hyperdrive/crash_report/crash_report.py
+++ b/lib/agent0/agent0/hyperdrive/crash_report/crash_report.py
@@ -188,6 +188,7 @@ def log_hyperdrive_crash_report(
     log_to_rollbar: bool = False,
     rollbar_log_prefix: str | None = None,
     rollbar_data: dict | None = None,
+    additional_info: dict | None = None,
 ) -> None:
     # pylint: disable=too-many-arguments
     """Log a crash report for a hyperdrive transaction.
@@ -213,12 +214,23 @@ def log_hyperdrive_crash_report(
     rollbar_data: dict | None, optional
         Optional dictionary of data to use for the the rollbar report.
         If not provided, will default to logging all of the crash report to rollbar.
+    additional_info: dict | None, optional
+        Optional dictionary of additional data to include in the crash report.
     """
     if log_level is None:
         log_level = logging.CRITICAL
 
     # If we're crash reporting, an exception is expected
     assert trade_result.exception is not None
+
+    # Add custom additional info to trade_results
+    if additional_info is None:
+        additional_info = {}
+
+    if trade_result.additional_info is None:
+        trade_result.additional_info = additional_info
+    else:
+        trade_result.additional_info.update(additional_info)
 
     curr_time = datetime.utcnow().replace(tzinfo=timezone.utc)
     fn_time_str = curr_time.strftime("%Y_%m_%d_%H_%M_%S_Z")

--- a/lib/agent0/agent0/hyperdrive/crash_report/crash_report.py
+++ b/lib/agent0/agent0/hyperdrive/crash_report/crash_report.py
@@ -302,10 +302,10 @@ def log_hyperdrive_crash_report(
             # Don't log anvil dump state to rollbar
             dump_obj["anvil_dump_state"] = None  # type: ignore
             rollbar_data = dump_obj
-        else:
-            # If we're supplying the subset of data, we want to link to the original crash report
-            if crash_report_file is not None:
-                rollbar_data["crash_report_file"] = os.path.abspath(crash_report_file)
+
+        # Link to original crash report file in rollbar
+        if crash_report_file is not None:
+            rollbar_data["crash_report_file"] = os.path.abspath(crash_report_file)
 
         # Format data
         rollbar_data = json.loads(json.dumps(rollbar_data, indent=2, cls=ExtendedJSONEncoder))

--- a/lib/agent0/agent0/hyperdrive/interactive/interactive_hyperdrive.py
+++ b/lib/agent0/agent0/hyperdrive/interactive/interactive_hyperdrive.py
@@ -8,7 +8,7 @@ import time
 from dataclasses import asdict, dataclass
 from decimal import Decimal
 from threading import Thread
-from typing import Literal, Type, overload
+from typing import Any, Literal, Type, overload
 
 import nest_asyncio
 import numpy as np
@@ -153,6 +153,7 @@ class InteractiveHyperdrive:
         rollbar_log_prefix: str | None = None
         crash_log_level: int = logging.CRITICAL
         crash_log_ticker: bool = False
+        crash_report_additional_info: dict[str, Any] | None = None
         # Random generators
         rng_seed: int | None = None
         rng: Generator | None = None
@@ -271,6 +272,7 @@ class InteractiveHyperdrive:
         self.rollbar_log_prefix = config.rollbar_log_prefix
         self.crash_log_level = config.crash_log_level
         self.crash_log_ticker = config.crash_log_ticker
+        self.crash_report_additional_info = config.crash_report_additional_info
 
     def _launch_data_pipeline(self, start_block: int | None = None):
         """Launches the data pipeline in background threads.
@@ -977,6 +979,7 @@ class InteractiveHyperdrive:
                 crash_report_file_prefix="interactive_hyperdrive",
                 log_to_rollbar=self.log_to_rollbar,
                 rollbar_log_prefix=self.rollbar_log_prefix,
+                additional_info=self.crash_report_additional_info,
             )
             raise trade_result.exception
 

--- a/lib/agent0/agent0/interactive_fuzz/fuzz_long_short_maturity_values.py
+++ b/lib/agent0/agent0/interactive_fuzz/fuzz_long_short_maturity_values.py
@@ -71,7 +71,10 @@ def fuzz_long_short_maturity_values(
     # TODO: set block time really high after contracts deployed:
     # chain_config = LocalChain.Config(block_time=1_000_000)
     chain, random_seed, rng, interactive_hyperdrive = setup_fuzz(
-        log_filename, chain_config, log_to_stdout, rollbar_log_prefix="fuzz_long_short_maturity_values"
+        log_filename,
+        chain_config,
+        log_to_stdout,
+        fuzz_test_name="fuzz_long_short_maturity_values",
     )
     signer = interactive_hyperdrive.init_agent(eth=FixedPoint(100))
 

--- a/lib/agent0/agent0/interactive_fuzz/fuzz_path_independence.py
+++ b/lib/agent0/agent0/interactive_fuzz/fuzz_path_independence.py
@@ -99,7 +99,7 @@ def fuzz_path_independence(
         # hyperdrive crashes as info instead of critical.
         crash_log_level=logging.INFO,
         fees=False,
-        rollbar_log_prefix="fuzz_path_independence",
+        fuzz_test_name="fuzz_path_independence",
     )
 
     # Open some trades

--- a/lib/agent0/agent0/interactive_fuzz/fuzz_present_value.py
+++ b/lib/agent0/agent0/interactive_fuzz/fuzz_present_value.py
@@ -70,7 +70,7 @@ def fuzz_present_value(
         chain_config,
         log_to_stdout,
         fees=False,
-        rollbar_log_prefix="fuzz_present_value",
+        fuzz_test_name="fuzz_present_value",
     )
 
     initial_pool_state = interactive_hyperdrive.hyperdrive_interface.current_pool_state

--- a/lib/agent0/agent0/interactive_fuzz/fuzz_profit_check.py
+++ b/lib/agent0/agent0/interactive_fuzz/fuzz_profit_check.py
@@ -62,7 +62,7 @@ def fuzz_profit_check(chain_config: LocalChain.Config | None = None, log_to_stdo
     # Setup the environment
     log_filename = ".logging/fuzz_profit_check.log"
     chain, random_seed, rng, interactive_hyperdrive = setup_fuzz(
-        log_filename, chain_config, log_to_stdout, rollbar_log_prefix="fuzz_profit_check"
+        log_filename, chain_config, log_to_stdout, fuzz_test_name="fuzz_profit_check"
     )
 
     # Get a random trade amount

--- a/lib/agent0/agent0/interactive_fuzz/helpers/setup_fuzz.py
+++ b/lib/agent0/agent0/interactive_fuzz/helpers/setup_fuzz.py
@@ -17,7 +17,7 @@ def setup_fuzz(
     log_to_stdout: bool = False,
     log_to_rollbar: bool = True,
     crash_log_level: int | None = None,
-    rollbar_log_prefix: str | None = None,
+    fuzz_test_name: str | None = None,
     fees=True,
     var_interest=None,
 ) -> tuple[LocalChain, int, Generator, InteractiveHyperdrive]:
@@ -37,7 +37,7 @@ def setup_fuzz(
         If True, log errors rollbar. Defaults to True.
     crash_log_level: int | None, optional
         The log level to log crashes at. Defaults to critical.
-    rollbar_log_prefix: str | None, optional
+    fuzz_test_name: str | None, optional
         The prefix to prepend to rollbar exception messages
     fees: bool, optional
         If False, will turn off fees when deploying hyperdrive. Defaults to True.
@@ -78,13 +78,20 @@ def setup_fuzz(
     if crash_log_level is None:
         crash_log_level = logging.CRITICAL
 
+    crash_report_additional_info = {
+        "fuzz_random_seed": random_seed,
+        "fuzz_test_name": fuzz_test_name,
+    }
+
     initial_pool_config = InteractiveHyperdrive.Config(
         preview_before_trade=True,
         checkpoint_duration=86400,
         log_to_rollbar=log_to_rollbar,
-        rollbar_log_prefix=rollbar_log_prefix,
+        rollbar_log_prefix=fuzz_test_name,
         crash_log_level=crash_log_level,
         crash_log_ticker=True,
+        # Put this
+        crash_report_additional_info=crash_report_additional_info,
     )
     if not fees:
         initial_pool_config.curve_fee = FixedPoint(0)

--- a/lib/agent0/bin/fuzz_bot_invariant_checks.py
+++ b/lib/agent0/bin/fuzz_bot_invariant_checks.py
@@ -65,11 +65,14 @@ def main(argv: Sequence[str] | None = None) -> None:
         except FuzzAssertionException as error:
             report = build_crash_trade_result(error, interface, additional_info=error.exception_data)
             report.anvil_state = get_anvil_state_dump(interface.web3)
+            rollbar_data = error.exception_data
+
             log_hyperdrive_crash_report(
                 report,
                 crash_report_to_file=True,
                 crash_report_file_prefix="fuzz_bots_invariant_checks",
                 log_to_rollbar=log_to_rollbar,
+                rollbar_data=rollbar_data,
             )
 
 


### PR DESCRIPTION
- Allowing interactive hyperdrive to add crash report additional info
- Interactive fuzz testing adds fuzz random seed and test name when setting up interactive fuzz, so this info shows up in the crash report if a trade crashes
- Always link to the full crash report file in rollbar
- Setting explicit rollbar data in continuous invariance checks