### PR TITLE
Hotfixes for hyperdrive v0.5.1

### DIFF
--- a/lib/agent0/bin/checkpoint_bot.py
+++ b/lib/agent0/bin/checkpoint_bot.py
@@ -118,7 +118,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     # Get the Hyperdrive contract.
     # TODO replace this with the hyperdrive interface
     addresses = fetch_hyperdrive_address_from_uri(os.path.join(eth_config.artifacts_uri, "addresses.json"))
-    hyperdrive_contract_address = web3.to_checksum_address(addresses.mock_hyperdrive)
+    hyperdrive_contract_address = web3.to_checksum_address(addresses.erc4626_hyperdrive)
     hyperdrive_contract: IERC4626HyperdriveContract = IERC4626HyperdriveContract.factory(w3=web3)(
         hyperdrive_contract_address
     )

--- a/lib/chainsync/bin/run_acquire_data.py
+++ b/lib/chainsync/bin/run_acquire_data.py
@@ -6,4 +6,9 @@ from hyperlogs import setup_logging
 
 if __name__ == "__main__":
     setup_logging(".logging/acquire_data.log", log_stdout=True)
-    acquire_data()
+    acquire_data(
+        # This is the start block needed based on the devnet image, which corresponds
+        # to the block that the contract was deployed.
+        # TODO ideally would gather this from the deployer
+        start_block=30,
+    )

--- a/lib/chainsync/bin/run_data_analysis.py
+++ b/lib/chainsync/bin/run_data_analysis.py
@@ -6,4 +6,9 @@ from hyperlogs import setup_logging
 
 if __name__ == "__main__":
     setup_logging(".logging/data_analysis.log", log_stdout=True)
-    data_analysis()
+    data_analysis(
+        # This is the start block needed based on the devnet image, which corresponds
+        # to the block that the contract was deployed.
+        # TODO ideally would gather this from the deployer
+        start_block=30,
+    )

--- a/lib/chainsync/chainsync/db/hyperdrive/convert_data.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/convert_data.py
@@ -131,7 +131,7 @@ def convert_pool_config(pool_config_dict: dict[str, Any]) -> PoolConfig:
                 value = Decimal(str(value))
             # Pool config contains many addresses, the DB only needs the mock hyperdrive address
             if isinstance(value, HyperdriveAddresses):
-                value = value.mock_hyperdrive
+                value = value.erc4626_hyperdrive
         args_dict[camel_to_snake(key)] = value
     pool_config = PoolConfig(**args_dict)
     return pool_config

--- a/lib/ethpy/ethpy/hyperdrive/addresses.py
+++ b/lib/ethpy/ethpy/hyperdrive/addresses.py
@@ -7,7 +7,6 @@ import time
 import attr
 import requests
 from eth_typing import Address, ChecksumAddress
-
 from hypertypes.utilities.conversions import camel_to_snake
 
 
@@ -18,8 +17,9 @@ class HyperdriveAddresses:
     # pylint: disable=too-few-public-methods
 
     base_token: Address | ChecksumAddress = attr.ib()
+    erc4626_hyperdrive: Address | ChecksumAddress = attr.ib()
     hyperdrive_factory: Address | ChecksumAddress = attr.ib()
-    mock_hyperdrive: Address | ChecksumAddress = attr.ib()
+    steth_hyperdrive: Address | ChecksumAddress = attr.ib()
     mock_hyperdrive_math: Address | ChecksumAddress | None = attr.ib()
 
 

--- a/lib/ethpy/ethpy/hyperdrive/deploy.py
+++ b/lib/ethpy/ethpy/hyperdrive/deploy.py
@@ -152,8 +152,10 @@ def deploy_hyperdrive_from_factory(
         hyperdrive_contract_addresses=HyperdriveAddresses(
             base_token=Web3.to_checksum_address(base_token_contract.address),
             hyperdrive_factory=Web3.to_checksum_address(factory_contract.address),
-            mock_hyperdrive=hyperdrive_checksum_address,
+            erc4626_hyperdrive=hyperdrive_checksum_address,
             mock_hyperdrive_math=None,
+            # We don't deploy a steth hyperdrive here, so we don't set this address
+            steth_hyperdrive=Web3.to_checksum_address(ADDRESS_ZERO),
         ),
         hyperdrive_contract=IERC4626HyperdriveContract.factory(web3)(hyperdrive_checksum_address),
         hyperdrive_factory_contract=factory_contract,

--- a/lib/ethpy/ethpy/hyperdrive/interface/read_interface.py
+++ b/lib/ethpy/ethpy/hyperdrive/interface/read_interface.py
@@ -119,7 +119,7 @@ class HyperdriveReadInterface:
         )
         # Setup Hyperdrive, Yield (variable rate), and Hyperdrive Factory contracts.
         self.hyperdrive_contract: IERC4626HyperdriveContract = IERC4626HyperdriveContract.factory(w3=self.web3)(
-            web3.to_checksum_address(self.addresses.mock_hyperdrive)
+            web3.to_checksum_address(self.addresses.erc4626_hyperdrive)
         )
         self.yield_address = self.hyperdrive_contract.functions.pool().call()
         self.yield_contract: MockERC4626Contract = MockERC4626Contract.factory(w3=self.web3)(

--- a/tests/bot_to_db_test.py
+++ b/tests/bot_to_db_test.py
@@ -200,7 +200,7 @@ class TestBotToDb:
         # Ignore linker factory since we don't know the target address
         db_pool_config_df = db_pool_config_df.drop(columns=["linker_factory"])
         expected_pool_config = {
-            "contract_address": hyperdrive_contract_addresses.mock_hyperdrive,
+            "contract_address": hyperdrive_contract_addresses.erc4626_hyperdrive,
             "base_token": hyperdrive_contract_addresses.base_token,
             "initial_share_price": _to_unscaled_decimal(FixedPoint("1")),
             "minimum_share_reserves": _to_unscaled_decimal(FixedPoint("10")),


### PR DESCRIPTION
- Updating schema from addresses.json
- Adding explicit start block on data pipeline due to anvil update keeping block number with save/load state
- Adding in check when attempting to query non-existent previous block in continuous fuzz invariance checks