### PR TITLE
Hotfixes for fuzz bots

### DIFF
--- a/lib/agent0/agent0/accounts_config.py
+++ b/lib/agent0/agent0/accounts_config.py
@@ -89,25 +89,31 @@ def initialize_accounts(
     if env_file is None:
         env_file = "account.env"
 
-    if not os.path.exists(env_file):
+    # If we're in develop mode, we don't use the env file at all
+    if develop:
+        account_key_config = build_account_key_config_from_agent_config(agent_config, random_seed)
+    # If we're not in develop mode and the env file doesn't exist
+    # we create the env file keeping track of keys and budgets
+    elif not os.path.exists(env_file):
         logging.info("Creating %s", env_file)
         # Create AccountKeyConfig from agent config
         account_key_config = build_account_key_config_from_agent_config(agent_config, random_seed)
         # Create file
         with open(env_file, "w", encoding="UTF-8") as file:
             file.write(account_key_config.to_env_str())
-        if not develop:
-            print(
-                f"Account key config written {env_file}. "
-                "Run the following command to fund the accounts, then rerun this script."
-            )
-            # Different commands depending on if default env file is used
-            command_str = "python lib/agent0/bin/fund_agents_from_user_key.py -u <user_private_key>"
-            if env_file != "account.env":
-                command_str += f" -f {env_file}"
-            print(command_str)
-            # Clean exit
-            sys.exit(0)
+        print(
+            f"Account key config written {env_file}. "
+            "Run the following command to fund the accounts, then rerun this script."
+        )
+        # Different commands depending on if default env file is used
+        command_str = "python lib/agent0/bin/fund_agents_from_user_key.py -u <user_private_key>"
+        if env_file != "account.env":
+            command_str += f" -f {env_file}"
+        print(command_str)
+        # Clean exit
+        sys.exit(0)
+    # If we're not in develop mode and the env file does exist
+    # we load the env file key
     else:
         logging.info("Loading %s", env_file)
         # Ensure account_config matches up with env_file

--- a/lib/agent0/agent0/hyperdrive/exec/run_agents.py
+++ b/lib/agent0/agent0/hyperdrive/exec/run_agents.py
@@ -269,6 +269,12 @@ def run_agents(
                 < minimum_avg_agent_base
             ):
                 _ = async_fund_agents_with_fake_user(eth_config, account_key_config, contract_addresses, interface)
+                # Update agent accounts with new wallet balances
+                for agent in agent_accounts:
+                    # Contract call to get base balance
+                    (_, base_amount) = interface.get_eth_base_balances(agent)
+                    base_obj = Quantity(amount=base_amount, unit=TokenType.BASE)
+                    agent.wallet.balance = base_obj
         if new_executed_block == last_executed_block:
             # wait
             time.sleep(poll_latency)


### PR DESCRIPTION
- Develop mode now ignores any existing account.env files and always explicitly uses accounts and budgets defined in runner scripts.
- Fixed a bug where agent wallet bookkeeping wasn't getting updated when we refund fuzz bots