### PR TITLE
Fuzz updates

### DIFF
--- a/lib/agent0/agent0/interactive_fuzz/fuzz_path_independence.py
+++ b/lib/agent0/agent0/interactive_fuzz/fuzz_path_independence.py
@@ -112,7 +112,10 @@ def fuzz_path_independence(
         # Trade crashes in this file have expected failures, hence we log interactive
         # hyperdrive crashes as info instead of critical.
         crash_log_level=logging.INFO,
-        fees=False,
+        curve_fee=FixedPoint(0),
+        flat_fee=FixedPoint(0),
+        governance_lp_fee=FixedPoint(0),
+        governance_zombie_fee=FixedPoint(0),
         fuzz_test_name="fuzz_path_independence",
     )
 

--- a/lib/agent0/agent0/interactive_fuzz/fuzz_present_value.py
+++ b/lib/agent0/agent0/interactive_fuzz/fuzz_present_value.py
@@ -71,7 +71,10 @@ def fuzz_present_value(
         log_filename,
         chain_config,
         log_to_stdout,
-        fees=False,
+        curve_fee=FixedPoint(0),
+        flat_fee=FixedPoint(0),
+        governance_lp_fee=FixedPoint(0),
+        governance_zombie_fee=FixedPoint(0),
         fuzz_test_name="fuzz_present_value",
     )
 

--- a/lib/agent0/agent0/interactive_fuzz/fuzz_profit_check.py
+++ b/lib/agent0/agent0/interactive_fuzz/fuzz_profit_check.py
@@ -66,6 +66,7 @@ def fuzz_profit_check(chain_config: LocalChain.Config | None = None, log_to_stdo
         If True, log to stdout in addition to a file.
         Defaults to False.
     """
+    # pylint: disable=too-many-statements
 
     # Setup the environment
     log_filename = ".logging/fuzz_profit_check.log"

--- a/lib/agent0/agent0/interactive_fuzz/fuzz_profit_check.py
+++ b/lib/agent0/agent0/interactive_fuzz/fuzz_profit_check.py
@@ -74,6 +74,11 @@ def fuzz_profit_check(chain_config: LocalChain.Config | None = None, log_to_stdo
         chain_config,
         log_to_stdout,
         fuzz_test_name="fuzz_profit_check",
+        flat_fee=FixedPoint(0),
+        curve_fee=FixedPoint(0.001),  # 0.1%
+        governance_lp_fee=FixedPoint(0),
+        governance_zombie_fee=FixedPoint(0),
+        var_interest=FixedPoint(0.0),
     )
 
     # Get a random trade amount

--- a/lib/agent0/agent0/interactive_fuzz/helpers/__init__.py
+++ b/lib/agent0/agent0/interactive_fuzz/helpers/__init__.py
@@ -1,5 +1,6 @@
 """Shared functions for interactive fuzz testing."""
 
+from .advance_time import advance_time_after_checkpoint, advance_time_before_checkpoint
 from .close_random_trades import close_trades, permute_trade_events
 from .execute_random_trades import execute_random_trades
 from .fuzz_assertion_exception import FuzzAssertionException, fp_isclose

--- a/lib/agent0/agent0/interactive_fuzz/helpers/__init__.py
+++ b/lib/agent0/agent0/interactive_fuzz/helpers/__init__.py
@@ -1,6 +1,6 @@
 """Shared functions for interactive fuzz testing."""
 
-from .close_random_trades import close_random_trades
+from .close_random_trades import close_trades, permute_trade_events
 from .execute_random_trades import execute_random_trades
 from .fuzz_assertion_exception import FuzzAssertionException, fp_isclose
 from .setup_fuzz import setup_fuzz

--- a/lib/agent0/agent0/interactive_fuzz/helpers/advance_time.py
+++ b/lib/agent0/agent0/interactive_fuzz/helpers/advance_time.py
@@ -1,0 +1,66 @@
+from numpy.random._generator import Generator
+
+from agent0.hyperdrive.interactive import InteractiveHyperdrive, LocalChain
+
+
+def advance_time_before_checkpoint(
+    chain: LocalChain, rng: Generator, interactive_hyperdrive: InteractiveHyperdrive
+) -> None:
+    """Advance time on the chain a random amount that is less than the next checkpoint time.
+
+    Arguments
+    ---------
+    chain: LocalChain
+        An instantiated LocalChain.
+    rng: `Generator <https://numpy.org/doc/stable/reference/random/generator.html>`_
+        The numpy Generator provides access to a wide range of distributions, and stores the random state.
+    interactive_hyperdrive: InteractiveHyperdrive
+        An instantiated InteractiveHyperdrive object.
+    """
+
+    current_block_time = interactive_hyperdrive.hyperdrive_interface.get_block_timestamp(
+        interactive_hyperdrive.hyperdrive_interface.get_current_block()
+    )
+    time_since_last_checkpoint = (
+        current_block_time % interactive_hyperdrive.hyperdrive_interface.pool_config.checkpoint_duration
+    )
+    time_to_next_checkpoint = (
+        interactive_hyperdrive.hyperdrive_interface.pool_config.checkpoint_duration - time_since_last_checkpoint
+    )
+    advance_upper_bound = time_to_next_checkpoint - 100  # minus 100 seconds to avoid edge cases
+
+    # If we're already within the boundary of the next checkpoint, we throw an error
+    if advance_upper_bound < 0:
+        raise AssertionError("Advance time before checkpoint already too close to checkpoint boundary")
+
+    checkpoint_info = chain.advance_time(
+        rng.integers(low=0, high=advance_upper_bound),
+        create_checkpoints=True,  # we don't want to create one, but only because we haven't advanced enough
+    )
+    # Do a final check to make sure that the checkpoint didn't happen
+    assert len(checkpoint_info[interactive_hyperdrive]) == 0, "Checkpoint was created when it should not have been."
+
+
+def advance_time_after_checkpoint(chain: LocalChain, interactive_hyperdrive: InteractiveHyperdrive) -> None:
+    """Advance time on the chain to the next checkpoint boundary plus some buffer.
+
+    Arguments
+    ---------
+    chain: LocalChain
+        An instantiated LocalChain.
+    interactive_hyperdrive: InteractiveHyperdrive
+        An instantiated InteractiveHyperdrive object.
+    """
+    # Advance enough time to make sure we're not going to cross a boundary during our trades
+    current_block_time = interactive_hyperdrive.hyperdrive_interface.get_block_timestamp(
+        interactive_hyperdrive.hyperdrive_interface.get_current_block()
+    )
+    time_since_last_checkpoint = (
+        current_block_time % interactive_hyperdrive.hyperdrive_interface.pool_config.checkpoint_duration
+    )
+    time_to_next_checkpoint = (
+        interactive_hyperdrive.hyperdrive_interface.pool_config.checkpoint_duration - time_since_last_checkpoint
+    )
+
+    # Add a small amount to ensure we're not at the edge of a checkpoint
+    chain.advance_time(time_to_next_checkpoint + 100, create_checkpoints=True)

--- a/lib/agent0/agent0/interactive_fuzz/helpers/advance_time.py
+++ b/lib/agent0/agent0/interactive_fuzz/helpers/advance_time.py
@@ -1,3 +1,4 @@
+"""Helpers for advancing time wrt checkpoint boundaries"""
 from numpy.random._generator import Generator
 
 from agent0.hyperdrive.interactive import InteractiveHyperdrive, LocalChain

--- a/lib/agent0/agent0/interactive_fuzz/helpers/close_random_trades.py
+++ b/lib/agent0/agent0/interactive_fuzz/helpers/close_random_trades.py
@@ -7,11 +7,11 @@ from agent0.hyperdrive.interactive.event_types import OpenLong, OpenShort
 from agent0.hyperdrive.interactive.interactive_hyperdrive_agent import InteractiveHyperdriveAgent
 
 
-def close_random_trades(
+def permute_trade_events(
     trade_events: list[tuple[InteractiveHyperdriveAgent, OpenLong | OpenShort]],
     rng: Generator,
-) -> None:
-    """Close trades provided in a random order.
+) -> list[tuple[InteractiveHyperdriveAgent, OpenLong | OpenShort]]:
+    """Given a list of trade events, returns the list in random order.
 
     Arguments
     ---------
@@ -21,9 +21,29 @@ def close_random_trades(
             - either the OpenLong or OpenShort trade event
     rng: `Generator <https://numpy.org/doc/stable/reference/random/generator.html>`_
         The numpy Generator provides access to a wide range of distributions, and stores the random state.
+
+    Returns
+    -------
+    list[tuple[InteractiveHyperdriveAgent, OpenLong | OpenShort]]
+        The trade event list in random order
     """
-    for trade_index in rng.permuted(list(range(len(trade_events)))):
-        agent, trade = trade_events[int(trade_index)]
+    trade_indices = rng.permuted(list(range(len(trade_events))))
+    return [trade_events[int(trade_index)] for trade_index in trade_indices]
+
+
+def close_trades(
+    trade_events: list[tuple[InteractiveHyperdriveAgent, OpenLong | OpenShort]],
+) -> None:
+    """Close trades provided.
+
+    Arguments
+    ---------
+    trade_events: list[tuple[InteractiveHyperdriveAgent, OpenLong | OpenShort]]
+        A list with an entry per trade, containing a tuple with:
+            - the agent executing the trade
+            - either the OpenLong or OpenShort trade event
+    """
+    for agent, trade in trade_events:
         if isinstance(trade, OpenLong):
             agent.close_long(maturity_time=trade.maturity_time, bonds=trade.bond_amount)
         if isinstance(trade, OpenShort):

--- a/lib/agent0/agent0/interactive_fuzz/helpers/setup_fuzz.py
+++ b/lib/agent0/agent0/interactive_fuzz/helpers/setup_fuzz.py
@@ -18,8 +18,11 @@ def setup_fuzz(
     log_to_rollbar: bool = True,
     crash_log_level: int | None = None,
     fuzz_test_name: str | None = None,
-    fees=True,
-    var_interest=None,
+    curve_fee: FixedPoint | None = None,
+    flat_fee: FixedPoint | None = None,
+    governance_lp_fee: FixedPoint | None = None,
+    governance_zombie_fee: FixedPoint | None = None,
+    var_interest: FixedPoint | None = None,
 ) -> tuple[LocalChain, int, Generator, InteractiveHyperdrive]:
     """Setup the fuzz experiment.
 
@@ -39,8 +42,14 @@ def setup_fuzz(
         The log level to log crashes at. Defaults to critical.
     fuzz_test_name: str | None, optional
         The prefix to prepend to rollbar exception messages
-    fees: bool, optional
-        If False, will turn off fees when deploying hyperdrive. Defaults to True.
+    curve_fee: FixedPoint | None, optional
+        The curve fee for the test. Defaults to using the default fee
+    flat_fee: FixedPoint | None, optional
+        The flat fee for the test. Defaults to using the default fee
+    governance_lp_fee: FixedPoint | None, optional
+        The governance lp fee for the test. Defaults to using the default fee
+    governance_zombie_fee: FixedPoint | None, optional
+        The governance zombie fee for the test. Defaults to using the default fee
     var_interest: FixedPoint | None, optional
         The variable interest rate. Defaults to using the default variable interest rate
         defined in interactive hyperdrive.
@@ -59,6 +68,7 @@ def setup_fuzz(
                 An instantiated InteractiveHyperdrive object.
     """
     # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-locals
     setup_logging(
         log_filename=log_filename,
         delete_previous_logs=False,
@@ -92,16 +102,18 @@ def setup_fuzz(
         rollbar_log_prefix=fuzz_test_name,
         crash_log_level=crash_log_level,
         crash_log_ticker=True,
-        # Put this
+        # Put this into crash report for all tests
         crash_report_additional_info=crash_report_additional_info,
     )
-    if not fees:
-        initial_pool_config.curve_fee = FixedPoint(0)
-        initial_pool_config.flat_fee = FixedPoint(0)
-        initial_pool_config.governance_lp_fee = FixedPoint(0)
-        initial_pool_config.max_curve_fee = FixedPoint(0)
-        initial_pool_config.max_flat_fee = FixedPoint(0)
-        initial_pool_config.max_governance_lp_fee = FixedPoint(0)
+
+    if curve_fee is not None:
+        initial_pool_config.curve_fee = curve_fee
+    if flat_fee is not None:
+        initial_pool_config.flat_fee = flat_fee
+    if governance_lp_fee is not None:
+        initial_pool_config.governance_lp_fee = governance_lp_fee
+    if governance_zombie_fee is not None:
+        initial_pool_config.governance_zombie_fee = governance_zombie_fee
 
     if var_interest is not None:
         initial_pool_config.initial_variable_rate = var_interest

--- a/lib/agent0/agent0/interactive_fuzz/run_all_fuzz_tests.py
+++ b/lib/agent0/agent0/interactive_fuzz/run_all_fuzz_tests.py
@@ -37,8 +37,11 @@ def main(argv: Sequence[str] | None = None):
         try:
             print("Running long short maturity test")
             chain_config = LocalChain.Config(db_port=5434, chain_port=10001)
-            maturity_vals_epsilon = 1e-14
-            fuzz_long_short_maturity_values(num_trades, maturity_vals_epsilon, chain_config)
+            long_maturity_vals_epsilon = 1e-14
+            short_maturity_vals_epsilon = 1e-9
+            fuzz_long_short_maturity_values(
+                num_trades, long_maturity_vals_epsilon, short_maturity_vals_epsilon, chain_config
+            )
         except FuzzAssertionException:
             pass
         # We catch other exceptions here, for some reason rollbar needs to be continuously running in order


### PR DESCRIPTION
- Path independence test now checks for duplicate paths, and logs all paths checked if < 2 successful paths
- Adding separate epsilon for short maturity fuzz, and setting the epsilon in fuzz tests
- Abstracting out (and fixing bug) in advancing time after a checkpoint
- Adding in assertions for ensuring profit check fuzz opens/closes within the same checkpoint
- Adding parameters for setting individual fees in interactive fuzz
- Setting curve fee to be 0.1% and no variable interest in profit check fuzz