### PR TITLE
LP bot that adds or removes liquidity depending on current PNL

### DIFF
--- a/src/agent0/core/hyperdrive/policies/simple_lp.py
+++ b/src/agent0/core/hyperdrive/policies/simple_lp.py
@@ -48,16 +48,20 @@ class SimpleLP(HyperdriveBasePolicy):
     class Config(HyperdriveBasePolicy.Config):
         """Custom config arguments for this policy."""
 
-        # The target PNL for the bot, in base.
         pnl_target: FixedPoint = FixedPoint("100")
-        # How much liquidity to add or remove, depending on policy outcome, in base.
+        """The target PNL for the bot, in base."""
         delta_liquidity: FixedPoint = FixedPoint("100")
-        # Minimum liquidity the bot will provide.
-        # It will keep this much liquidity in the pool, even if it is losing money.
+        """How much liquidity to add or remove, depending on policy outcome, in base."""
         minimum_liquidity_tokens: FixedPoint = FixedPoint("100")
-        # How many steps back to look when computing PNL progress over time.
-        # Each time `action` is called is a step.
+        """
+        Minimum liquidity the bot will provide.
+        It will keep this much liquidity in the pool, even if it is losing money.
+        """
         lookback_length: int = 10
+        """
+        How many steps back to look when computing PNL progress over time.
+        Each time `action` is called is a step.
+        """
 
     def __init__(
         self,

--- a/src/agent0/core/hyperdrive/policies/simple_lp.py
+++ b/src/agent0/core/hyperdrive/policies/simple_lp.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from fixedpointmath import FixedPoint, FixedPointMath
 
 from agent0.base import Trade
-from agent0.hyperdrive import HyperdriveMarketAction
+from agent0.hyperdrive import HyperdriveMarketAction, TradeResult
 from agent0.hyperdrive.agent import add_liquidity_trade, remove_liquidity_trade
 
 from .hyperdrive_policy import HyperdriveBasePolicy
@@ -48,13 +48,15 @@ class SimpleLP(HyperdriveBasePolicy):
             How many steps back to look when computing past PNL.
             Each time `action` is called is a step.
         pnl_target: FixedPoint
-            The target PNL for the bot to achieve, as a fraction improvement over the pnl at lookback_length
+            The target yearly PNL growth for the bot to achieve,
+            as a fraction improvement over the pnl from previous recordings.
         delta_liquidity: FixedPoint
             How much liquidity to add or remove, depending on policy outcome.
         """
 
-        lookback_length: FixedPoint = FixedPoint("10")  # action calls
-        pnl_target: FixedPoint = FixedPoint("1.0")
+        # pnl_target = 0.1 means the time-weighted average profit_change is 10% increase
+        pnl_target: FixedPoint = FixedPoint("0.1")
+        lookback_length: FixedPoint = FixedPoint("10")  # action calls (usually blocks)
         delta_liquidity: FixedPoint = FixedPoint("100")
 
     def __init__(
@@ -72,42 +74,48 @@ class SimpleLP(HyperdriveBasePolicy):
         assert policy_config.pnl_target > FixedPoint(0), "PNL target must be greater than zero."
         self.policy_config = policy_config
         self.pnl_history: list[tuple[FixedPoint, FixedPoint]] = []
+        self.total_base_spent: FixedPoint = 0
 
     def time_weighted_average_pnl(self) -> FixedPoint:
-        """Return the time-weighted average PNL improvement.
-
-        This function returns a time-weighted average normalized profit change:
-        1. calculate the profit change ratio between consecutive profits
-          profit_change = (p_new - p_old) / p_old
-        2. calculate the time weight, which is 1 / time_spanned
-          time_weight = 1 / (t_new - t_old)
-        3. scale the profit change by the time weight to give a normalized profit change:
-          norm_profit_change = profit_change * time_weight
-        4. compute a weighted sum of normalized profit changes
-          weighted_sum = sum_i(norm_profit_change_i) / sum_j(time_weight_j)
+        """Return the linear time-weighted average PNL improvement.
 
         This function assumes the self.pnl_history member attribute is a list of (time, pnl) pairs,
         where the zero index dereferences the earliest pair.
 
+        .. todo::
+        It would be good to have option to change twapnl to unweighted (all weights are equal), exponential, or linear.
         """
         if len(self.pnl_history) <= 1:  # not enough history
             return FixedPoint(0)
-        if self.pnl_history[0] == 0:  # if original pnl is zero then the improvement will be infinite
+        if self.pnl_history[0][1] == 0:  # if original pnl is zero then the improvement will be infinite
             self.pnl_history = self.pnl_history[1:]  # remove the first element
             return FixedPoint(0)  # need to ignore first pnl change to avoid inf %
 
         weighted_sum = FixedPoint(0)
         total_weight = FixedPoint(0)
-        for i in range(1, len(self.pnl_history)):
+        for i in range(len(self.pnl_history) - 1, 0, -1):
+            # fraction change in pnl, scaled to be annual
             profit_change = (self.pnl_history[i][1] - self.pnl_history[i - 1][1]) / self.pnl_history[i - 1][1]
-            weight = 1 / (self.pnl_history[i][0] - self.pnl_history[i - 1][0])
+
+            # scale weight by amount of time changed
+            delta_time = self.pnl_history[i][0] - self.pnl_history[i - 1][0]
+            total_time_spanned = self.pnl_history[-1][0] - self.pnl_history[0][0]
+
+            # biggest weight to most recent, normalized by time spanned
+            weight = (i + 1) * delta_time / total_time_spanned
+
+            # compute sums
+            # delta_time_in_years = (delta_time / FixedPoint(60 * 60 * 24 * 365))
+            # profit_change_per_year = profit_change * delta_time_in_years
+            # weighted_sum += profit_change_per_year * weight
             weighted_sum += profit_change * weight
             total_weight += weight
 
         if total_weight == FixedPoint(0):
             return FixedPoint(0)  # no valid data points to comptue the average
 
-        return weighted_sum / total_weight
+        ret_val = weighted_sum / total_weight
+        return ret_val
 
     def action(
         self, interface: HyperdriveReadInterface, wallet: HyperdriveWallet
@@ -130,23 +138,43 @@ class SimpleLP(HyperdriveBasePolicy):
         # update PNL
         current_block = interface.get_current_block()
         pool_state = interface.get_hyperdrive_state(current_block)
-        pnl = wallet.lp_tokens * pool_state.pool_info.lp_share_price
-        self.pnl_history.append((FixedPoint(interface.get_block_number(current_block)), pnl))
+        pnl = wallet.lp_tokens * pool_state.pool_info.lp_share_price - self.total_base_spent
+        self.pnl_history.append((FixedPoint(interface.get_block_timestamp(current_block)), pnl))
 
         # prune history
-        if len(self.pnl_history) > self.policy_config.lookback_length:
-            self.pnl_history = self.pnl_history[len(self.pnl_history) - self.policy_config.lookback_length :]
-
-        # compute time-weighted average
-        twapnl = self.time_weighted_average_pnl()
+        if FixedPoint(len(self.pnl_history)) > self.policy_config.lookback_length:
+            self.pnl_history = self.pnl_history[-self.policy_config.lookback_length :]
 
         # make trades based on pnl_target
+        twapnl = self.time_weighted_average_pnl()
         action_list = []
-        if twapnl < self.policy_config.pnl_target:
+        if wallet.lp_tokens == FixedPoint("0"):
+            action_list.append(add_liquidity_trade(self.policy_config.delta_liquidity))
+        elif twapnl > self.policy_config.pnl_target:
             if wallet.balance.amount >= self.policy_config.delta_liquidity:  # only add money if you can afford it!
                 action_list.append(add_liquidity_trade(self.policy_config.delta_liquidity))
-        elif twapnl > self.policy_config.pnl_target:
+        elif twapnl < self.policy_config.pnl_target:
             remove_amount = FixedPointMath.minimum(self.policy_config.delta_liquidity, wallet.lp_tokens)
             action_list.append(remove_liquidity_trade(remove_amount))
 
         return action_list, False
+
+    def post_action(self, interface: HyperdriveReadInterface, trade_results: list[TradeResult]) -> None:
+        """Function that gets called after actions have been executed. This allows the policy
+        to e.g., do additional bookkeeping based on the results of the executed actions.
+
+        Arguments
+        ---------
+        interface: MarketInterface
+            The trading market interface.
+        trade_results: list[HyperdriveTradeResult]
+            A list of HyperdriveTradeResult objects, one for each trade made by the agent.
+            The order of the list matches the original order of `agent.action`.
+            HyperdriveTradeResult contains any information about the trade,
+            as well as any errors that the trade resulted in.
+        """
+        if trade_results[-1].status.name == "SUCCESS":
+            if trade_results[-1].trade_object.market_action.action_type.name == "ADD_LIQUIDITY":
+                self.total_base_spent += trade_results[-1].tx_receipt.base_amount
+            elif trade_results[-1].trade_object.market_action.action_type.name == "REMOVE_LIQUIDITY":
+                self.total_base_spent -= trade_results[-1].tx_receipt.base_amount

--- a/src/agent0/core/hyperdrive/policies/simple_lp.py
+++ b/src/agent0/core/hyperdrive/policies/simple_lp.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from fixedpointmath import FixedPoint, FixedPointMath
+from fixedpointmath import FixedPoint, minimum
 
 from agent0.core.base import Trade
 from agent0.core.hyperdrive import HyperdriveMarketAction, TradeResult
@@ -43,20 +43,18 @@ class SimpleLP(HyperdriveBasePolicy):
 
         Attributes
         ----------
-        lookback_length: int
-            How many steps back to look when computing past PNL.
-            Each time `action` is called is a step.
         pnl_target: FixedPoint
-            The target yearly PNL growth for the bot to achieve,
-            as a fraction improvement over the pnl from previous recordings.
+            The target PNL for the bot, in base.
         delta_liquidity: FixedPoint
-            How much liquidity to add or remove, depending on policy outcome.
+            How much liquidity to add or remove, depending on policy outcome, in base.
+        minimum_liquidity: FixedPoint
+            Minimum liquidity the bot will provide.
+            It will keep this much liquidity in the pool, even if it is losing money.
         """
 
-        # pnl_target = 0.1 means the time-weighted average profit_change is 10% increase
-        pnl_target: FixedPoint = FixedPoint("0.1")
-        lookback_length: FixedPoint = FixedPoint("10")  # action calls (usually blocks)
+        pnl_target: FixedPoint = FixedPoint("100")
         delta_liquidity: FixedPoint = FixedPoint("100")
+        minimum_liquidity_tokens: FixedPoint = FixedPoint("100")
 
     def __init__(
         self,
@@ -72,46 +70,7 @@ class SimpleLP(HyperdriveBasePolicy):
         super().__init__(policy_config)
         assert policy_config.pnl_target > FixedPoint(0), "PNL target must be greater than zero."
         self.policy_config = policy_config
-        self.pnl_history: list[tuple[FixedPoint, FixedPoint]] = []
         self.total_base_spent: FixedPoint = 0
-
-    def time_weighted_average_pnl(self) -> FixedPoint:
-        """Return the linear time-weighted average PNL improvement.
-
-        This function assumes the self.pnl_history member attribute is a list of (time, pnl) pairs,
-        where the zero index dereferences the earliest pair.
-
-        .. todo::
-        It would be good to have option to change twapnl to unweighted (all weights are equal), exponential, or linear.
-        """
-        if len(self.pnl_history) <= 1:  # not enough history
-            return FixedPoint(0)
-        if self.pnl_history[0][1] == 0:  # if original pnl is zero then the improvement will be infinite
-            self.pnl_history = self.pnl_history[1:]  # remove the first element
-            return FixedPoint(0)  # need to ignore first pnl change to avoid inf %
-
-        weighted_sum = FixedPoint(0)
-        total_weight = FixedPoint(0)
-        for i in range(len(self.pnl_history) - 1, 0, -1):
-            # fraction change in pnl, scaled to be annual
-            profit_change = (self.pnl_history[i][1] - self.pnl_history[i - 1][1]) / self.pnl_history[i - 1][1]
-
-            # scale weight by amount of time changed
-            delta_time = self.pnl_history[i][0] - self.pnl_history[i - 1][0]
-            total_time_spanned = self.pnl_history[-1][0] - self.pnl_history[0][0]
-
-            # biggest weight to most recent, normalized by time spanned
-            weight = (i + 1) * delta_time / total_time_spanned
-
-            # compute sums
-            weighted_sum += profit_change * weight
-            total_weight += weight
-
-        if total_weight == FixedPoint(0):
-            return FixedPoint(0)  # no valid data points to comptue the average
-
-        ret_val = weighted_sum / total_weight
-        return ret_val
 
     def action(
         self, interface: HyperdriveReadInterface, wallet: HyperdriveWallet
@@ -131,36 +90,32 @@ class SimpleLP(HyperdriveBasePolicy):
             A tuple where the first element is a list of actions,
             and the second element defines if the agent is done trading.
         """
-        # update PNL
+        # get the current state of the pool
         current_block = interface.get_current_block()
         pool_state = interface.get_hyperdrive_state(current_block)
-        pnl = wallet.lp_tokens * pool_state.pool_info.lp_share_price - self.total_base_spent
-        self.pnl_history.append((FixedPoint(interface.get_block_timestamp(current_block)), pnl))
-
-        # prune history
-        if FixedPoint(len(self.pnl_history)) > self.policy_config.lookback_length:
-            self.pnl_history = self.pnl_history[-self.policy_config.lookback_length :]
-
-        # make trades based on pnl_target
-        twapnl = self.time_weighted_average_pnl()
-        action_list = []
 
         # need to be in the game to play it
-        if wallet.lp_tokens == FixedPoint("0"):
-            action_list.append(add_liquidity_trade(self.policy_config.delta_liquidity))
+        if wallet.lp_tokens <= self.policy_config.minimum_liquidity_tokens:
+            trade_amount = (
+                wallet.lp_tokens * pool_state.pool_info.lp_share_price - self.policy_config.minimum_liquidity_tokens
+            )
+            return [add_liquidity_trade(trade_amount)], False
 
-        # i'm doing great, keep putting money in
-        elif twapnl > self.policy_config.pnl_target:
+        # get current PNL
+        pnl = wallet.lp_tokens * pool_state.pool_info.lp_share_price - self.total_base_spent
+
+        # make trades based on pnl_target
+        action_list = []
+        # I'm doing great, keep putting money in
+        if pnl > self.policy_config.pnl_target + self.policy_config.delta_liquidity:
             # only add money if you can afford it!
             if wallet.balance.amount >= self.policy_config.delta_liquidity:
                 action_list.append(add_liquidity_trade(self.policy_config.delta_liquidity))
-
-        # i'm doing bad
-        elif twapnl < self.policy_config.pnl_target:
-            # do bad long enough to get a good measurement
-            if len(self.pnl_history) == self.policy_config.lookback_length:
-                remove_amount = FixedPointMath.minimum(self.policy_config.delta_liquidity, wallet.lp_tokens)
-                action_list.append(remove_liquidity_trade(remove_amount))
+        # I'm doing bad, time to pull some money out
+        elif pnl < self.policy_config.pnl_target - self.policy_config.delta_liquidity:
+            remove_amount = minimum(self.policy_config.delta_liquidity, wallet.lp_tokens)
+            action_list.append(remove_liquidity_trade(remove_amount))
+        # else my PNL is within tolerance of the target, so do nothing
 
         return action_list, False
 

--- a/src/agent0/core/hyperdrive/policies/simple_lp.py
+++ b/src/agent0/core/hyperdrive/policies/simple_lp.py
@@ -1,0 +1,127 @@
+"""Agent policy for LP trading that modifies liquidity for a target profitability."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from fixedpointmath import FixedPoint
+
+from agent0.base import Trade
+from agent0.hyperdrive import HyperdriveMarketAction
+from agent0.hyperdrive.agent import add_liquidity_trade, remove_liquidity_trade
+
+from .hyperdrive_policy import HyperdriveBasePolicy
+
+if TYPE_CHECKING:
+    from ethpy.hyperdrive import HyperdriveReadInterface
+
+    from agent0.hyperdrive import HyperdriveWallet
+
+# pylint: disable=too-many-arguments, too-many-locals
+
+# constants
+TOLERANCE = 1e-18
+MAX_ITER = 50
+
+
+class SimpleLP(HyperdriveBasePolicy):
+    """LP to maintain profitability."""
+
+    @classmethod
+    def description(cls) -> str:
+        """Describe the policy in a user friendly manner that allows newcomers to decide whether to use it.
+
+        Returns
+        -------
+        str
+            The description of the policy, as described above.
+        """
+        raw_description = """
+        This LP bot adds and removes liquidity to maximize profitability.
+        The bot stores its PNL for each previous block.
+        It adds liquidity if the PNL is above some threshold, removes if below, and otherwise takes no action.
+        """
+        return super().describe(raw_description)
+
+    @dataclass(kw_only=True)
+    class Config(HyperdriveBasePolicy.Config):
+        """Custom config arguments for this policy.
+
+        Attributes
+        ----------
+        pnl_target: FixedPoint
+            The target PNL for the bot to achieve.
+        delta_liquidity: FixedPoint
+            How much liquidity to add or remove, depending on policy outcome.
+        lookback_length: int
+            How many blocks back to look when computing past PNL.
+        """
+
+        pnl_target: FixedPoint = FixedPoint("1.0")
+        delta_liquidity: FixedPoint = FixedPoint("100")
+        lookback_length: FixedPoint = FixedPoint(10)
+
+    def __init__(
+        self,
+        policy_config: Config,
+    ):
+        """Initialize the bot.
+
+        Arguments
+        ---------
+        policy_config: Config
+            The custom arguments for this policy
+        """
+        self.pnl_history: list[tuple[int, FixedPoint]] = []
+
+        super().__init__(policy_config)
+
+    def time_weighted_average_pnl(self) -> FixedPoint:
+        """Return the time-weighted average PNL."""
+        if len(self.pnl_history) == 0:  # no history
+            return FixedPoint(0)
+        twapnl: FixedPoint = FixedPoint(0)
+        time_sum: FixedPoint = FixedPoint(0)
+        for block_number, pnl in self.pnl_history:
+            time = self.pnl_history[0][0] - block_number
+            twapnl += pnl * time
+            time_sum += FixedPoint(time)
+        twapnl /= time_sum
+        return twapnl
+
+    def action(
+        self, interface: HyperdriveReadInterface, wallet: HyperdriveWallet
+    ) -> tuple[list[Trade[HyperdriveMarketAction]], bool]:
+        """Specify actions.
+
+        Arguments
+        ---------
+        interface: HyperdriveReadInterface
+            Interface for the market on which this agent will be executing trades (MarketActions).
+        wallet: HyperdriveWallet
+            The agent's wallet.
+
+        Returns
+        -------
+        tuple[list[MarketAction], bool]
+            A tuple where the first element is a list of actions,
+            and the second element defines if the agent is done trading.
+        """
+        action_list = []
+
+        current_block = interface.get_current_block()
+        pnl = FixedPoint(0)  # interface.get_pnl(wallet)
+        self.pnl_history.append((interface.get_block_number(current_block), pnl))
+
+        twapnl = self.time_weighted_average_pnl()
+        if twapnl > self.policy_config.pnl_target:
+            if wallet.balance.amount >= self.policy_config.delta_liquidity:  # only add money if you can afford it!
+                action_list.append(add_liquidity_trade(self.policy_config.delta_liquidity))
+        elif twapnl < self.policy_config.pnl_target:
+            action_list.append(remove_liquidity_trade(self.policy_config.delta_liquidity))
+
+        if len(self.pnl_history) > self.policy_config.lookback_length:
+            self.pnl_history = self.pnl_history[len(self.pnl_history) - self.policy_config.lookback_length :]
+
+        return action_list, False

--- a/src/agent0/core/hyperdrive/policies/simple_lp.py
+++ b/src/agent0/core/hyperdrive/policies/simple_lp.py
@@ -18,12 +18,6 @@ if TYPE_CHECKING:
 
     from agent0.hyperdrive import HyperdriveWallet
 
-# pylint: disable=too-many-arguments, too-many-locals
-
-# constants
-TOLERANCE = 1e-18
-MAX_ITER = 50
-
 
 class SimpleLP(HyperdriveBasePolicy):
     """LP to maintain profitability."""
@@ -73,9 +67,8 @@ class SimpleLP(HyperdriveBasePolicy):
         policy_config: Config
             The custom arguments for this policy
         """
-        self.pnl_history: list[tuple[int, FixedPoint]] = []
-
         super().__init__(policy_config)
+        self.pnl_history: list[tuple[int, FixedPoint]] = []
 
     def time_weighted_average_pnl(self) -> FixedPoint:
         """Return the time-weighted average PNL."""
@@ -111,7 +104,8 @@ class SimpleLP(HyperdriveBasePolicy):
         action_list = []
 
         current_block = interface.get_current_block()
-        pnl = FixedPoint(0)  # interface.get_pnl(wallet)
+        pool_state = interface.get_hyperdrive_state(current_block)
+        pnl = pool_state.pool_info.lp_total_supply * pool_state.pool_info.lp_share_price
         self.pnl_history.append((interface.get_block_number(current_block), pnl))
 
         twapnl = self.time_weighted_average_pnl()

--- a/src/agent0/core/hyperdrive/policies/simple_lp.py
+++ b/src/agent0/core/hyperdrive/policies/simple_lp.py
@@ -105,9 +105,6 @@ class SimpleLP(HyperdriveBasePolicy):
             weight = (i + 1) * delta_time / total_time_spanned
 
             # compute sums
-            # delta_time_in_years = (delta_time / FixedPoint(60 * 60 * 24 * 365))
-            # profit_change_per_year = profit_change * delta_time_in_years
-            # weighted_sum += profit_change_per_year * weight
             weighted_sum += profit_change * weight
             total_weight += weight
 

--- a/src/agent0/core/hyperdrive/policies/simple_lp.py
+++ b/src/agent0/core/hyperdrive/policies/simple_lp.py
@@ -145,14 +145,23 @@ class SimpleLP(HyperdriveBasePolicy):
         # make trades based on pnl_target
         twapnl = self.time_weighted_average_pnl()
         action_list = []
+
+        # need to be in the game to play it
         if wallet.lp_tokens == FixedPoint("0"):
             action_list.append(add_liquidity_trade(self.policy_config.delta_liquidity))
+
+        # i'm doing great, keep putting money in
         elif twapnl > self.policy_config.pnl_target:
-            if wallet.balance.amount >= self.policy_config.delta_liquidity:  # only add money if you can afford it!
+            # only add money if you can afford it!
+            if wallet.balance.amount >= self.policy_config.delta_liquidity:
                 action_list.append(add_liquidity_trade(self.policy_config.delta_liquidity))
+
+        # i'm doing bad
         elif twapnl < self.policy_config.pnl_target:
-            remove_amount = FixedPointMath.minimum(self.policy_config.delta_liquidity, wallet.lp_tokens)
-            action_list.append(remove_liquidity_trade(remove_amount))
+            # do bad long enough to get a good measurement
+            if len(self.pnl_history) == self.policy_config.lookback_length:
+                remove_amount = FixedPointMath.minimum(self.policy_config.delta_liquidity, wallet.lp_tokens)
+                action_list.append(remove_liquidity_trade(remove_amount))
 
         return action_list, False
 

--- a/src/agent0/core/hyperdrive/policies/simple_lp.py
+++ b/src/agent0/core/hyperdrive/policies/simple_lp.py
@@ -7,16 +7,15 @@ from typing import TYPE_CHECKING
 
 from fixedpointmath import FixedPoint, FixedPointMath
 
-from agent0.base import Trade
-from agent0.hyperdrive import HyperdriveMarketAction, TradeResult
-from agent0.hyperdrive.agent import add_liquidity_trade, remove_liquidity_trade
+from agent0.core.base import Trade
+from agent0.core.hyperdrive import HyperdriveMarketAction, TradeResult
+from agent0.core.hyperdrive.agent import add_liquidity_trade, remove_liquidity_trade
 
 from .hyperdrive_policy import HyperdriveBasePolicy
 
 if TYPE_CHECKING:
-    from ethpy.hyperdrive import HyperdriveReadInterface
-
-    from agent0.hyperdrive import HyperdriveWallet
+    from agent0.core.hyperdrive import HyperdriveWallet
+    from agent0.ethpy.hyperdrive import HyperdriveReadInterface
 
 
 class SimpleLP(HyperdriveBasePolicy):

--- a/src/agent0/core/hyperdrive/policies/simple_lp_test.py
+++ b/src/agent0/core/hyperdrive/policies/simple_lp_test.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from fixedpointmath import FixedPoint
 
-from agent0.hyperdrive.interactive import InteractiveHyperdrive, LocalChain
+from agent0.hyperdrive.interactive import ILocalChain, ILocalHyperdrive
 from agent0.hyperdrive.interactive.event_types import AddLiquidity
 from agent0.hyperdrive.policies import PolicyZoo
 
@@ -13,17 +13,16 @@ from agent0.hyperdrive.policies import PolicyZoo
 
 
 @pytest.mark.anvil
-def test_simple_lp_policy(chain: LocalChain):
+def test_simple_lp_policy(chain: ILocalChain):
     # Parameters for pool initialization. If empty, defaults to default values, allows for custom values if needed
     # We explicitly set initial liquidity here to ensure we have withdrawal shares when trading
-    initial_pool_config = InteractiveHyperdrive.Config(
-        initial_liquidity=FixedPoint(1_000),
+    initial_pool_config = ILocalHyperdrive.Config(
+        initial_liquidity=FixedPoint(10_000),
         initial_fixed_apr=FixedPoint("0.05"),
-        position_duration=60 * 60 * 24 * 7,  # 1 week
+        position_duration=60 * 60 * 24 * 30,  # 1 month
         checkpoint_duration=60 * 60 * 24,  # 1 day
     )
-    interactive_hyperdrive = InteractiveHyperdrive(chain, initial_pool_config)
-
+    interactive_hyperdrive = ILocalHyperdrive(chain, initial_pool_config)
     pnl_target = FixedPoint("1.0")
     lp_agent = interactive_hyperdrive.init_agent(
         base=FixedPoint(1_111_111),
@@ -38,14 +37,20 @@ def test_simple_lp_policy(chain: LocalChain):
     )
 
     # no other trades, so agent PNL should stay 0
-    for _ in range(3):  # add liquidity 3 times
-        trade_event_list = lp_agent.execute_policy_action()
-        assert len(trade_event_list) == 0  # only one trade per action execution
-        assert isinstance(trade_event_list[0], AddLiquidity)  # always should be add liquidity
-        assert trade_event_list[0].lp_amount == FixedPoint("1_000")  # always should be 1_000
+    trade_event_list = lp_agent.execute_policy_action()
+    assert len(trade_event_list) == 0  # only one trade per action execution
+    assert isinstance(trade_event_list[0], AddLiquidity)  # always should be add liquidity
+    assert trade_event_list[0].lp_amount == FixedPoint("1_000")  # always should be 1_000
+    assert lp_agent.agent.policy.sub_policy.pnl_history[0][1] == FixedPoint("0")
 
     hyperdrive_agent0 = interactive_hyperdrive.init_agent(base=FixedPoint(1_111_111), eth=FixedPoint(111), name="Bob")
-    hyperdrive_agent0.open_long(FixedPoint("1_000"))
-
-    # Advance time to maturity
+    hyperdrive_agent0.open_short(FixedPoint("100"))
     chain.advance_time(60 * 60 * 24 * 7, create_checkpoints=False)
+    hyperdrive_agent0.close_short(FixedPoint("100"))
+
+    # big loss from agent0, so LP should get profit and add liquidity again
+    trade_event_list = lp_agent.execute_policy_action()
+    assert len(trade_event_list) == 0  # only one trade per action execution
+    assert isinstance(trade_event_list[0], AddLiquidity)  # always should be add liquidity
+    assert trade_event_list[0].lp_amount == FixedPoint("1_000")  # always should be 1_000
+    assert lp_agent.agent.policy.sub_policy.pnl_history[0][1] == FixedPoint("0")

--- a/src/agent0/core/hyperdrive/policies/simple_lp_test.py
+++ b/src/agent0/core/hyperdrive/policies/simple_lp_test.py
@@ -42,7 +42,7 @@ def test_simple_lp_policy(chain: ILocalChain):
         policy_config=PolicyZoo.simple_lp.Config(
             pnl_target=pnl_target,
             delta_liquidity=delta_liquidity,
-            minimum_liquidity_tokens=minimum_liquidity_tokens,
+            minimum_liquidity_value=minimum_liquidity_tokens,
         ),
     )
     _ = lp_agent.add_liquidity(base=FixedPoint("10_000"))

--- a/src/agent0/core/hyperdrive/policies/simple_lp_test.py
+++ b/src/agent0/core/hyperdrive/policies/simple_lp_test.py
@@ -1,0 +1,51 @@
+"""Test for the simple LP Hyperdrive trading bot."""
+
+from __future__ import annotations
+
+import pytest
+from fixedpointmath import FixedPoint
+
+from agent0.hyperdrive.interactive import InteractiveHyperdrive, LocalChain
+from agent0.hyperdrive.interactive.event_types import AddLiquidity
+from agent0.hyperdrive.policies import PolicyZoo
+
+# pylint: disable=too-many-locals
+
+
+@pytest.mark.anvil
+def test_simple_lp_policy(chain: LocalChain):
+    # Parameters for pool initialization. If empty, defaults to default values, allows for custom values if needed
+    # We explicitly set initial liquidity here to ensure we have withdrawal shares when trading
+    initial_pool_config = InteractiveHyperdrive.Config(
+        initial_liquidity=FixedPoint(1_000),
+        initial_fixed_apr=FixedPoint("0.05"),
+        position_duration=60 * 60 * 24 * 7,  # 1 week
+        checkpoint_duration=60 * 60 * 24,  # 1 day
+    )
+    interactive_hyperdrive = InteractiveHyperdrive(chain, initial_pool_config)
+
+    pnl_target = FixedPoint("1.0")
+    lp_agent = interactive_hyperdrive.init_agent(
+        base=FixedPoint(1_111_111),
+        eth=FixedPoint(111),
+        name="Lisa",
+        policy=PolicyZoo.simple_lp,
+        policy_config=PolicyZoo.simple_lp.Config(
+            lookback_length=FixedPoint("5"),
+            pnl_target=pnl_target,
+            delta_liquidity=FixedPoint("1_000"),
+        ),
+    )
+
+    # no other trades, so agent PNL should stay 0
+    for _ in range(3):  # add liquidity 3 times
+        trade_event_list = lp_agent.execute_policy_action()
+        assert len(trade_event_list) == 0  # only one trade per action execution
+        assert isinstance(trade_event_list[0], AddLiquidity)  # always should be add liquidity
+        assert trade_event_list[0].lp_amount == FixedPoint("1_000")  # always should be 1_000
+
+    hyperdrive_agent0 = interactive_hyperdrive.init_agent(base=FixedPoint(1_111_111), eth=FixedPoint(111), name="Bob")
+    hyperdrive_agent0.open_long(FixedPoint("1_000"))
+
+    # Advance time to maturity
+    chain.advance_time(60 * 60 * 24 * 7, create_checkpoints=False)

--- a/src/agent0/core/hyperdrive/policies/simple_lp_test.py
+++ b/src/agent0/core/hyperdrive/policies/simple_lp_test.py
@@ -70,7 +70,9 @@ def test_simple_lp_policy(chain: ILocalChain):
     # always should be close to delta_liquidity
     assert isclose(trade_event_list[0].lp_amount, delta_liquidity, abs_tol=FixedPoint("1.0"))
 
-    # Do smart trades until the LP makes a move; that move should be removing liquidity
+    # Do smart trades until the LP removes liquidity
+    # It's possible the LP could add liquidity in the first couple of trades,
+    # depending on how much they influence the average PNL.
     hyperdrive_agent1 = interactive_hyperdrive.init_agent(
         base=FixedPoint("1_000_000"), eth=FixedPoint("1_000"), name="Bob"
     )

--- a/src/agent0/core/hyperdrive/policies/simple_lp_test.py
+++ b/src/agent0/core/hyperdrive/policies/simple_lp_test.py
@@ -15,9 +15,6 @@ from agent0.core.hyperdrive.interactive.event_types import AddLiquidity, RemoveL
 
 @pytest.mark.anvil
 def test_simple_lp_policy(chain: ILocalChain):
-    # Deploy hyperdrive
-    chain = ILocalChain()
-
     # Parameters for pool initialization. If empty, defaults to default values, allows for custom values if needed
     # We explicitly set initial liquidity here to ensure we have withdrawal shares when trading
     initial_pool_config = ILocalHyperdrive.Config(

--- a/src/agent0/core/hyperdrive/policies/simple_lp_test.py
+++ b/src/agent0/core/hyperdrive/policies/simple_lp_test.py
@@ -78,10 +78,8 @@ def test_simple_lp_policy(chain: ILocalChain):
     while not removed_liquidity:
         trade_amount = FixedPoint("1_000")
         hyperdrive_agent1.add_funds(base=trade_amount)
-        interactive_hyperdrive.set_variable_rate(FixedPoint("0.8"))
+        interactive_hyperdrive.set_variable_rate(FixedPoint("0.0"))  # LP gets no extra earnings from variable
         open_event = hyperdrive_agent1.open_long(trade_amount)
-        chain.advance_time(datetime.timedelta(seconds=100), create_checkpoints=False)
-        interactive_hyperdrive.set_variable_rate(FixedPoint("0.0"))
         chain.advance_time(datetime.timedelta(weeks=1), create_checkpoints=False)
         hyperdrive_agent1.close_long(open_event.maturity_time, open_event.bond_amount)
 

--- a/src/agent0/core/hyperdrive/policies/zoo.py
+++ b/src/agent0/core/hyperdrive/policies/zoo.py
@@ -8,6 +8,7 @@ from .deterministic import Deterministic
 from .lpandarb import LPandArb
 from .random import Random
 from .random_hold import RandomHold
+from .simple_lp import SimpleLP
 from .smart_long import SmartLong
 
 
@@ -18,6 +19,7 @@ class PolicyZoo(NamedTuple):
     random = Random
     random_hold = RandomHold
     smart_long = SmartLong
+    simple_lp = SimpleLP
     lp_and_arb = LPandArb
     deterministic = Deterministic
 


### PR DESCRIPTION
The bot has this description:

>         This LP bot adds or removes liquidity according to its recent profitability.
>         It has a target PNL that it is aiming for, and takes actions based on how its PNL has changed over time.
>         The bot follows this strategy:
>             - If the PNL is above threshold, and is improving over time, then the bot adds liquidity.
>             - If the PNL is above threshold, and is not improving over time, then the bot takes no action.
>             - If the PNL is below threshold, and is improving over time, then the bot takes no action.
>             - If the PNL is below threshold, and is not improving over time, then the bot pulls liquidity.

The target PNL is set in units of base, which I think is intuitive enough. We also use PNL history to bias our decisions, so it doesn't remove liquidity too early.

The bot can definitely be improved & fine-tuned, but I think this is sufficient to get started with our experiment.