### PR TITLE
Chainsync calculates pnl via rust instead of contract calls

### DIFF
--- a/lib/agent0/agent0/hyperdrive/interactive/i_local_hyperdrive.py
+++ b/lib/agent0/agent0/hyperdrive/interactive/i_local_hyperdrive.py
@@ -673,7 +673,7 @@ class ILocalHyperdrive(IHyperdrive):
         Returns
         -------
         pd.Dataframe
-            A pandas dataframe that consists of the checkpoint info per block.
+            A pandas dataframe that consists of previous checkpoints made.
         """
         # DB read calls ensures data pipeline is caught up before returning
         if self.chain.experimental_data_threading:

--- a/lib/chainsync/chainsync/analysis/calc_pnl.py
+++ b/lib/chainsync/chainsync/analysis/calc_pnl.py
@@ -80,7 +80,6 @@ def calc_single_closeout(
             close_share_price = hyperdrive_state.pool_info.vault_share_price
 
         try:
-            # TODO, we need the vault share price of the open/close
             out_pnl = interface.calc_close_short(
                 amount,
                 open_vault_share_price=open_share_price,

--- a/lib/chainsync/chainsync/analysis/calc_pnl.py
+++ b/lib/chainsync/chainsync/analysis/calc_pnl.py
@@ -56,7 +56,8 @@ def calc_single_closeout(
     if tokentype == "LONG":
         try:
             out_pnl = interface.calc_close_long(amount, normalized_time_remaining, hyperdrive_state)
-        except Exception as exception:  # pylint: disable=broad-except
+        # Rust Panic Exceptions are base exceptions, not Exceptions
+        except BaseException as exception:  # pylint: disable=broad-except
             logging.warning("Chainsync: Exception caught in calculating close long, ignoring: %s", exception)
         # FixedPoint to Decimal
         out_pnl = Decimal(str(out_pnl))
@@ -87,7 +88,8 @@ def calc_single_closeout(
                 normalized_time_remaining=normalized_time_remaining,
                 pool_state=hyperdrive_state,
             )
-        except Exception as exception:  # pylint: disable=broad-except
+        # Rust Panic Exceptions are base exceptions, not Exceptions
+        except BaseException as exception:  # pylint: disable=broad-except
             logging.warning("Chainsync: Exception caught in calculating close short, ignoring: %s", exception)
         out_pnl = Decimal(str(out_pnl))
 

--- a/lib/chainsync/chainsync/analysis/calc_pnl.py
+++ b/lib/chainsync/chainsync/analysis/calc_pnl.py
@@ -51,12 +51,7 @@ def calc_single_closeout(
     if tokentype in ["LONG", "SHORT"]:
         maturity = int(position["maturity_time"])
         # If mature, set time left to 0
-        time_left_seconds = max(maturity - hyperdrive_state.block_time, 0)
-        # Set normalized time remaining, 0 is at opening and 1 is at maturity
-        normalized_time_remaining = 1 - (FixedPoint(time_left_seconds) / FixedPoint(position_duration))
-        # Sanity check
-        assert normalized_time_remaining >= 0
-        assert normalized_time_remaining <= 1
+        normalized_time_remaining = max(maturity - hyperdrive_state.block_time, 0) / FixedPoint(position_duration)
 
     out_pnl = Decimal("nan")
     if tokentype == "LONG":

--- a/lib/chainsync/chainsync/analysis/data_to_analysis.py
+++ b/lib/chainsync/chainsync/analysis/data_to_analysis.py
@@ -17,9 +17,9 @@ from chainsync.db.hyperdrive import (
     get_transactions,
     get_wallet_deltas,
 )
+from ethpy.hyperdrive import HyperdriveReadInterface
 from sqlalchemy import exc
 from sqlalchemy.orm import Session
-from web3.contract.contract import Contract
 
 from .calc_base_buffer import calc_base_buffer
 from .calc_fixed_rate import calc_fixed_rate
@@ -153,7 +153,7 @@ def data_to_analysis(
     end_block: int,
     pool_config: pd.Series,
     db_session: Session,
-    hyperdrive_contract: Contract,
+    interface: HyperdriveReadInterface,
     calc_pnl: bool = True,
 ) -> None:
     """Function to query postgres data tables and insert to analysis tables.
@@ -197,7 +197,7 @@ def data_to_analysis(
         # since we only get the current wallet for the end_block
         wallet_pnl = get_current_wallet(db_session, end_block=end_block, coerce_float=False)
         if calc_pnl:
-            pnl_df = calc_closeout_pnl(wallet_pnl, hyperdrive_contract, pool_info["vault_share_price"].iloc[-1])
+            pnl_df = calc_closeout_pnl(wallet_pnl, interface, pool_info["vault_share_price"].iloc[-1])
         else:
             pnl_df = np.nan
 

--- a/lib/chainsync/chainsync/analysis/data_to_analysis.py
+++ b/lib/chainsync/chainsync/analysis/data_to_analysis.py
@@ -169,8 +169,8 @@ def data_to_analysis(
         The pool config data.
     db_session: Session
         The initialized db session.
-    hyperdrive_contract: Contract
-        The hyperdrive contract.
+    interface: HyperdriveReadInterface
+        The hyperdrive read interface
     calc_pnl: bool
         Whether to calculate pnl. Defaults to True.
     """

--- a/lib/chainsync/chainsync/analysis/data_to_analysis.py
+++ b/lib/chainsync/chainsync/analysis/data_to_analysis.py
@@ -12,6 +12,7 @@ from chainsync.db.hyperdrive import (
     PoolAnalysis,
     Ticker,
     WalletPNL,
+    get_checkpoint_info,
     get_current_wallet,
     get_pool_info,
     get_transactions,
@@ -197,7 +198,8 @@ def data_to_analysis(
         # since we only get the current wallet for the end_block
         wallet_pnl = get_current_wallet(db_session, end_block=end_block, coerce_float=False)
         if calc_pnl:
-            pnl_df = calc_closeout_pnl(wallet_pnl, interface, pool_info["vault_share_price"].iloc[-1])
+            checkpoint_info = get_checkpoint_info(db_session, coerce_float=False)
+            pnl_df = calc_closeout_pnl(wallet_pnl, checkpoint_info, interface)
         else:
             pnl_df = np.nan
 

--- a/lib/chainsync/chainsync/db/hyperdrive/__init__.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/__init__.py
@@ -9,7 +9,7 @@ from .convert_data import (
 )
 from .import_export_data import export_db_to_file, import_to_db, import_to_pandas
 from .interface import (
-    add_checkpoint_infos,
+    add_checkpoint_info,
     add_pool_config,
     add_pool_infos,
     add_transactions,

--- a/lib/chainsync/chainsync/db/hyperdrive/chain_to_db.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/chain_to_db.py
@@ -15,7 +15,7 @@ from .convert_data import (
     convert_pool_config,
     convert_pool_info,
 )
-from .interface import add_checkpoint_infos, add_pool_config, add_pool_infos, add_transactions, add_wallet_deltas
+from .interface import add_checkpoint_info, add_pool_config, add_pool_infos, add_transactions, add_wallet_deltas
 
 
 def init_data_chain_to_db(
@@ -63,10 +63,9 @@ def data_chain_to_db(interface: HyperdriveReadInterface, block: BlockData, sessi
 
     ## Query and add block_checkpoint_info
     checkpoint_dict = asdict(pool_state.checkpoint)
-    checkpoint_dict["block_number"] = int(pool_state.block_number)
-    checkpoint_dict["timestamp"] = datetime.fromtimestamp(int(pool_state.block_time))
+    checkpoint_dict["checkpoint_time"] = pool_state.checkpoint_time
     block_checkpoint_info = convert_checkpoint_info(checkpoint_dict)
-    add_checkpoint_infos([block_checkpoint_info], session)
+    add_checkpoint_info(block_checkpoint_info, session)
 
     ## Query and add block_transactions and wallet deltas
     block_transactions = None

--- a/lib/chainsync/chainsync/db/hyperdrive/chain_to_db.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/chain_to_db.py
@@ -65,7 +65,10 @@ def data_chain_to_db(interface: HyperdriveReadInterface, block: BlockData, sessi
     checkpoint_dict = asdict(pool_state.checkpoint)
     checkpoint_dict["checkpoint_time"] = pool_state.checkpoint_time
     block_checkpoint_info = convert_checkpoint_info(checkpoint_dict)
-    add_checkpoint_info(block_checkpoint_info, session)
+    # When the contract call fails due to missing checkpoint, solidity returns 0
+    # Hence, we detect that here and don't add the checkpoint info if that happens
+    if block_checkpoint_info.vault_share_price != 0:
+        add_checkpoint_info(block_checkpoint_info, session)
 
     ## Query and add block_transactions and wallet deltas
     block_transactions = None

--- a/lib/chainsync/chainsync/db/hyperdrive/interface.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/interface.py
@@ -137,7 +137,7 @@ def add_checkpoint_info(checkpoint_info: CheckpointInfo, session: Session) -> No
         The initialized session object
     """
     # NOTE the logic below is not thread safe, i.e., a race condition can exists
-    # if multiple threads try to add pool config at the same time
+    # if multiple threads try to add checkpoint info at the same time
     # This function is being called by acquire_data.py, which should only have one
     # instance per db, so no need to worry about it here
     # Since we're doing a direct equality comparison, we don't want to coerce into floats here

--- a/lib/chainsync/chainsync/db/hyperdrive/interface_test.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/interface_test.py
@@ -9,7 +9,7 @@ from chainsync.db.base import get_latest_block_number_from_table
 from ethpy.hyperdrive import BASE_TOKEN_SYMBOL
 
 from .interface import (
-    add_checkpoint_infos,
+    add_checkpoint_info,
     add_current_wallet,
     add_pool_config,
     add_pool_infos,
@@ -90,7 +90,7 @@ class TestCheckpointInterface:
     def test_latest_block_number(self, db_session):
         """Testing retrieval of checkpoint via interface"""
         checkpoint_1 = CheckpointInfo(block_number=1, timestamp=datetime.now())
-        add_checkpoint_infos([checkpoint_1], db_session)
+        add_checkpoint_info([checkpoint_1], db_session)
         db_session.commit()
 
         latest_block_number = get_latest_block_number_from_table(CheckpointInfo, db_session)
@@ -98,7 +98,7 @@ class TestCheckpointInterface:
 
         checkpoint_2 = CheckpointInfo(block_number=2, timestamp=datetime.now())
         checkpoint_3 = CheckpointInfo(block_number=3, timestamp=datetime.now())
-        add_checkpoint_infos([checkpoint_2, checkpoint_3], db_session)
+        add_checkpoint_info([checkpoint_2, checkpoint_3], db_session)
 
         latest_block_number = get_latest_block_number_from_table(CheckpointInfo, db_session)
         assert latest_block_number == 3
@@ -112,7 +112,7 @@ class TestCheckpointInterface:
         checkpoint_1 = CheckpointInfo(block_number=0, timestamp=date_1)
         checkpoint_2 = CheckpointInfo(block_number=1, timestamp=date_2)
         checkpoint_3 = CheckpointInfo(block_number=2, timestamp=date_3)
-        add_checkpoint_infos([checkpoint_1, checkpoint_2, checkpoint_3], db_session)
+        add_checkpoint_info([checkpoint_1, checkpoint_2, checkpoint_3], db_session)
 
         checkpoints_df = get_checkpoint_info(db_session)
         np.testing.assert_array_equal(
@@ -125,7 +125,7 @@ class TestCheckpointInterface:
         checkpoint_1 = CheckpointInfo(block_number=0, timestamp=datetime.now(), vault_share_price=Decimal("3.1"))
         checkpoint_2 = CheckpointInfo(block_number=1, timestamp=datetime.now(), vault_share_price=Decimal("3.2"))
         checkpoint_3 = CheckpointInfo(block_number=2, timestamp=datetime.now(), vault_share_price=Decimal("3.3"))
-        add_checkpoint_infos([checkpoint_1, checkpoint_2, checkpoint_3], db_session)
+        add_checkpoint_info([checkpoint_1, checkpoint_2, checkpoint_3], db_session)
 
         checkpoints_df = get_checkpoint_info(db_session, start_block=1)
         np.testing.assert_array_equal(checkpoints_df["vault_share_price"], [3.2, 3.3])

--- a/lib/chainsync/chainsync/db/hyperdrive/schema.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/schema.py
@@ -51,8 +51,7 @@ class CheckpointInfo(Base):
 
     __tablename__ = "checkpoint_info"
 
-    block_number: Mapped[int] = mapped_column(BigInteger, primary_key=True)
-    timestamp: Mapped[datetime] = mapped_column(DateTime)
+    checkpoint_time: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     vault_share_price: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
     # TODO we'd like to add the checkpoint id here as a field as well
 

--- a/lib/chainsync/chainsync/db/hyperdrive/schema_test.py
+++ b/lib/chainsync/chainsync/db/hyperdrive/schema_test.py
@@ -59,41 +59,41 @@ class TestCheckpointTable:
     @pytest.mark.docker
     def test_create_checkpoint(self, db_session):
         """Create and entry"""
-        timestamp = datetime.now()
-        checkpoint = CheckpointInfo(block_number=1, timestamp=timestamp)
+        vault_share_price = Decimal("1.1")
+        checkpoint = CheckpointInfo(checkpoint_time=1, vault_share_price=vault_share_price)
         db_session.add(checkpoint)
         db_session.commit()
 
-        retrieved_checkpoint = db_session.query(CheckpointInfo).filter_by(block_number=1).first()
+        retrieved_checkpoint = db_session.query(CheckpointInfo).filter_by(checkpoint_time=1).first()
         assert retrieved_checkpoint is not None
-        assert retrieved_checkpoint.timestamp == timestamp
+        assert retrieved_checkpoint.vault_share_price == vault_share_price
 
     @pytest.mark.docker
     def test_update_checkpoint(self, db_session):
         """Update an entry"""
-        timestamp = datetime.now()
-        checkpoint = CheckpointInfo(block_number=1, timestamp=timestamp)
+        vault_share_price = Decimal("1.1")
+        checkpoint = CheckpointInfo(checkpoint_time=1, vault_share_price=vault_share_price)
         db_session.add(checkpoint)
         db_session.commit()
 
         checkpoint.vault_share_price = Decimal("5.0")
         db_session.commit()
 
-        updated_checkpoint = db_session.query(CheckpointInfo).filter_by(block_number=1).first()
-        assert updated_checkpoint.vault_share_price == 5.0
+        updated_checkpoint = db_session.query(CheckpointInfo).filter_by(checkpoint_time=1).first()
+        assert updated_checkpoint.vault_share_price == Decimal("5.0")
 
     @pytest.mark.docker
     def test_delete_checkpoint(self, db_session):
         """Delete an entry"""
-        timestamp = datetime.now()
-        checkpoint = CheckpointInfo(block_number=1, timestamp=timestamp)
+        vault_share_price = Decimal("1.1")
+        checkpoint = CheckpointInfo(checkpoint_time=1, vault_share_price=vault_share_price)
         db_session.add(checkpoint)
         db_session.commit()
 
         db_session.delete(checkpoint)
         db_session.commit()
 
-        deleted_checkpoint = db_session.query(CheckpointInfo).filter_by(block_number=1).first()
+        deleted_checkpoint = db_session.query(CheckpointInfo).filter_by(checkpoint_time=1).first()
         assert deleted_checkpoint is None
 
 

--- a/lib/chainsync/chainsync/exec/data_analysis.py
+++ b/lib/chainsync/chainsync/exec/data_analysis.py
@@ -82,9 +82,6 @@ def data_analysis(
         db_session_init = True
         db_session = initialize_session(postgres_config=postgres_config, ensure_database_created=True)
 
-    # Get hyperdrive contract
-    hyperdrive_contract = interface.hyperdrive_contract
-
     ## Get starting point for restarts
     analysis_latest_block_number = get_latest_block_number_from_analysis_table(db_session)
 
@@ -129,9 +126,7 @@ def data_analysis(
         analysis_end_block = latest_data_block_number + 1
         if not suppress_logs:
             logging.info("Running batch %s to %s", analysis_start_block, analysis_end_block)
-        data_to_analysis(
-            analysis_start_block, analysis_end_block, pool_config, db_session, hyperdrive_contract, calc_pnl
-        )
+        data_to_analysis(analysis_start_block, analysis_end_block, pool_config, db_session, interface, calc_pnl)
         curr_start_write_block = latest_data_block_number + 1
 
     # Clean up resources on clean exit

--- a/lib/ethpy/ethpy/hyperdrive/interface/read_interface.py
+++ b/lib/ethpy/ethpy/hyperdrive/interface/read_interface.py
@@ -238,7 +238,7 @@ class HyperdriveReadInterface:
         """
         return _get_block_time(block)
 
-    def get_hyperdrive_state(self, block: BlockData | None = None):
+    def get_hyperdrive_state(self, block: BlockData | None = None) -> PoolState:
         """Use RPCs and contract calls to get the Hyperdrive pool and block state, given a block identifier.
 
         Arguments

--- a/lib/ethpy/ethpy/hyperdrive/interface/read_interface.py
+++ b/lib/ethpy/ethpy/hyperdrive/interface/read_interface.py
@@ -269,17 +269,18 @@ class HyperdriveReadInterface:
         hyperdrive_eth_balance = self.get_hyperdrive_eth_balance()
         gov_fees_accrued = self.get_gov_fees_accrued(block_number)
         return PoolState(
-            block,
-            pool_config,
-            pool_info,
-            checkpoint,
-            exposure,
-            variable_rate,
-            vault_shares,
-            total_supply_withdrawal_shares,
-            hyperdrive_base_balance,
-            hyperdrive_eth_balance,
-            gov_fees_accrued,
+            block=block,
+            pool_config=pool_config,
+            pool_info=pool_info,
+            checkpoint_time=checkpoint_time,
+            checkpoint=checkpoint,
+            exposure=exposure,
+            variable_rate=variable_rate,
+            vault_shares=vault_shares,
+            total_supply_withdrawal_shares=total_supply_withdrawal_shares,
+            hyperdrive_base_balance=hyperdrive_base_balance,
+            hyperdrive_eth_balance=hyperdrive_eth_balance,
+            gov_fees_accrued=gov_fees_accrued,
         )
 
     def get_total_supply_withdrawal_shares(self, block_number: BlockNumber | None) -> FixedPoint:

--- a/lib/ethpy/ethpy/hyperdrive/state/pool_state.py
+++ b/lib/ethpy/ethpy/hyperdrive/state/pool_state.py
@@ -25,6 +25,7 @@ class PoolState:
     block: BlockData
     pool_config: PoolConfigFP
     pool_info: PoolInfoFP
+    checkpoint_time: int
     checkpoint: CheckpointFP
     exposure: FixedPoint
     variable_rate: FixedPoint


### PR DESCRIPTION
Adding checkpoint_time to interface pool_state

Breaking changes: Checkpoint table in database changed from getting info per block to being one row per checkpoint time.