### PR TITLE
make uv installable

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - uv-installable
+      - main
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,8 +3,8 @@ name: "Docker: Build and push agent0 image"
 on:
   workflow_dispatch:
   push:
-    branches: ["main"]
-    tags: ["*"]
+    branches:
+      - uv-installable
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: lint
 on:
   push:
     branches:
-      - main
+      - uv-installable
   pull_request:
 
 jobs:
@@ -22,14 +22,14 @@ jobs:
           cache: "pip"
           token: ${{github.token}}
 
-      - name: upgrade pip
-        run: python -m pip install --upgrade pip
+      - name: install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
       - name: install requirements
         run: |
-          python -m pip install --upgrade -r requirements.txt
-          python -m pip install --upgrade -r requirements-rl.txt
-          python -m pip install --upgrade -r requirements-dev.txt
+          uv pip install --upgrade -r requirements.txt
+          uv pip install --upgrade -r requirements-rl.txt
+          uv pip install --upgrade -r requirements-dev.txt
 
       - name: run black
         run: python -m black --config pyproject.toml --check --diff .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: lint
 on:
   push:
     branches:
-      - uv-installable
+      - main
   pull_request:
 
 jobs:
@@ -27,6 +27,8 @@ jobs:
 
       - name: install requirements
         run: |
+          uv venv .venv -p 3.10
+          source .venv/bin/activate
           uv pip install --upgrade -r requirements.txt
           uv pip install --upgrade -r requirements-rl.txt
           uv pip install --upgrade -r requirements-dev.txt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,9 @@ jobs:
           uv pip install --upgrade -r requirements-dev.txt
 
       - name: run black
-        run: python -m black --config pyproject.toml --check --diff .
+        run: |
+          source .venv/bin/activate
+          python -m black --config pyproject.toml --check --diff .
 
       - name: get all Python files
         id: list_files
@@ -43,6 +45,7 @@ jobs:
 
       - name: run Pylint on files
         run: |
+          source .venv/bin/activate
           files="${{ steps.list_files.outputs.files }}"
           if [ -n "$files" ]; then
             pylint --rcfile=.pylintrc $files

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,4 +34,6 @@ jobs:
           uv pip install --upgrade -r requirements-dev.txt
 
       - name: analysing code with pyright
-        run: python -m pyright $(git ls-files '*.py' '*.pyi')
+        run: |
+          source .venv/bin/activate
+          python -m pyright $(git ls-files '*.py' '*.pyi')

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: install requirements
         run: |
+          uv venv .venv -p 3.10
+          source .venv/bin/activate
           uv pip install --upgrade -r requirements.txt
           uv pip install --upgrade -r requirements-rl.txt
           uv pip install --upgrade -r requirements-dev.txt

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -3,7 +3,7 @@ name: static
 on:
   push:
     branches:
-      - uv-installable
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -3,7 +3,7 @@ name: static
 on:
   push:
     branches:
-      - main
+      - uv-installable
   pull_request:
 
 jobs:
@@ -22,14 +22,14 @@ jobs:
           cache: "pip"
           token: ${{github.token}}
 
-      - name: upgrade pip
-        run: python -m pip install --upgrade pip
+      - name: install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
       - name: install requirements
         run: |
-          python -m pip install --upgrade -r requirements.txt
-          python -m pip install --upgrade -r requirements-rl.txt
-          python -m pip install --upgrade -r requirements-dev.txt
+          uv pip install --upgrade -r requirements.txt
+          uv pip install --upgrade -r requirements-rl.txt
+          uv pip install --upgrade -r requirements-dev.txt
 
       - name: analysing code with pyright
         run: python -m pyright $(git ls-files '*.py' '*.pyi')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: test
 on:
   push:
     branches:
-      - main
+      - uv-installable
   pull_request:
 
 jobs:
@@ -41,14 +41,14 @@ jobs:
           cache: "pip"
           token: ${{github.token}}
 
-      - name: upgrade pip
-        run: python -m pip install --upgrade pip
+      - name: install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
       - name: install requirements
         run: |
-          python -m pip install --upgrade -r requirements.txt
-          python -m pip install --upgrade -r requirements-rl.txt
-          python -m pip install --upgrade -r requirements-dev.txt
+          uv pip install --upgrade -r requirements.txt
+          uv pip install --upgrade -r requirements-rl.txt
+          uv pip install --upgrade -r requirements-dev.txt
 
       - name: run pytest with coverage
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,10 +54,12 @@ jobs:
 
       - name: run pytest with coverage
         run: |
+          source .venv/bin/activate
           IN_CI=true coverage run -m pytest
 
       - name: generate coverage report
         run: |
+          source .venv/bin/activate
           coverage xml -i
           coverage html -i
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: install requirements
         run: |
+          uv venv .venv -p 3.10
+          source .venv/bin/activate
           uv pip install --upgrade -r requirements.txt
           uv pip install --upgrade -r requirements-rl.txt
           uv pip install --upgrade -r requirements-dev.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: test
 on:
   push:
     branches:
-      - uv-installable
+      - main
   pull_request:
 
 jobs:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,39 +1,31 @@
 # Install -- overview
 
-All `agent0` packages should be accessed from Python 3.10.
-The following outlines our recommended install workflow, although alternatives are listed below.
+`Agent0` requires Python 3.10.
 
 ## 1. Clone the `agent0` monorepo
 
-Clone the repo into a <repo_location> of your choice.
+Clone the repo into a <repo_location> of your choice, then enter that directory.
 
 ```bash
 git clone https://github.com/delvtech/agent0.git <repo_location>
-```
-
-## 2. Install Pyenv
-
-Follow [Pyenv install instructions](https://github.com/pyenv/pyenv#installation).
-
-## 3. Set up a virtual environment
-
-You can use any environment; we use [venv](https://docs.python.org/3/library/venv.html):
-
-```bash
 cd <repo_location>
-pyenv install 3.10
-pyenv local 3.10
-python -m venv .venv
-source .venv/bin/activate
 ```
 
-## 4. Install `agent0` packages and requirements
+## 2. Install uv
 
-All of the agent0 packages can be installed from `requirements.txt`:
+We use [uv](https://github.com/astral-sh/uv) for package management and virtual environments.
 
 ```bash
-python -m pip install --upgrade pip
-python -m pip install --upgrade -r requirements.txt
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+## 3. Install `agent0` in a virtual environment
+
+```bash
+uv venv .venv -p 3.10
+source .venv/bin/activate
+uv pip install -r requirements.txt
+uv pip install -r requirements-dev.txt
 ```
 
 If you want to use the CI tools, such as run tests, check linting or types, build containers or documentation, then you must also [install Foundry](https://book.getfoundry.sh/getting-started/installation) and the dev packages:
@@ -43,27 +35,6 @@ python -m pip install --upgrade -r requirements-dev.txt
 ```
 
 Finally, you can test that everything is working by calling: `python -m pytest .`
-
-# Alternate install paths
-
-The default installation directions above should automatically install all local sub-packages, and should be sufficient for development.
-We also support these installation options:
-
-## Installing each subpackage independently
-
-After you have cloned the repository you can install each package independently.
-For example:
-
-```bash
-python -m pip install --upgrade lib/agent0[with-dependencies]
-```
-
-Internally, the above installation calls
-
-```bash
-pip install agent0[base] # Install with base packages only (this is what's called in requirements.txt)
-pip install agent0[lateral] # Installs dependent sub-packages from git (e.g., ethpy)
-```
 
 # Working with smart contracts
 

--- a/lib/agent0/pyproject.toml
+++ b/lib/agent0/pyproject.toml
@@ -15,29 +15,17 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ]
-
-[project.optional-dependencies]
-# This flag installs all dependencies and should be ran when installing this subpackage in isolation
-with-dependencies = ["agent0[base, lateral]"]
-base = [
-    "fixedpointmath",
+dependencies = [
     "numpy",
     "python-dotenv",
-    # will include eth- packages
     "web3",
     "hexbytes",
     "pandas",
     "nest_asyncio",
     "rollbar",
     "dill",
+    "fixedpointmath @ git+https://github.com/delvtech/fixedpointmath.git",
 ]
-lateral = [
-    # Lateral dependencies across subpackages are pointing to github
-    "hyperlogs[with-dependencies] @ git+https://github.com/delvtech/agent0.git/#subdirectory=lib/hyperlogs",
-    "ethpy[with-dependencies] @ git+https://github.com/delvtech/agent0.git/#subdirectory=lib/ethpy",
-    "chainsync[with-dependencies] @ git+https://github.com/delvtech/agent0.git/#subdirectory=lib/chainsync",
-]
-
 
 [build-system]
 requires = ["flit_core>=3.2"]

--- a/lib/chainsync/pyproject.toml
+++ b/lib/chainsync/pyproject.toml
@@ -15,13 +15,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ]
-
-[project.optional-dependencies]
-# This flag installs all dependencies and should be ran when installing this subpackage in isolation
-with-dependencies = [
-    "chainsync[base, lateral]"
-]
-base = [
+dependencies = [
     "fixedpointmath",
     "matplotlib",
     "numpy",
@@ -36,11 +30,6 @@ base = [
     "sqlalchemy-utils",
     "pandas-stubs",
     "requests",
-]
-lateral = [
-    # Lateral dependencies across subpackages are pointing to github
-    "hyperlogs[with-dependencies] @ git+https://github.com/delvtech/agent0.git/#subdirectory=lib/hyperlogs",
-    "ethpy[with-dependencies] @ git+https://github.com/delvtech/agent0.git/#subdirectory=lib/ethpy",
 ]
 
 [build-system]

--- a/lib/ethpy/pyproject.toml
+++ b/lib/ethpy/pyproject.toml
@@ -15,21 +15,11 @@ classifiers = [
     "License :: OSI Approved :: Apache License 2.0",
     "Operating System :: OS Independent",
 ]
-
-[project.optional-dependencies]
-# This flag installs all dependencies and should be run when installing this subpackage in isolation
-with-dependencies = [
-    "ethpy[base, lateral]"
-]
-base = [
+dependencies = [
     "fixedpointmath",
     "numpy",
     "python-dotenv",
     "web3",
-]
-lateral = [
-    # Lateral dependencies across subpackages are pointing to github
-    "hypertypes[with-dependencies] @ git+https://github.com/delvtech/agent0.git/#subdirectory=lib/hypertypes",
 ]
 
 [project.urls]

--- a/lib/hyperlogs/pyproject.toml
+++ b/lib/hyperlogs/pyproject.toml
@@ -16,14 +16,6 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
-[project.optional-dependencies]
-# This flag installs all dependencies and should be ran when installing this subpackage in isolation
-with-dependencies = [
-    "hyperlogs[base, lateral]"
-]
-base = []
-lateral = []
-
 [build-system]
 requires = ["flit_core>=3.2"]
 build-backend = "flit_core.buildapi"

--- a/lib/hypertypes/pyproject.toml
+++ b/lib/hypertypes/pyproject.toml
@@ -10,10 +10,10 @@ classifiers = [
     "License :: OSI Approved :: Apache License 2.0",
     "Operating System :: OS Independent",
 ]
-
-[project.optional-dependencies]
-with-dependencies = ["hypertypes[base]"]
-base = ["web3", "pypechain"]
+dependencies = [
+    "web3",
+    "pypechain",
+]
 
 [build-system]
 requires = ["flit_core>=3.2"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@
 -e lib/chainsync[base]
 -e lib/ethpy[base]
 -e lib/hypertypes[base]
---find-links="packages/hyperdrivepy"
+--find-links=packages/hyperdrivepy
 hyperdrivepy
 rollbar


### PR DESCRIPTION
./install_with_pip.sh  31.08s user 3.95s system 93% cpu 37.321 total
./install_with_pip_no_cache.sh  37.59s user 5.75s system 85% cpu 50.785 total
./install_with_uv.sh  0.80s user 3.19s system 336% cpu 1.184 total
./install_with_uv_no_cache.sh  5.12s user 4.71s system 209% cpu 4.697 total

<table>
<th>
 <td>pip
 <td>uv
 <td>speedup
<tr>
 <td>no cache
 <td>51s
 <td>4.7s
 <td>11x
<tr>
 <td>with cache
 <td>37s
 <td>1.2s
 <td>31x
</table>

install_with_uv.sh:
```bash
uv venv .venv -p 3.10
source .venv/bin/activate
uv pip install -r requirements.txt
uv pip install -r requirements-dev.txt
```

install_with_uv_no_cache.sh:
```bash
uv venv .venv -p 3.10
source .venv/bin/activate
uv pip install --no-cache -r requirements.txt
uv pip install --no-cache -r requirements-dev.txt
```

for pip I use uv for environment management here, since I don't have pyenv installed and require 3.10
install_with_pip.sh:
```bash
uv venv .venv -p 3.10
source .venv/bin/activate
uv pip install pip
python -m pip install --upgrade pip
python -m pip install --upgrade -r requirements.txt
python -m pip install --upgrade -r requirements-dev.txt
```

install_with_pip_no_cache.sh:
```bash
uv venv .venv -p 3.10
source .venv/bin/activate
uv pip install pip
python -m pip install --upgrade pip
python -m pip cache purge
python -m pip install --upgrade -r requirements.txt
python -m pip install --upgrade -r requirements-dev.txt
```

results in 5 editable packages installed, as previously:
```
agent0                        0.0.0             /code/elfpy/lib/agent0
chainsync                     0.0.0             /code/elfpy/lib/chainsync
ethpy                         0.0.0             /code/elfpy/lib/ethpy
hyperlogs                     0.0.0             /code/elfpy/lib/hyperlogs
hypertypes                    0.0.0             /code/elfpy/lib/hypertypes
```