### PR TITLE
update README; docs; autoupload

### DIFF
--- a/.github/workflows/build_and_upload.yml
+++ b/.github/workflows/build_and_upload.yml
@@ -1,0 +1,77 @@
+name: build and upload wheels
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  detect-version-changes:
+    uses: ./.github/workflows/check_version.yml
+    with:
+      file_path: crates/hyperdrivepy/pyproject.toml
+
+  build-wheels:
+    needs: detect-version-changes
+    # Run on main if version has changed
+    if: needs.detect-version-changes.outputs.version_changed == 'true'
+    name: build wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{github.token}}
+
+      - name: set up python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+          token: ${{github.token}}
+
+      - name: set up pip
+        run: python -m pip install --upgrade pip
+
+      - name: build hyperdrivepy
+        shell: bash
+        run: source scripts/build_wheels.sh
+
+      - name: upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-linux
+          path: ./wheelhouse/*.whl
+
+  build-sdist:
+    needs: detect-version-changes
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    # Run on main if version has changed
+    if: needs.detect-version-changes.outputs.version_changed == 'true'
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-sdist
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build-wheels, build-sdist, detect-version-changes]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    # Run on main if version has changed
+    if: needs.detect-version-changes.outputs.version_changed == 'true'
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          # unpacks all wheels into dist/
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build_and_upload.yml
+++ b/.github/workflows/build_and_upload.yml
@@ -9,7 +9,7 @@ jobs:
   detect-version-changes:
     uses: ./.github/workflows/check_version.yml
     with:
-      file_path: crates/hyperdrivepy/pyproject.toml
+      file_path: pyproject.toml
 
   build-wheels:
     needs: detect-version-changes
@@ -32,7 +32,7 @@ jobs:
       - name: set up pip
         run: python -m pip install --upgrade pip
 
-      - name: build hyperdrivepy
+      - name: build agent0
         shell: bash
         run: source scripts/build_wheels.sh
 

--- a/.github/workflows/check_version.yml
+++ b/.github/workflows/check_version.yml
@@ -1,0 +1,65 @@
+name: Check Version
+
+on:
+  workflow_call:
+    inputs:
+      file_path:
+        description: File path to check for version change
+        required: true
+        type: string
+    outputs:
+      version_changed:
+        description: true if the version line in the file has changed
+        value: ${{ jobs.check.outputs.version_changed }}
+      only_patch_version_changed:
+        description: true if only the patch version has changed
+        value: ${{ jobs.check.outputs.only_patch_version_changed }}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      version_changed: ${{ steps.check.outputs.version_changed }}
+      only_patch_version_changed: ${{ steps.check.outputs.only_patch_version_changed }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+          submodules: recursive
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check for version changes
+        id: check
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # For PRs, compare PR head against base branch
+            OLD_VERSION=$(git show ${{ github.event.pull_request.base.sha }}:${{ inputs.file_path }} | grep '^version = ' | cut -d '"' -f 2)
+          else
+            # For direct pushes, compare the last two commits
+            OLD_VERSION=$(git show HEAD~1:${{ inputs.file_path }} | grep '^version = ' | cut -d '"' -f 2)
+          fi
+
+          # `cut` grabs everything inside the ", i.e. the version number x.y.z
+          NEW_VERSION=$(grep '^version = ' ${{ inputs.file_path }} | cut -d '"' -f 2)
+
+          echo "OLD_VERSION=$OLD_VERSION"
+          echo "NEW_VERSION=$NEW_VERSION"
+
+          if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
+            echo "Version has changed."
+            echo "version_changed=true" >> $GITHUB_OUTPUT
+            IFS='.' read -ra OLD_PARTS <<< "$OLD_VERSION"
+            IFS='.' read -ra NEW_PARTS <<< "$NEW_VERSION"
+
+            if [ "${OLD_PARTS[0]}" == "${NEW_PARTS[0]}" ] && [ "${OLD_PARTS[1]}" == "${NEW_PARTS[1]}" ]; then
+              echo "Only the patch version has changed."
+              echo "only_patch_version_changed=true" >> $GITHUB_OUTPUT
+            else
+              echo "Major or minor version has changed."
+              echo "only_patch_version_changed=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "No version change detected."
+            echo "version_changed=false" >> $GITHUB_OUTPUT
+            echo "only_patch_version_changed=false" >> $GITHUB_OUTPUT
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ __pypackages__/
 # build directories
 .build
 *.egg-info
+dist/
+wheelhouse/
 
 # output directory for saved notebook figures
 figs

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,5 +1,11 @@
 # Build
 
+## Python
+
+Run `./scripts/build_wheels.sh` to build the python wheels, which are stored in the `wheelhouse` folder.
+
+## Docker
+
 We use Docker to manage our build environment.
 
 To build a local image, make sure you have Docker installed and running, then use:

--- a/BUILD.md
+++ b/BUILD.md
@@ -2,13 +2,11 @@
 
 We use Docker to manage our build environment.
 
-This requires access to the private hyperdrive repo, available only to Delv team members currently.
-
 To build a local image, make sure you have Docker installed and running, then use:
 
 ```bash
-chmod +x build_local_docker_image.sh
-./build_local_docker_image.sh
+chmod +x scripts/build_local_docker_image.sh
+./scripts/build_local_docker_image.sh
 ```
 
 If built successfully, a `docker image ls` command should look like this:
@@ -18,8 +16,7 @@ REPOSITORY    TAG       IMAGE ID       CREATED          SIZE
 agent0        latest    fd84351979d7   21 minutes ago   2.04GB
 ```
 
-This image receives the `agent0` tag and can be reference with`image: agent0:latest`,
-for instance if you're using Docker Compose.
+This image receives the `agent0` tag and can be reference with`image: agent0:latest`, for instance if you're using Docker Compose.
 To build a local image and push it to ghcr.io, make sure you have Docker installed and running, then use:
 
 ```bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,12 @@ COPY . ./
 RUN apt-get update && \
   apt-get install -y --no-install-recommends gcc python3-dev libssl-dev git && \
   python -m pip install --no-cache-dir --upgrade pip && \
+<<<<<<< HEAD
   python -m pip install --no-cache-dir . && \
+=======
+  python -m pip install --no-cache-dir uv && \
+  python -m uv pip install --no-cache-dir agent0@.[all] && \
+>>>>>>> e030f8e9 (remove hyperdrivepy txt install)
   apt-get remove -y gcc python3-dev libssl-dev && \
   apt-get autoremove -y && \
   pip uninstall pipenv -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,7 @@ COPY . ./
 RUN apt-get update && \
   apt-get install -y --no-install-recommends gcc python3-dev libssl-dev git && \
   python -m pip install --no-cache-dir --upgrade pip && \
-  python -m pip install --no-cache-dir uv && \
-  python -m uv pip install --no-cache-dir agent0@.[all] && \
+  python -m pip install --no-cache-dir . && \
   apt-get remove -y gcc python3-dev libssl-dev && \
   apt-get autoremove -y && \
   pip uninstall pipenv -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,8 @@ COPY . ./
 RUN apt-get update && \
   apt-get install -y --no-install-recommends gcc python3-dev libssl-dev git && \
   python -m pip install --no-cache-dir --upgrade pip && \
-<<<<<<< HEAD
-  python -m pip install --no-cache-dir . && \
-=======
   python -m pip install --no-cache-dir uv && \
   python -m uv pip install --no-cache-dir agent0@.[all] && \
->>>>>>> e030f8e9 (remove hyperdrivepy txt install)
   apt-get remove -y gcc python3-dev libssl-dev && \
   apt-get autoremove -y && \
   pip uninstall pipenv -y

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,8 +27,8 @@ source .venv/bin/activate
 ```bash
 uv pip install -e .
 # uv pip install agent0@. # For non-editable install
-# uv pip install -e .[dev] # For dev and testing tools
-# uv pip install -e .[all] # Install everything
+# uv pip install -e '.[dev]' # For dev and testing tools
+# uv pip install -e '.[all]' # Install everything
 ```
 
 ## 5. Verify

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,4 +31,6 @@ uv pip install -e .
 # uv pip install -e .[all] # Install everything
 ```
 
+## 5. Verify
+
 You can test that everything is working by calling `python -m pytest .`

--- a/README.md
+++ b/README.md
@@ -8,10 +8,7 @@
 [![docs: build](https://readthedocs.org/projects/agent0/badge/?version=latest)](https://agent0.readthedocs.io/en/latest/?badge=latest)
 <br><a href="https://app.codecov.io/gh/delvtech/agent0?displayType=list"><img height="50px" src="https://codecov.io/gh/delvtech/agent0/graphs/sunburst.svg?token=1S60MD42ZP"><a>
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="icons/agent0-dark.svg">
-  <img alt="Agent 0" src="icons/agent0-light.svg">
-</picture>
+<img src="icons/agent0-dark.svg" width="800" alt="agent0"><br>
 
 # [DELV](https://delv.tech) repo for market simulation and analysis
 
@@ -21,7 +18,13 @@ This docs page can be found via [https://agent0.readthedocs.io/en/latest/](https
 
 This repo contains general purpose code for interacting with Ethereum smart contracts.
 However, it was bulit for the primary use case of trading on [Hyperdrive](https://hyperdrive.delv.tech) markets.
-Below is an example for executing Hyperdrive trades in a simulated blockchain environment:
+Using a Python 3.10 environment, you can install agent0 via pip:
+
+```sh
+pip install --upgrade agent0
+```
+
+Next you can execute Hyperdrive trades in a simulated blockchain environment:
 
 ```python
 import datetime
@@ -49,8 +52,6 @@ pool_state.plot(x="block_number", y="longs_outstanding", kind="line")
 See our [tutorial notebook](examples/tutorial.ipynb) for more information, including details on executing trades on remote chains.
 
 ## Install
-
-Install via pip: `pip install agent0`
 
 Please refer to [INSTALL.md](INSTALL.md) for more advanced install options.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-[![](https://codecov.io/gh/delvtech/agent0/branch/main/graph/badge.svg?token=1S60MD42ZP)](https://app.codecov.io/gh/delvtech/agent0?displayType=list)
-[![](https://readthedocs.org/projects/agent0/badge/?version=latest)](https://agent0.readthedocs.io/en/latest/?badge=latest)
-[![](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![](https://img.shields.io/badge/testing-pytest-blue.svg)](https://docs.pytest.org/en/latest/contents.html)
+[![linting: pylint](https://img.shields.io/badge/linting-pylint-yellowgreen)](https://github.com/pylint-dev/pylint)
+[![code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![testing: pytest](https://img.shields.io/badge/testing-pytest-blue.svg)](https://docs.pytest.org/en/latest/contents.html)
+[![license: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-lightgrey)](http://www.apache.org/licenses/LICENSE-2.0)
+[![DELV - Terms of Service](https://img.shields.io/badge/DELV-Terms_of_Service-orange)](https://elementfi.s3.us-east-2.amazonaws.com/element-finance-terms-of-service.pdf)
+
+[![testing: coverage](https://codecov.io/gh/delvtech/agent0/branch/main/graph/badge.svg?token=1S60MD42ZP)](https://app.codecov.io/gh/delvtech/agent0?displayType=list)
+[![docs: build](https://readthedocs.org/projects/agent0/badge/?version=latest)](https://agent0.readthedocs.io/en/latest/?badge=latest)
 <br><a href="https://app.codecov.io/gh/delvtech/agent0?displayType=list"><img height="50px" src="https://codecov.io/gh/delvtech/agent0/graphs/sunburst.svg?token=1S60MD42ZP"><a>
 
 <picture>
@@ -11,10 +15,13 @@
 
 # [DELV](https://delv.tech) repo for market simulation and analysis
 
-This project is a work-in-progress. All code is provided as is and without guarantee.
-The language used in this code and documentation is not intended to, and does not, have any particular financial, legal, or regulatory significance.
-
 This docs page can be found via [https://agent0.readthedocs.io/en/latest/](https://agent0.readthedocs.io/en/latest/).
+
+## Quickstart
+
+This repo contains general purpose code for interacting with Ethereum smart contracts.
+However, it was bulit for the primary use case of trading on [Hyperdrive](https://hyperdrive.delv.tech) markets.
+Below is an example for executing Hyperdrive trades in a simulated blockchain environment:
 
 ```python
 import datetime
@@ -39,11 +46,13 @@ pool_state = interactive_hyperdrive.get_pool_state(coerce_float=True)
 pool_state.plot(x="block_number", y="longs_outstanding", kind="line")
 ```
 
-See our [tutorial notebook](examples/tutorial.ipynb) for more information.
+See our [tutorial notebook](examples/tutorial.ipynb) for more information, including details on executing trades on remote chains.
 
 ## Install
 
-Please refer to [INSTALL.md](INSTALL.md).
+Install via pip: `pip install agent0`
+
+Please refer to [INSTALL.md](INSTALL.md) for more advanced install options.
 
 ## Deployment
 
@@ -51,9 +60,16 @@ Please refer to [BUILD.md](BUILD.md).
 
 ## Testing
 
-We deploy a local anvil chain to run system tests. Therefore, you must [install foundry](https://github.com/foundry-rs/foundry#installatio://github.com/foundry-rs/foundry#installation) as a prerequisite for running tests.
+We deploy a local anvil chain to run system tests.
+Therefore, you must [install foundry](https://github.com/foundry-rs/foundry#installatio://github.com/foundry-rs/foundry#installation) as a prerequisite for running tests.
 
-Testing is achieved with [py.test](https://docs.pytest.org/en/latest/contents.html). You can run all tests from the repository root directory by running `python -m pytest`, or you can pick a specific test in the `tests/` folder with `python -m pytest tests/{test_file.py}`.
+Testing is achieved with [py.test](https://docs.pytest.org/en/latest/contents.html).
+You can run all tests from the repository root directory by running `python -m pytest`, or you can pick a specific test with `python -m pytest {path/to/test_file.py}`.
+General integration-level tests are in the `tests` folder, while more isolated or unit tests are colocated with the files they are testing and end with a `_test.py` suffix.
+
+## Contributions
+
+Please refer to [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Coverage
 
@@ -67,10 +83,22 @@ coverage html
 
 then just open `htmlcov/index.html` to view the report!
 
-## Contributions
-
-Please refer to [CONTRIBUTING.md](CONTRIBUTING.md).
-
 ## Number format
 
 We frequently use 18-decimal [fixed-point precision numbers](https://github.com/delvtech/fixedpointmath#readme) for arithmetic.
+
+## Disclaimer
+
+This project is a work-in-progress.
+The language used in this code and documentation is not intended to, and does not, have any particular financial, legal, or regulatory significance.
+
+---
+
+Copyright © 2024  DELV
+
+Licensed under the Apache License, Version 2.0 (the "OSS License").
+
+By accessing or using this code, you signify that you have read, understand and agree to be bound by and to comply with the [OSS License](http://www.apache.org/licenses/LICENSE-2.0) and [DELV's Terms of Service](https://elementfi.s3.us-east-2.amazonaws.com/element-finance-terms-of-service.pdf). If you do not agree to those terms, you are prohibited from accessing or using this code.
+
+
+Unless required by applicable law or agreed to in writing, software distributed under the OSS License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the OSS License and the DELV Terms of Service for the specific language governing permissions and limitations.

--- a/README.md
+++ b/README.md
@@ -100,5 +100,4 @@ Licensed under the Apache License, Version 2.0 (the "OSS License").
 
 By accessing or using this code, you signify that you have read, understand and agree to be bound by and to comply with the [OSS License](http://www.apache.org/licenses/LICENSE-2.0) and [DELV's Terms of Service](https://elementfi.s3.us-east-2.amazonaws.com/element-finance-terms-of-service.pdf). If you do not agree to those terms, you are prohibited from accessing or using this code.
 
-
 Unless required by applicable law or agreed to in writing, software distributed under the OSS License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the OSS License and the DELV Terms of Service for the specific language governing permissions and limitations.

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -7,3 +7,4 @@
 - Write docstrings in [Numpy format](https://numpydoc.readthedocs.io/en/latest/format.html), with a few tweaks:
   - Use "Arguments" instead of "Parameters".
   - Don't use space before `:` in the type specification. Sphinx and VSCode render it the same, and it's closer to the signature.
+- When in doubt, lean in the direction of verbosity and readability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ name = "agent0"
 version = "0.16.0"
 # Authors are the current, primary stuards of the repo
 # contributors can be found on github
-
 authors = [
     { name = "Dylan Paiton", email = "dylan@delv.tech" },
     { name = "Mihai Cosma", email = "mihai@delv.tech" },
@@ -21,6 +20,8 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
+    "Development Status :: 3 - Alpha",
+    "Natural Language :: English",
 ]
 
 dependencies = [
@@ -88,14 +89,13 @@ all = [
     "agent0[dev,ai,rollbar]",
 ]
 
+[project.urls]
+"Homepage" = "https://agent0.readthedocs.io/en/latest/"
+"Bug Tracker" = "https://github.com/delvtech/agent0/issues"
+
 [build-system]
 requires = ["flit_core>=3.2"]
 build-backend = "flit_core.buildapi"
-
-[project.urls]
-"Homepage" = "https://github.com/delvtech/agent0"
-"Bug Tracker" = "https://github.com/delvtech/agent0/issues"
-
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent0"
-version = "0.16.0"
+version = "0.16.1"
 # Authors are the current, primary stuards of the repo
 # contributors can be found on github
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,45 +24,46 @@ classifiers = [
 ]
 
 dependencies = [
-    "fixedpointmath",
-    "numpy",
-    "python-dotenv",
-    # will include eth- packages
-    "web3",
-    "hexbytes",
-    "pandas",
-    "nest_asyncio",
-    "rollbar",
     "dill",
-    "matplotlib",
-    "mplfinance",
-    "streamlit",
+    "docker",
+    "fixedpointmath",
     "flask",
     "flask-expects-json",
+    "hexbytes",
+    "hyperdrivepy",
+    "ipython",
+    "matplotlib",
+    "mplfinance",
+    "nest_asyncio",
+    "numpy",
+    "pandas",
+    "pandas-stubs",
     "psycopg[binary]",
+    "pytest",
+    "python-dotenv",
+    "requests",
+    "rollbar",
+    "streamlit",
     "sqlalchemy",
     "sqlalchemy-utils",
-    "pandas-stubs",
-    "requests",
-    "docker",
-    "pytest",
-    "ipython",
-    "hyperdrivepy",
+    "web3",
 ]
 
 
 [project.optional-dependencies]
 dev = [
-    "pypechain",
     "autodocsumm>=0.2.11",
     "black==24.*",
     "coverage",
+    "ipykernel",
     "jupytext",
     "myst-parser>=2.0.0",
     "nbconvert",
     "nbsphinx>=0.8.12",
     "numpydoc>=1.5.0",
     "pylint",
+    "pypechain",
+    "pytest-postgresql",
     "pyright",
     "sphinx>=6",
     "sphinx-autoapi>=2.0.1",
@@ -70,16 +71,13 @@ dev = [
     "sphinx-rtd-theme>=1.2.2",
     "sphinxcontrib-napoleon>=0.7",
     "tomli>=2.0.1",
-    # urllib3 v2 requires OpenSSL v1.1.1+, but Vercel uses v1.0.2
-    "urllib3<2.0",
-    "pytest-postgresql",
-    "ipykernel",
+    "urllib3",
 ]
 
 ai = [
     "gymnasium",
-    "stable-baselines3",
     "scipy",
+    "stable-baselines3",
 ]
 
 rollbar = [
@@ -117,8 +115,7 @@ line-length = 120
 extend-exclude = "\\.ipynb"
 
 [tool.pylint]
-exclude = [".venv", ".vscode", "docs", "src/agent0/hypertypes/types/"
-]
+exclude = [".venv", ".vscode", "docs", "src/agent0/hypertypes/types/"]
 
 [tool.pylance]
 exclude = [".venv", ".vscode", "docs"]

--- a/scripts/build_wheels.sh
+++ b/scripts/build_wheels.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# agent0 install
+
+echo "install required packages for building wheels"
+python -m pip install --upgrade pip uv build
+uv pip install agent0@.[all]
+
+echo "build the wheel for the current platform"
+python -m build
+
+# Move remaining wheels into wheelhouse folder
+mv dist/* wheelhouse/

--- a/src/agent0/core/hyperdrive/interactive/i_local_hyperdrive_test.py
+++ b/src/agent0/core/hyperdrive/interactive/i_local_hyperdrive_test.py
@@ -469,7 +469,8 @@ def test_access_deployer_account(chain: ILocalChain):
     privkey = chain.get_deployer_account_private_key()  # anvil account 0
     pubkey = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
     larry = interactive_hyperdrive.init_agent(base=FixedPoint(100_000), name="larry", private_key=privkey)
-    assert larry.wallet.address.hex().startswith(pubkey.lower())  # deployer public key
+    larry_pubkey = larry.wallet.address.hex().strip("0x").lower()
+    assert larry_pubkey == pubkey.lower().strip("0x")  # deployer public key
 
 
 @pytest.mark.anvil


### PR DESCRIPTION
This PR
- various updates to switch to installing hyperdrivepy via pip
- updates the install, build, readme docs (incl  new disclaimer)
- adds the ability to autoupload agent0 to pypi so it can be pip installed

note that I got rid of the urllib dependency version peg; we're not using vercel anymore so this should be fine but we'll want to double check docs build before merging