### PR TITLE
Build and upload wheel hotfix. Version bump to 0.16.2

### DIFF
--- a/.github/workflows/build_and_upload.yml
+++ b/.github/workflows/build_and_upload.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  # FIXME remove after testing in CI
+  pull_request:
+
 
 jobs:
   detect-version-changes:

--- a/.github/workflows/build_and_upload.yml
+++ b/.github/workflows/build_and_upload.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  # FIXME remove after testing in CI
-  pull_request:
-
 
 jobs:
   detect-version-changes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,10 @@ dependencies = [
     "python-dotenv",
     "requests",
     "rollbar",
-    "streamlit",
+    "setuptools",
     "sqlalchemy",
     "sqlalchemy-utils",
+    "streamlit",
     "web3",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent0"
-version = "0.16.1"
+version = "0.16.2"
 # Authors are the current, primary stuards of the repo
 # contributors can be found on github
 authors = [

--- a/scripts/build_wheels.sh
+++ b/scripts/build_wheels.sh
@@ -3,10 +3,10 @@
 # agent0 install
 
 echo "install required packages for building wheels"
-python -m pip install --upgrade pip uv build
+python -m pip install --upgrade pip uv
 uv venv .venv -p 3.10
 source .venv/bin/activate
-uv pip install 'agent0[all]@.'
+uv pip install 'agent0[all]@.' build
 
 echo "build the wheel for the current platform"
 python -m build

--- a/scripts/build_wheels.sh
+++ b/scripts/build_wheels.sh
@@ -12,4 +12,5 @@ echo "build the wheel for the current platform"
 python -m build
 
 # Move remaining wheels into wheelhouse folder
+mkdir -p wheelhouse/
 mv dist/* wheelhouse/

--- a/scripts/build_wheels.sh
+++ b/scripts/build_wheels.sh
@@ -4,7 +4,9 @@
 
 echo "install required packages for building wheels"
 python -m pip install --upgrade pip uv build
-uv pip install agent0@.[all]
+uv venv .venv -p 3.10
+source .venv/bin/activate
+uv pip install 'agent0[all]@.'
 
 echo "build the wheel for the current platform"
 python -m build


### PR DESCRIPTION
- Fixing build wheels script.
- Adding missing requirement for base install.
- Version bump to 0.16.2 to kick off building wheel.
- Added correct permissions to pypi for upload