### PR TITLE
add typing to BasePolicy.config

### DIFF
--- a/src/agent0/core/base/policies/base.py
+++ b/src/agent0/core/base/policies/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from textwrap import dedent, indent
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 from fixedpointmath import FixedPoint
 from numpy.random import default_rng
@@ -43,10 +43,7 @@ class BasePolicy(Generic[MarketInterface, Wallet]):
         policy_config: Config
             The configuration for the policy.
         """
-        # TODO: We add this as a helper property so that subclasses can access the config without
-        # overwriting the __init__ function. The downside is that users of this member variable
-        # can't be type checked. There's probably a way to do this with generics instead of Any.
-        self.config: Any = policy_config
+        self.config: BasePolicy.Config = policy_config
         self.slippage_tolerance = policy_config.slippage_tolerance
         # Generate rng if not set in config
         if policy_config.rng is None:


### PR DESCRIPTION
goal is to implement type narrowing all the way down to the lowest agent and policy level, through the use of generics