### PR TITLE
Adding event queries to db

### DIFF
--- a/examples/interactive_local_hyperdrive_example.py
+++ b/examples/interactive_local_hyperdrive_example.py
@@ -58,7 +58,7 @@ open_long_event_1  # pyright: ignore
 open_long_event_2 = hyperdrive_agent0.open_long(FixedPoint(22222))
 
 # View current wallet
-print(hyperdrive_agent0.wallet)
+print(hyperdrive_agent0.get_positions())
 
 # NOTE these calls are chainwide calls, so all pools connected to this chain gets affected.
 # Advance time, accepts timedelta or seconds
@@ -72,7 +72,7 @@ close_long_event_1 = hyperdrive_agent0.close_long(
     maturity_time=open_long_event_1.maturity_time, bonds=open_long_event_1.bond_amount
 )
 
-agent0_longs = list(hyperdrive_agent0.wallet.longs.values())
+agent0_longs = list(hyperdrive_agent0.get_positions().longs.values())
 close_long_event_2 = hyperdrive_agent0.close_long(
     maturity_time=agent0_longs[0].maturity_time, bonds=agent0_longs[0].balance
 )
@@ -85,7 +85,7 @@ close_short_event = hyperdrive_agent1.close_short(
 
 # LP
 add_lp_event = hyperdrive_agent2.add_liquidity(base=FixedPoint(44444))
-remove_lp_event = hyperdrive_agent2.remove_liquidity(shares=hyperdrive_agent2.wallet.lp_tokens)
+remove_lp_event = hyperdrive_agent2.remove_liquidity(shares=hyperdrive_agent2.get_positions().lp_tokens)
 
 # The above trades doesn't result in withdraw shares, but the function below allows you
 # to withdrawal shares from the pool.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ exclude = [".venv", ".vscode", "docs"]
 
 [tool.isort]
 line_length = 120
+multi_line_output=3
 
 [tool.ruff]
 line-length = 120

--- a/src/agent0/chainsync/db/hyperdrive/__init__.py
+++ b/src/agent0/chainsync/db/hyperdrive/__init__.py
@@ -1,6 +1,6 @@
 """Hyperdrive database utilities."""
 
-from .chain_to_db import data_chain_to_db, init_data_chain_to_db, transfer_events_to_db
+from .chain_to_db import data_chain_to_db, init_data_chain_to_db, trade_events_to_db
 from .convert_data import (
     convert_checkpoint_info,
     convert_hyperdrive_transactions_for_block,

--- a/src/agent0/chainsync/db/hyperdrive/__init__.py
+++ b/src/agent0/chainsync/db/hyperdrive/__init__.py
@@ -27,6 +27,7 @@ from .interface import (
     get_positions_from_db,
     get_ticker,
     get_total_wallet_pnl_over_time,
+    get_trade_events,
     get_transactions,
     get_wallet_deltas,
     get_wallet_pnl,

--- a/src/agent0/chainsync/db/hyperdrive/__init__.py
+++ b/src/agent0/chainsync/db/hyperdrive/__init__.py
@@ -24,6 +24,7 @@ from .interface import (
     get_pool_analysis,
     get_pool_config,
     get_pool_info,
+    get_positions_from_db,
     get_ticker,
     get_total_wallet_pnl_over_time,
     get_transactions,

--- a/src/agent0/chainsync/db/hyperdrive/__init__.py
+++ b/src/agent0/chainsync/db/hyperdrive/__init__.py
@@ -1,6 +1,6 @@
 """Hyperdrive database utilities."""
 
-from .chain_to_db import data_chain_to_db, init_data_chain_to_db
+from .chain_to_db import data_chain_to_db, init_data_chain_to_db, transfer_events_to_db
 from .convert_data import (
     convert_checkpoint_info,
     convert_hyperdrive_transactions_for_block,
@@ -13,6 +13,7 @@ from .interface import (
     add_pool_config,
     add_pool_infos,
     add_transactions,
+    add_transfer_events,
     add_wallet_deltas,
     get_all_traders,
     get_checkpoint_info,

--- a/src/agent0/chainsync/db/hyperdrive/chain_to_db.py
+++ b/src/agent0/chainsync/db/hyperdrive/chain_to_db.py
@@ -119,6 +119,13 @@ def _event_data_to_dict(in_val: EventData) -> dict[str, Any]:
     out = dict(in_val)
     # The args field is also an attribute dict, change to dict
     out["args"] = dict(in_val["args"])
+    # There are issues with storing very large integers
+    # in the database, so we convert the assetId to a string
+    if "assetId" in out["args"]:
+        out["args"]["assetId"] = str(in_val["args"]["assetId"])
+    if "id" in out["args"]:
+        out["args"]["id"] = str(in_val["args"]["id"])
+
     # Convert transaction hash to string
     out["transactionHash"] = in_val["transactionHash"].to_0x_hex()
     # Get token id field from args.

--- a/src/agent0/chainsync/db/hyperdrive/chain_to_db.py
+++ b/src/agent0/chainsync/db/hyperdrive/chain_to_db.py
@@ -119,12 +119,6 @@ def _event_data_to_dict(in_val: EventData) -> dict[str, Any]:
     out = dict(in_val)
     # The args field is also an attribute dict, change to dict
     out["args"] = dict(in_val["args"])
-    # There are issues with storing very large integers
-    # in the database, so we convert the assetId to a string
-    if "assetId" in out["args"]:
-        out["args"]["assetId"] = str(in_val["args"]["assetId"])
-    if "id" in out["args"]:
-        out["args"]["id"] = str(in_val["args"]["id"])
 
     # Convert transaction hash to string
     out["transactionHash"] = in_val["transactionHash"].to_0x_hex()
@@ -389,7 +383,6 @@ def trade_events_to_db(
         "token_id": "token_id",
         "token_delta": "token_delta",
         "base_delta": "base_delta",
-        "args": "event_json",
     }
 
     events_df = events_df[list(rename_dict.keys())].rename(columns=rename_dict)

--- a/src/agent0/chainsync/db/hyperdrive/chain_to_db.py
+++ b/src/agent0/chainsync/db/hyperdrive/chain_to_db.py
@@ -151,7 +151,8 @@ def trade_events_to_db(
     # Get the earliest block to get events from
     # TODO can narrow this down to the last block we checked
     # For now, keep this as the latest entry of this wallet.
-    latest_db_block_entry = get_latest_block_number_from_trade_event(db_session, wallet_addr)
+    # + 1 since the queries are inclusive
+    from_block = get_latest_block_number_from_trade_event(db_session, wallet_addr) + 1
 
     # Gather all events we care about here
     # Transfers to and from wallet address
@@ -161,57 +162,57 @@ def trade_events_to_db(
 
     for interface in interfaces:
         events = interface.hyperdrive_contract.events.TransferSingle.get_logs(
-            fromBlock=latest_db_block_entry,
+            fromBlock=from_block,
             argument_filters={"to": wallet_addr},
         )
         # Change events from attribute dict to dictionary
         all_events.extend([_event_data_to_dict(event) for event in events])
 
         events = interface.hyperdrive_contract.events.TransferSingle.get_logs(
-            fromBlock=latest_db_block_entry,
+            fromBlock=from_block,
             argument_filters={"from": wallet_addr},
         )
         all_events.extend([_event_data_to_dict(event) for event in events])
 
         # Hyperdrive events
         events = interface.hyperdrive_contract.events.OpenLong.get_logs(
-            fromBlock=latest_db_block_entry,
+            fromBlock=from_block,
             argument_filters={"trader": wallet_addr},
         )
         all_events.extend([_event_data_to_dict(event) for event in events])
 
         events = interface.hyperdrive_contract.events.CloseLong.get_logs(
-            fromBlock=latest_db_block_entry,
+            fromBlock=from_block,
             argument_filters={"trader": wallet_addr},
         )
         all_events.extend([_event_data_to_dict(event) for event in events])
 
         events = interface.hyperdrive_contract.events.OpenShort.get_logs(
-            fromBlock=latest_db_block_entry,
+            fromBlock=from_block,
             argument_filters={"trader": wallet_addr},
         )
         all_events.extend([_event_data_to_dict(event) for event in events])
 
         events = interface.hyperdrive_contract.events.CloseShort.get_logs(
-            fromBlock=latest_db_block_entry,
+            fromBlock=from_block,
             argument_filters={"trader": wallet_addr},
         )
         all_events.extend([_event_data_to_dict(event) for event in events])
 
         events = interface.hyperdrive_contract.events.AddLiquidity.get_logs(
-            fromBlock=latest_db_block_entry,
+            fromBlock=from_block,
             argument_filters={"provider": wallet_addr},
         )
         all_events.extend([_event_data_to_dict(event) for event in events])
 
         events = interface.hyperdrive_contract.events.RemoveLiquidity.get_logs(
-            fromBlock=latest_db_block_entry,
+            fromBlock=from_block,
             argument_filters={"provider": wallet_addr},
         )
         all_events.extend([_event_data_to_dict(event) for event in events])
 
         events = interface.hyperdrive_contract.events.RedeemWithdrawalShares.get_logs(
-            fromBlock=latest_db_block_entry,
+            fromBlock=from_block,
             argument_filters={"provider": wallet_addr},
         )
         all_events.extend([_event_data_to_dict(event) for event in events])

--- a/src/agent0/chainsync/db/hyperdrive/chain_to_db.py
+++ b/src/agent0/chainsync/db/hyperdrive/chain_to_db.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any
 
+import numpy as np
 import pandas as pd
 from fixedpointmath import FixedPoint
 from sqlalchemy.orm import Session
@@ -316,6 +317,9 @@ def trade_events_to_db(
         events_df.loc[events_idx, "token_id"] = "LP"
         # The wallet here is the "provider" column, we remap it to "trader"
         events_df.loc[events_idx, "trader"] = events_df.loc[events_idx, "provider"]
+        # We explicitly add a maturity time here to ensure this column exists
+        # if there were no longs in this event set.
+        events_df.loc[events_idx, "maturityTime"] = np.nan
 
     events_idx = events_df["event"] == "AddLiquidity"
     if events_idx.any():
@@ -354,6 +358,9 @@ def trade_events_to_db(
         events_df.loc[events_idx, "token_id"] = "WITHDRAWAL_SHARE"
         # The wallet here is the "provider" column, we remap it to "trader"
         events_df.loc[events_idx, "trader"] = events_df.loc[events_idx, "provider"]
+        # We explicitly add a maturity time here to ensure this column exists
+        # if there were no longs in this event set.
+        events_df.loc[events_idx, "maturityTime"] = np.nan
         # Pandas apply doesn't play nice with types
         events_df.loc[events_idx, "token_delta"] = -events_df.loc[events_idx, "withdrawalShareAmount"].apply(
             lambda x: Decimal(x) / Decimal(1e18)  # type: ignore

--- a/src/agent0/chainsync/db/hyperdrive/chain_to_db.py
+++ b/src/agent0/chainsync/db/hyperdrive/chain_to_db.py
@@ -130,6 +130,7 @@ def _event_data_to_dict(in_val: EventData) -> dict[str, Any]:
 # TODO cleanup
 # pylint: disable=too-many-branches
 # pylint: disable=too-many-statements
+# pylint: disable=too-many-locals
 def trade_events_to_db(
     interfaces: list[HyperdriveReadInterface],
     wallet_addr: str,

--- a/src/agent0/chainsync/db/hyperdrive/chain_to_db.py
+++ b/src/agent0/chainsync/db/hyperdrive/chain_to_db.py
@@ -45,7 +45,7 @@ def init_data_chain_to_db(
         The database session
     """
     pool_config_dict = asdict(interface.current_pool_state.pool_config)
-    pool_config_dict["contract_address"] = interface.hyperdrive_address
+    pool_config_dict["hyperdrive_address"] = interface.hyperdrive_address
     fees = pool_config_dict["fees"]
     pool_config_dict["curve_fee"] = fees["curve"]
     pool_config_dict["flat_fee"] = fees["flat"]

--- a/src/agent0/chainsync/db/hyperdrive/chain_to_db.py
+++ b/src/agent0/chainsync/db/hyperdrive/chain_to_db.py
@@ -242,9 +242,9 @@ def trade_events_to_db(
     # if this wallet is the initializer of the pool.
     # TODO we have a test for initializer of the pool, but we need to implement
     # wallet to wallet transfers of tokens in the interactive interface for a full test
-    transfer_events_trx_hash = (
-        (unique_events_per_transaction["nunique"] < 2).to_frame().reset_index()["transactionHash"]
-    )
+    transfer_events_trx_hash = unique_events_per_transaction[
+        unique_events_per_transaction["nunique"] < 2
+    ].reset_index()["transactionHash"]
     transfer_events_df = events_df[events_df["transactionHash"].isin(transfer_events_trx_hash)].copy()
     if len(transfer_events_df) > 0:
         # Expand the args dict without losing the args dict field
@@ -254,7 +254,7 @@ def trade_events_to_db(
         # We apply the decode function to each element, then expand the resulting
         # tuple to multiple columns
         transfer_events_df["token_type"], transfer_events_df["maturityTime"] = zip(
-            *transfer_events_df["id"].apply(decode_asset_id)
+            *transfer_events_df["id"].astype(int).apply(decode_asset_id)
         )
         # Convert token_type enum to name
         transfer_events_df["token_type"] = transfer_events_df["token_type"].apply(lambda x: AssetIdPrefix(x).name)

--- a/src/agent0/chainsync/db/hyperdrive/chain_to_db.py
+++ b/src/agent0/chainsync/db/hyperdrive/chain_to_db.py
@@ -26,8 +26,9 @@ from .interface import (
     add_pool_infos,
     add_transactions,
     add_wallet_deltas,
-    get_latest_block_number_from_transfer_event,
+    get_latest_block_number_from_trade_event,
 )
+from .schema import TradeEvent
 
 
 def init_data_chain_to_db(
@@ -127,7 +128,7 @@ def _event_data_to_dict(in_val: EventData) -> dict[str, Any]:
 # TODO cleanup
 # pylint: disable=too-many-branches
 # pylint: disable=too-many-statements
-def transfer_events_to_db(
+def trade_events_to_db(
     interfaces: list[HyperdriveReadInterface],
     wallet_addr: str,
     db_session: Session,
@@ -149,7 +150,7 @@ def transfer_events_to_db(
     # Get the earliest block to get events from
     # TODO can narrow this down to the last block we checked
     # For now, keep this as the latest entry of this wallet.
-    latest_db_block_entry = get_latest_block_number_from_transfer_event(db_session, wallet_addr)
+    latest_db_block_entry = get_latest_block_number_from_trade_event(db_session, wallet_addr)
 
     # Gather all events we care about here
     # Transfers to and from wallet address
@@ -378,4 +379,4 @@ def transfer_events_to_db(
 
     events_df = events_df[list(rename_dict.keys())].rename(columns=rename_dict)
     # Add to db
-    df_to_db(events_df, HyperdriveEvent, db_session)
+    df_to_db(events_df, TradeEvent, db_session)

--- a/src/agent0/chainsync/db/hyperdrive/import_export_data.py
+++ b/src/agent0/chainsync/db/hyperdrive/import_export_data.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Type
 
 import pandas as pd
 from sqlalchemy import exc
@@ -12,12 +11,12 @@ from sqlalchemy.orm import Session
 
 from agent0.chainsync.db.base import (
     AddrToUsername,
-    Base,
     UsernameToUser,
     get_addr_to_username,
     get_username_to_user,
     initialize_session,
 )
+from agent0.chainsync.df_to_db import df_to_db
 
 from .interface import (
     get_checkpoint_info,
@@ -39,11 +38,10 @@ from .schema import (
     PoolConfig,
     PoolInfo,
     Ticker,
+    TradeEvent,
     WalletDelta,
     WalletPNL,
 )
-
-MAX_BATCH_SIZE = 10000
 
 
 def export_db_to_file(out_dir: str, db_session: Session | None = None, raw: bool = False) -> None:
@@ -162,6 +160,7 @@ def import_to_db(db_session: Session, in_dir: str, drop=True) -> None:
     if drop:
         db_session.query(AddrToUsername).delete()
         db_session.query(UsernameToUser).delete()
+        db_session.query(TradeEvent).delete()
         db_session.query(PoolConfig).delete()
         db_session.query(CheckpointInfo).delete()
         db_session.query(PoolInfo).delete()
@@ -179,40 +178,15 @@ def import_to_db(db_session: Session, in_dir: str, drop=True) -> None:
             raise err
 
     out = import_to_pandas(in_dir)
-    _df_to_db(out["addr_to_username"], AddrToUsername, db_session)
-    _df_to_db(out["username_to_user"], UsernameToUser, db_session)
-    _df_to_db(out["pool_config"], PoolConfig, db_session)
-    _df_to_db(out["checkpoint_info"], CheckpointInfo, db_session)
-    _df_to_db(out["pool_info"], PoolInfo, db_session)
-    _df_to_db(out["wallet_delta"], WalletDelta, db_session)
-    _df_to_db(out["transactions"], HyperdriveTransaction, db_session)
-    _df_to_db(out["pool_analysis"], PoolAnalysis, db_session)
-    _df_to_db(out["current_wallet"], CurrentWallet, db_session)
-    _df_to_db(out["ticker"], Ticker, db_session)
-    _df_to_db(out["wallet_pnl"], WalletPNL, db_session)
-
-
-def _df_to_db(insert_df: pd.DataFrame, schema_obj: Type[Base], session: Session):
-    """Helper function to add a dataframe to a database"""
-    table_name = schema_obj.__tablename__
-
-    # dataframe to_sql needs data types from the schema object
-    dtype = {c.name: c.type for c in schema_obj.__table__.columns}
-    # Pandas doesn't play nice with types
-    insert_df.to_sql(
-        table_name,
-        con=session.connection(),
-        method="multi",
-        # if_exists=if_exists_method,
-        if_exists="append",
-        index=False,
-        dtype=dtype,  # type: ignore
-        chunksize=MAX_BATCH_SIZE,
-    )
-    # commit the transaction
-    try:
-        session.commit()
-    except exc.DataError as err:
-        session.rollback()
-        logging.error("Error on adding %s: %s", table_name, err)
-        raise err
+    df_to_db(out["addr_to_username"], AddrToUsername, db_session)
+    df_to_db(out["username_to_user"], UsernameToUser, db_session)
+    df_to_db(out["trade_event"], TradeEvent, db_session)
+    df_to_db(out["pool_config"], PoolConfig, db_session)
+    df_to_db(out["checkpoint_info"], CheckpointInfo, db_session)
+    df_to_db(out["pool_info"], PoolInfo, db_session)
+    df_to_db(out["wallet_delta"], WalletDelta, db_session)
+    df_to_db(out["transactions"], HyperdriveTransaction, db_session)
+    df_to_db(out["pool_analysis"], PoolAnalysis, db_session)
+    df_to_db(out["current_wallet"], CurrentWallet, db_session)
+    df_to_db(out["ticker"], Ticker, db_session)
+    df_to_db(out["wallet_pnl"], WalletPNL, db_session)

--- a/src/agent0/chainsync/db/hyperdrive/import_export_data.py
+++ b/src/agent0/chainsync/db/hyperdrive/import_export_data.py
@@ -26,6 +26,7 @@ from .interface import (
     get_pool_config,
     get_pool_info,
     get_ticker,
+    get_trade_events,
     get_transactions,
     get_wallet_deltas,
     get_wallet_pnl,
@@ -76,6 +77,9 @@ def export_db_to_file(out_dir: str, db_session: Session | None = None, raw: bool
     get_username_to_user(db_session).to_parquet(
         os.path.join(out_dir, "username_to_user.parquet"), index=False, engine="pyarrow"
     )
+
+    # Agent event tables
+    get_trade_events(db_session).to_parquet(os.path.join(out_dir, "trade_event.parquet"), index=False, engine="pyarrow")
 
     # Hyperdrive tables
     get_pool_config(db_session, coerce_float=False).to_parquet(
@@ -128,6 +132,7 @@ def import_to_pandas(in_dir: str) -> dict[str, pd.DataFrame]:
 
     out["addr_to_username"] = pd.read_parquet(os.path.join(in_dir, "addr_to_username.parquet"), engine="pyarrow")
     out["username_to_user"] = pd.read_parquet(os.path.join(in_dir, "username_to_user.parquet"), engine="pyarrow")
+    out["trade_event"] = pd.read_parquet(os.path.join(in_dir, "trade_event.parquet"), engine="pyarrow")
     out["pool_config"] = pd.read_parquet(os.path.join(in_dir, "pool_config.parquet"), engine="pyarrow")
     out["checkpoint_info"] = pd.read_parquet(os.path.join(in_dir, "checkpoint_info.parquet"), engine="pyarrow")
     out["pool_info"] = pd.read_parquet(os.path.join(in_dir, "pool_info.parquet"), engine="pyarrow")

--- a/src/agent0/chainsync/db/hyperdrive/import_export_data_test.py
+++ b/src/agent0/chainsync/db/hyperdrive/import_export_data_test.py
@@ -19,7 +19,7 @@ class TestExportImportData:
         """Testing retrieval of transaction via interface"""
         # Write data to database
         # Ensuring decimal format gets preserved
-        pool_config = PoolConfig(contract_address="0", initial_vault_share_price=Decimal("3.22222222222222"))
+        pool_config = PoolConfig(hyperdrive_address="0", initial_vault_share_price=Decimal("3.22222222222222"))
         add_pool_config(pool_config, db_session)
         # We need pool config as a dataframe, so we read it from the db here
         pool_config_in = get_pool_config(db_session, coerce_float=False)

--- a/src/agent0/chainsync/db/hyperdrive/interface.py
+++ b/src/agent0/chainsync/db/hyperdrive/interface.py
@@ -54,6 +54,7 @@ def get_latest_block_number_from_trade_event(session: Session, wallet_addr: str)
         The initialized session object.
     wallet_addr: str
         The wallet address to filter the results on.
+
     Returns
     -------
     int
@@ -66,15 +67,24 @@ def get_latest_block_number_from_trade_event(session: Session, wallet_addr: str)
     return int(query)
 
 
-def get_trade_events(session: Session):
+def get_trade_events(session: Session, wallet_addr: str | None = None) -> pd.DataFrame:
     """Get all trade events and returns as a pandas dataframe.
 
     Arguments
     ---------
     session: Session
         The initialized db session object.
+    wallet_addr: str | None, optional
+        The wallet address to filter the results on. Return all if None
+
+    Returns
+    -------
+    DataFrame
+        A DataFrame that consists of the queried trade events data
     """
     query = session.query(TradeEvent)
+    if wallet_addr is not None:
+        query = query.filter(TradeEvent.wallet_address == wallet_addr)
     return pd.read_sql(query.statement, con=session.connection(), coerce_float=False)
 
 

--- a/src/agent0/chainsync/db/hyperdrive/interface.py
+++ b/src/agent0/chainsync/db/hyperdrive/interface.py
@@ -14,12 +14,12 @@ from agent0.ethpy.hyperdrive import BASE_TOKEN_SYMBOL
 from .schema import (
     CheckpointInfo,
     CurrentWallet,
-    HyperdriveEvent,
     HyperdriveTransaction,
     PoolAnalysis,
     PoolConfig,
     PoolInfo,
     Ticker,
+    TradeEvent,
     WalletDelta,
     WalletPNL,
 )
@@ -27,7 +27,7 @@ from .schema import (
 # Event Data Ingestion Interface
 
 
-def add_transfer_events(transfer_events: list[HyperdriveEvent], session: Session) -> None:
+def add_transfer_events(transfer_events: list[TradeEvent], session: Session) -> None:
     """Add transfer events to the transfer events table.
     Arguments
     ---------
@@ -46,7 +46,7 @@ def add_transfer_events(transfer_events: list[HyperdriveEvent], session: Session
         raise err
 
 
-def get_latest_block_number_from_transfer_event(session: Session, wallet_addr: str) -> int:
+def get_latest_block_number_from_trade_event(session: Session, wallet_addr: str) -> int:
     """Get the latest block number based on the hyperdrive events table in the db.
     Arguments
     ---------
@@ -60,11 +60,7 @@ def get_latest_block_number_from_transfer_event(session: Session, wallet_addr: s
         The latest block number in the hyperdrive_events table.
     """
 
-    query = (
-        session.query(func.max(HyperdriveEvent.block_number))
-        .filter(HyperdriveEvent.wallet_address == wallet_addr)
-        .scalar()
-    )
+    query = session.query(func.max(TradeEvent.block_number)).filter(TradeEvent.wallet_address == wallet_addr).scalar()
     if query is None:
         return 0
     return int(query)

--- a/src/agent0/chainsync/db/hyperdrive/interface.py
+++ b/src/agent0/chainsync/db/hyperdrive/interface.py
@@ -29,6 +29,7 @@ from .schema import (
 
 def add_transfer_events(transfer_events: list[TradeEvent], session: Session) -> None:
     """Add transfer events to the transfer events table.
+
     Arguments
     ---------
     transfer_events: list[HyperdriveTransferEvent]
@@ -48,6 +49,7 @@ def add_transfer_events(transfer_events: list[TradeEvent], session: Session) -> 
 
 def get_latest_block_number_from_trade_event(session: Session, wallet_addr: str) -> int:
     """Get the latest block number based on the hyperdrive events table in the db.
+
     Arguments
     ---------
     session: Session
@@ -68,19 +70,19 @@ def get_latest_block_number_from_trade_event(session: Session, wallet_addr: str)
 
 
 def get_trade_events(session: Session, wallet_addr: str | None = None) -> pd.DataFrame:
-    """Get all trade events and returns as a pandas dataframe.
+    """Get all trade events and returns a pandas dataframe.
 
     Arguments
     ---------
     session: Session
         The initialized db session object.
     wallet_addr: str | None, optional
-        The wallet address to filter the results on. Return all if None
+        The wallet address to filter the results on. Return all if None.
 
     Returns
     -------
     DataFrame
-        A DataFrame that consists of the queried trade events data
+        A DataFrame that consists of the queried trade events data.
     """
     query = session.query(TradeEvent)
     if wallet_addr is not None:
@@ -97,13 +99,13 @@ def get_positions_from_db(session: Session, wallet_addr: str, hyperdrive_address
         The initialized db session object.
     wallet_addr: str
         The wallet address to filter the results on.
-    hyperdrive_address: str
-        The hyperdrive address to filter the results on.
+    hyperdrive_address: str | None, optional
+        The hyperdrive address to filter the results on. Returns all if None.
 
     Returns
     -------
     DataFrame
-        A DataFrame that consists of the queried pool info data
+        A DataFrame that consists of the queried pool info data.
     """
     # TODO also accept and filter by hyperdrive address here
     # when we move to multi-pool db support
@@ -134,9 +136,9 @@ def add_transactions(transactions: list[HyperdriveTransaction], session: Session
     Arguments
     ---------
     transactions: list[HyperdriveTransaction]
-        A list of HyperdriveTransaction objects to insert into postgres
+        A list of HyperdriveTransaction objects to insert into postgres.
     session: Session
-        The initialized session object
+        The initialized session object.
     """
     for transaction in transactions:
         session.add(transaction)
@@ -149,21 +151,21 @@ def add_transactions(transactions: list[HyperdriveTransaction], session: Session
 
 
 def get_pool_config(session: Session, contract_address: str | None = None, coerce_float=True) -> pd.DataFrame:
-    """Get all pool config and returns as a pandas dataframe.
+    """Get all pool config and returns a pandas dataframe.
 
     Arguments
     ---------
     session: Session
-        The initialized session object
+        The initialized session object.
     contract_address: str | None, optional
-        The contract_address to filter the results on. Return all if None
+        The contract_address to filter the results on. Return all if None.
     coerce_float: bool
-        If True, will coerce all numeric columns to float
+        If True, will coerce all numeric columns to float.
 
     Returns
     -------
     DataFrame
-        A DataFrame that consists of the queried pool config data
+        A DataFrame that consists of the queried pool config data.
     """
     query = session.query(PoolConfig)
     if contract_address is not None:
@@ -179,9 +181,9 @@ def add_pool_config(pool_config: PoolConfig, session: Session) -> None:
     Arguments
     ---------
     pool_config: PoolConfig
-        A PoolConfig object to insert into postgres
+        A PoolConfig object to insert into postgres.
     session: Session
-        The initialized session object
+        The initialized session object.
     """
     # NOTE the logic below is not thread safe, i.e., a race condition can exists
     # if multiple threads try to add pool config at the same time
@@ -217,9 +219,9 @@ def add_pool_infos(pool_infos: list[PoolInfo], session: Session) -> None:
     Arguments
     ---------
     pool_infos: list[PoolInfo]
-        A list of PoolInfo objects to insert into postgres
+        A list of PoolInfo objects to insert into postgres.
     session: Session
-        The initialized session object
+        The initialized session object.
     """
     for pool_info in pool_infos:
         session.add(pool_info)
@@ -237,9 +239,9 @@ def add_checkpoint_info(checkpoint_info: CheckpointInfo, session: Session) -> No
     Arguments
     ---------
     checkpoint_info: CheckpointInfo
-        A CheckpointInfo object to insert into postgres
+        A CheckpointInfo object to insert into postgres.
     session: Session
-        The initialized session object
+        The initialized session object.
     """
     # NOTE the logic below is not thread safe, i.e., a race condition can exists
     # if multiple threads try to add checkpoint info at the same time
@@ -273,9 +275,9 @@ def add_wallet_deltas(wallet_deltas: list[WalletDelta], session: Session) -> Non
     Arguments
     ---------
     wallet_deltas: list[WalletDelta]
-        A list of WalletDelta objects to insert into postgres
+        A list of WalletDelta objects to insert into postgres.
     session: Session
-        The initialized session object
+        The initialized session object.
     """
     for wallet_delta in wallet_deltas:
         session.add(wallet_delta)
@@ -293,12 +295,12 @@ def get_latest_block_number_from_pool_info_table(session: Session) -> int:
     Arguments
     ---------
     session: Session
-        The initialized session object
+        The initialized session object.
 
     Returns
     -------
     int
-        The latest block number in the poolinfo table
+        The latest block number in the poolinfo table.
     """
     return get_latest_block_number_from_table(PoolInfo, session)
 
@@ -309,12 +311,12 @@ def get_latest_block_number_from_analysis_table(session: Session) -> int:
     Arguments
     ---------
     session: Session
-        The initialized session object
+        The initialized session object.
 
     Returns
     -------
     int
-        The latest block number in the poolinfo table
+        The latest block number in the poolinfo table.
     """
     return get_latest_block_number_from_table(PoolAnalysis, session)
 
@@ -322,25 +324,25 @@ def get_latest_block_number_from_analysis_table(session: Session) -> int:
 def get_pool_info(
     session: Session, start_block: int | None = None, end_block: int | None = None, coerce_float=True
 ) -> pd.DataFrame:
-    """Get all pool info and returns as a pandas dataframe.
+    """Get all pool info and returns a pandas dataframe.
 
     Arguments
     ---------
     session: Session
-        The initialized session object
+        The initialized session object.
     start_block: int | None, optional
         The starting block to filter the query on. start_block integers
-        matches python slicing notation, e.g., list[:3], list[:-3]
+        matches python slicing notation, e.g., list[:3], list[:-3].
     end_block: int | None, optional
         The ending block to filter the query on. end_block integers
-        matches python slicing notation, e.g., list[:3], list[:-3]
+        matches python slicing notation, e.g., list[:3], list[:-3].
     coerce_float: bool, optional
-        If true, will return floats in dataframe. Otherwise, will return fixed point Decimal
+        If true, will return floats in dataframe. Otherwise, will return fixed point Decimal.
 
     Returns
     -------
     DataFrame
-        A DataFrame that consists of the queried pool info data
+        A DataFrame that consists of the queried pool info data.
     """
     query = session.query(PoolInfo)
 
@@ -367,25 +369,25 @@ def get_transactions(
     end_block: int | None = None,
     coerce_float=True,
 ) -> pd.DataFrame:
-    """Get all transactions and returns as a pandas dataframe.
+    """Get all transactions and returns a pandas dataframe.
 
     Arguments
     ---------
     session: Session
-        The initialized session object
+        The initialized session object.
     start_block: int | None
         The starting block to filter the query on. start_block integers
-        matches python slicing notation, e.g., list[:3], list[:-3]
+        matches python slicing notation, e.g., list[:3], list[:-3].
     end_block: int | None
         The ending block to filter the query on. end_block integers
-        matches python slicing notation, e.g., list[:3], list[:-3]
+        matches python slicing notation, e.g., list[:3], list[:-3].
     coerce_float: bool
-        If true, will return floats in dataframe. Otherwise, will return fixed point Decimal
+        If true, will return floats in dataframe. Otherwise, will return fixed point Decimal.
 
     Returns
     -------
     DataFrame
-        A DataFrame that consists of the queried transactions data
+        A DataFrame that consists of the queried transactions data.
     """
     query = session.query(HyperdriveTransaction)
 
@@ -413,16 +415,16 @@ def get_checkpoint_info(session: Session, checkpoint_time: int | None = None, co
     Arguments
     ---------
     session: Session
-        The initialized session object
+        The initialized session object.
     checkpoint_time: int | None, optional
         The checkpoint time to filter the query on. Defaults to returning all checkpoint infos.
     coerce_float: bool
-        If true, will return floats in dataframe. Otherwise, will return fixed point Decimal
+        If true, will return floats in dataframe. Otherwise, will return fixed point Decimal.
 
     Returns
     -------
     DataFrame
-        A DataFrame that consists of the queried checkpoint info
+        A DataFrame that consists of the queried checkpoint info.
     """
     query = session.query(CheckpointInfo)
 
@@ -442,27 +444,27 @@ def get_wallet_deltas(
     return_timestamp: bool = True,
     coerce_float=True,
 ) -> pd.DataFrame:
-    """Get all wallet_delta data in history and returns as a pandas dataframe.
+    """Get all wallet_delta data in history and returns a pandas dataframe.
 
     Arguments
     ---------
     session: Session
-        The initialized session object
+        The initialized session object.
     start_block: int | None, optional
         The starting block to filter the query on. start_block integers
-        matches python slicing notation, e.g., list[:3], list[:-3]
+        matches python slicing notation, e.g., list[:3], list[:-3].
     end_block: int | None, optional
         The ending block to filter the query on. end_block integers
-        matches python slicing notation, e.g., list[:3], list[:-3]
+        matches python slicing notation, e.g., list[:3], list[:-3].
     return_timestamp: bool, optional
-        Gets timestamps when looking at pool analysis. Defaults to True
+        Gets timestamps when looking at pool analysis. Defaults to True.
     coerce_float: bool
-        If true, will return floats in dataframe. Otherwise, will return fixed point Decimal
+        If true, will return floats in dataframe. Otherwise, will return fixed point Decimal.
 
     Returns
     -------
     DataFrame
-        A DataFrame that consists of the queried wallet info data
+        A DataFrame that consists of the queried wallet info data.
     """
     if return_timestamp:
         query = session.query(PoolInfo.timestamp, WalletDelta)
@@ -495,20 +497,20 @@ def get_all_traders(
     Arguments
     ---------
     session: Session
-        The initialized session object
+        The initialized session object.
     start_block: int | None, optional
         The starting block to filter the query on. start_block integers
-        matches python slicing notation, e.g., list[:3], list[:-3]
+        matches python slicing notation, e.g., list[:3], list[:-3].
     end_block: int | None, optional
         The ending block to filter the query on. end_block integers
-        matches python slicing notation, e.g., list[:3], list[:-3]
+        matches python slicing notation, e.g., list[:3], list[:-3].
     coerce_float: bool
-        If true, will return floats in dataframe. Otherwise, will return fixed point Decimal
+        If true, will return floats in dataframe. Otherwise, will return fixed point Decimal.
 
     Returns
     -------
     list[str]
-        A list of addresses that have made a trade
+        A list of addresses that have made a trade.
     """
     query = session.query(WalletDelta.wallet_address)
     # Support for negative indices
@@ -540,9 +542,9 @@ def add_current_wallet(current_wallet: list[CurrentWallet], session: Session) ->
     Arguments
     ---------
     current_wallet: list[CurrentWallet]
-        A list of CurrentWallet objects to insert into postgres
+        A list of CurrentWallet objects to insert into postgres.
     session: Session
-        The initialized session object
+        The initialized session object.
     """
     for wallet in current_wallet:
         session.add(wallet)
@@ -561,26 +563,26 @@ def get_current_wallet(
     coerce_float=True,
     raw: bool = False,
 ) -> pd.DataFrame:
-    """Get all current wallet data in history and returns as a pandas dataframe.
+    """Get all current wallet data in history and returns a pandas dataframe.
 
     Arguments
     ---------
     session: Session
-        The initialized session object
+        The initialized session object.
     end_block: int | None, optional
         The ending block to filter the query on. end_block integers
-        matches python slicing notation, e.g., list[:3], list[:-3]
+        matches python slicing notation, e.g., list[:3], list[:-3].
     wallet_address: list[str] | None, optional
-        The wallet addresses to filter the query on
+        The wallet addresses to filter the query on.
     coerce_float: bool
-        If true, will return floats in dataframe. Otherwise, will return fixed point Decimal
+        If true, will return floats in dataframe. Otherwise, will return fixed point Decimal.
     raw: bool
         If true, will return the raw data without any adjustments.
 
     Returns
     -------
     DataFrame
-        A DataFrame that consists of the queried wallet info data
+        A DataFrame that consists of the queried wallet info data.
     """
     # TODO this function might not scale, as it's looking across all blocks from the beginning of time
     # Ways to improve: add indexes on wallet_address, token_type, block_number
@@ -634,27 +636,27 @@ def get_pool_analysis(
     return_timestamp: bool = True,
     coerce_float=True,
 ) -> pd.DataFrame:
-    """Get all pool analysis and returns as a pandas dataframe.
+    """Get all pool analysis and returns a pandas dataframe.
 
     Arguments
     ---------
     session: Session
-        The initialized session object
+        The initialized session object.
     start_block: int | None, optional
         The starting block to filter the query on. start_block integers
-        matches python slicing notation, e.g., list[:3], list[:-3]
+        matches python slicing notation, e.g., list[:3], list[:-3].
     end_block: int | None, optional
         The ending block to filter the query on. end_block integers
-        matches python slicing notation, e.g., list[:3], list[:-3]
+        matches python slicing notation, e.g., list[:3], list[:-3].
     return_timestamp: bool, optional
-        Gets timestamps when looking at pool analysis. Defaults to True
+        Gets timestamps when looking at pool analysis. Defaults to True.
     coerce_float: bool
-        If true, will return floats in dataframe. Otherwise, will return fixed point Decimal
+        If true, will return floats in dataframe. Otherwise, will return fixed point Decimal.
 
     Returns
     -------
     DataFrame
-        A DataFrame that consists of the queried pool info data
+        A DataFrame that consists of the queried pool info data.
     """
     if return_timestamp:
         query = session.query(PoolInfo.timestamp, PoolAnalysis)
@@ -691,31 +693,31 @@ def get_ticker(
     sort_desc: bool | None = False,
     coerce_float=True,
 ) -> pd.DataFrame:
-    """Get all pool analysis and returns as a pandas dataframe.
+    """Get all pool analysis and returns a pandas dataframe.
 
     Arguments
     ---------
     session: Session
-        The initialized session object
+        The initialized session object.
     start_block: int | None, optional
         The starting block to filter the query on. start_block integers
-        matches python slicing notation, e.g., list[:3], list[:-3]
+        matches python slicing notation, e.g., list[:3], list[:-3].
     end_block: int | None, optional
         The ending block to filter the query on. end_block integers
-        matches python slicing notation, e.g., list[:3], list[:-3]
+        matches python slicing notation, e.g., list[:3], list[:-3].
     wallet_address: list[str] | None, optional
-        The wallet addresses to filter the query on
+        The wallet addresses to filter the query on.
     max_rows: int | None
-        The number of rows to return. If None, will return all rows
+        The number of rows to return. If None, will return all rows.
     sort_desc: bool, optional
-        If true, will sort in descending order
+        If true, will sort in descending order.
     coerce_float: bool
-        If true, will return floats in dataframe. Otherwise, will return fixed point Decimal
+        If true, will return floats in dataframe. Otherwise, will return fixed point Decimal.
 
     Returns
     -------
     DataFrame
-        A DataFrame that consists of the queried pool info data
+        A DataFrame that consists of the queried pool info data.
     """
     # pylint: disable=too-many-arguments
     query = session.query(Ticker)
@@ -757,29 +759,29 @@ def get_wallet_pnl(
     return_timestamp: bool = True,
     coerce_float=True,
 ) -> pd.DataFrame:
-    """Get all wallet pnl and returns as a pandas dataframe.
+    """Get all wallet pnl and returns a pandas dataframe.
 
     Arguments
     ---------
     session: Session
-        The initialized session object
+        The initialized session object.
     start_block: int | None, optional
         The starting block to filter the query on. start_block integers
-        matches python slicing notation, e.g., list[:3], list[:-3]
+        matches python slicing notation, e.g., list[:3], list[:-3].
     end_block: int | None, optional
         The ending block to filter the query on. end_block integers
-        matches python slicing notation, e.g., list[:3], list[:-3]
+        matches python slicing notation, e.g., list[:3], list[:-3].
     wallet_address: list[str] | None, optional
         The wallet addresses to filter the query on. Returns all if None.
     return_timestamp: bool, optional
         Returns the timestamp from the pool info table if True. Defaults to True.
     coerce_float: bool
-        If true, will return floats in dataframe. Otherwise, will return fixed point Decimal
+        If true, will return floats in dataframe. Otherwise, will return fixed point Decimal.
 
     Returns
     -------
     DataFrame
-        A DataFrame that consists of the queried pool info data
+        A DataFrame that consists of the queried pool info data.
     """
     if return_timestamp:
         query = session.query(PoolInfo.timestamp, WalletPNL)
@@ -820,27 +822,27 @@ def get_total_wallet_pnl_over_time(
     wallet_address: list[str] | None = None,
     coerce_float=True,
 ) -> pd.DataFrame:
-    """Get total pnl across wallets over time and returns as a pandas dataframe.
+    """Get total pnl across wallets over time and returns a pandas dataframe.
 
     Arguments
     ---------
     session: Session
-        The initialized session object
+        The initialized session object.
     start_block: int | None, optional
         The starting block to filter the query on. start_block integers
-        matches python slicing notation, e.g., list[:3], list[:-3]
+        matches python slicing notation, e.g., list[:3], list[:-3].
     end_block: int | None, optional
         The ending block to filter the query on. end_block integers
-        matches python slicing notation, e.g., list[:3], list[:-3]
+        matches python slicing notation, e.g., list[:3], list[:-3].
     wallet_address: list[str] | None, optional
         The wallet addresses to filter the query on. Returns all if None.
     coerce_float: bool
-        If true, will return floats in dataframe. Otherwise, will return fixed point Decimal
+        If true, will return floats in dataframe. Otherwise, will return fixed point Decimal.
 
     Returns
     -------
     DataFrame
-        A DataFrame that consists of the queried pool info data
+        A DataFrame that consists of the queried pool info data.
     """
     # Do a subquery that groups wallet pnl by address and block
     # Not sure why func.sum is not callable, but it is
@@ -882,27 +884,27 @@ def get_wallet_positions_over_time(
     wallet_address: list[str] | None = None,
     coerce_float=True,
 ) -> pd.DataFrame:
-    """Get wallet positions over time and returns as a pandas dataframe.
+    """Get wallet positions over time and returns a pandas dataframe.
 
     Arguments
     ---------
     session: Session
-        The initialized session object
+        The initialized session object.
     start_block: int | None, optional
         The starting block to filter the query on. start_block integers
-        matches python slicing notation, e.g., list[:3], list[:-3]
+        matches python slicing notation, e.g., list[:3], list[:-3].
     end_block: int | None, optional
         The ending block to filter the query on. end_block integers
-        matches python slicing notation, e.g., list[:3], list[:-3]
+        matches python slicing notation, e.g., list[:3], list[:-3].
     wallet_address: list[str] | None, optional
         The wallet addresses to filter the query on. Returns all if None.
     coerce_float: bool
-        If true, will return floats in dataframe. Otherwise, will return fixed point Decimal
+        If true, will return floats in dataframe. Otherwise, will return fixed point Decimal.
 
     Returns
     -------
     DataFrame
-        A DataFrame that consists of the queried pool info data
+        A DataFrame that consists of the queried pool info data.
     """
     # Not sure why func.sum is not callable, but it is
     subquery = session.query(

--- a/src/agent0/chainsync/db/hyperdrive/interface.py
+++ b/src/agent0/chainsync/db/hyperdrive/interface.py
@@ -66,7 +66,19 @@ def get_latest_block_number_from_trade_event(session: Session, wallet_addr: str)
     return int(query)
 
 
-def get_positions_from_db(session: Session, wallet_addr: str) -> pd.DataFrame:
+def get_trade_events(session: Session):
+    """Get all trade events and returns as a pandas dataframe.
+
+    Arguments
+    ---------
+    session: Session
+        The initialized db session object.
+    """
+    query = session.query(TradeEvent)
+    return pd.read_sql(query.statement, con=session.connection(), coerce_float=False)
+
+
+def get_positions_from_db(session: Session, wallet_addr: str, hyperdrive_address: str | None = None) -> pd.DataFrame:
     """Gets all positions for a given wallet address.
 
     Arguments
@@ -75,6 +87,8 @@ def get_positions_from_db(session: Session, wallet_addr: str) -> pd.DataFrame:
         The initialized db session object.
     wallet_addr: str
         The wallet address to filter the results on.
+    hyperdrive_address: str
+        The hyperdrive address to filter the results on.
 
     Returns
     -------
@@ -83,14 +97,19 @@ def get_positions_from_db(session: Session, wallet_addr: str) -> pd.DataFrame:
     """
     # TODO also accept and filter by hyperdrive address here
     # when we move to multi-pool db support
-    query = (
-        session.query(
-            TradeEvent.hyperdrive_address,
-            TradeEvent.wallet_address,
-            TradeEvent.token_id,
-            func.sum(TradeEvent.token_delta).label("balance"),
-        ).filter(TradeEvent.wallet_address == wallet_addr)
-    ).group_by(TradeEvent.hyperdrive_address, TradeEvent.wallet_address, TradeEvent.token_id)
+    query = session.query(
+        TradeEvent.hyperdrive_address,
+        TradeEvent.wallet_address,
+        TradeEvent.token_id,
+        func.sum(TradeEvent.token_delta).label("balance"),
+    )
+    if hyperdrive_address is not None:
+        query = query.filter(
+            TradeEvent.wallet_address == wallet_addr, TradeEvent.hyperdrive_address == hyperdrive_address
+        )
+    else:
+        query = query.filter(TradeEvent.wallet_address == wallet_addr)
+    query = query.group_by(TradeEvent.hyperdrive_address, TradeEvent.wallet_address, TradeEvent.token_id)
     out_df = pd.read_sql(query.statement, con=session.connection(), coerce_float=False)
     # Filter out zero balances
     return out_df[out_df["balance"] != 0]

--- a/src/agent0/chainsync/db/hyperdrive/interface_test.py
+++ b/src/agent0/chainsync/db/hyperdrive/interface_test.py
@@ -15,18 +15,28 @@ from .interface import (
     add_pool_config,
     add_pool_infos,
     add_transactions,
+    add_transfer_events,
     add_wallet_deltas,
     get_all_traders,
     get_checkpoint_info,
     get_current_wallet,
     get_latest_block_number_from_pool_info_table,
     get_latest_block_number_from_table,
+    get_latest_block_number_from_transfer_event,
     get_pool_config,
     get_pool_info,
     get_transactions,
     get_wallet_deltas,
 )
-from .schema import CheckpointInfo, CurrentWallet, HyperdriveTransaction, PoolConfig, PoolInfo, WalletDelta
+from .schema import (
+    CheckpointInfo,
+    CurrentWallet,
+    HyperdriveEvent,
+    HyperdriveTransaction,
+    PoolConfig,
+    PoolInfo,
+    WalletDelta,
+)
 
 
 # These tests are using fixtures defined in conftest.py
@@ -157,14 +167,14 @@ class TestPoolConfigInterface:
     @pytest.mark.docker
     def test_get_pool_config(self, db_session):
         """Testing retrieval of pool config via interface"""
-        pool_config_1 = PoolConfig(contract_address="0", initial_vault_share_price=Decimal("3.2"))
+        pool_config_1 = PoolConfig(hyperdrive_address="0", initial_vault_share_price=Decimal("3.2"))
         add_pool_config(pool_config_1, db_session)
 
         pool_config_df_1 = get_pool_config(db_session)
         assert len(pool_config_df_1) == 1
         np.testing.assert_array_equal(pool_config_df_1["initial_vault_share_price"], np.array([3.2]))
 
-        pool_config_2 = PoolConfig(contract_address="1", initial_vault_share_price=Decimal("3.4"))
+        pool_config_2 = PoolConfig(hyperdrive_address="1", initial_vault_share_price=Decimal("3.4"))
         add_pool_config(pool_config_2, db_session)
 
         pool_config_df_2 = get_pool_config(db_session)
@@ -174,7 +184,7 @@ class TestPoolConfigInterface:
     @pytest.mark.docker
     def test_primary_id_query_pool_config(self, db_session):
         """Testing retrieval of pool config via interface"""
-        pool_config = PoolConfig(contract_address="0", initial_vault_share_price=Decimal("3.2"))
+        pool_config = PoolConfig(hyperdrive_address="0", initial_vault_share_price=Decimal("3.2"))
         add_pool_config(pool_config, db_session)
 
         pool_config_df_1 = get_pool_config(db_session, contract_address="0")
@@ -187,21 +197,21 @@ class TestPoolConfigInterface:
     @pytest.mark.docker
     def test_pool_config_verify(self, db_session):
         """Testing retrieval of pool config via interface"""
-        pool_config_1 = PoolConfig(contract_address="0", initial_vault_share_price=Decimal("3.2"))
+        pool_config_1 = PoolConfig(hyperdrive_address="0", initial_vault_share_price=Decimal("3.2"))
         add_pool_config(pool_config_1, db_session)
         pool_config_df_1 = get_pool_config(db_session)
         assert len(pool_config_df_1) == 1
         assert pool_config_df_1.loc[0, "initial_vault_share_price"] == 3.2
 
         # Nothing should happen if we give the same pool_config
-        pool_config_2 = PoolConfig(contract_address="0", initial_vault_share_price=Decimal("3.2"))
+        pool_config_2 = PoolConfig(hyperdrive_address="0", initial_vault_share_price=Decimal("3.2"))
         add_pool_config(pool_config_2, db_session)
         pool_config_df_2 = get_pool_config(db_session)
         assert len(pool_config_df_2) == 1
         assert pool_config_df_2.loc[0, "initial_vault_share_price"] == 3.2
 
         # If we try to add another pool config with a different value, should throw a ValueError
-        pool_config_3 = PoolConfig(contract_address="0", initial_vault_share_price=Decimal("3.4"))
+        pool_config_3 = PoolConfig(hyperdrive_address="0", initial_vault_share_price=Decimal("3.4"))
         with pytest.raises(ValueError):
             add_pool_config(pool_config_3, db_session)
 
@@ -401,3 +411,24 @@ class TestCurrentWalletInterface:
         wallet_info_df = wallet_info_df.sort_values(by=["value"])
         np.testing.assert_array_equal(wallet_info_df["token_type"], ["LP", BASE_TOKEN_SYMBOL])
         np.testing.assert_array_equal(wallet_info_df["value"], [5.1, 6.1])
+
+
+class TestHyperdriveEventsInterface:
+    """Testing postgres interface for walletinfo table"""
+
+    @pytest.mark.docker
+    def test_latest_block_number(self, db_session):
+        """Testing retrieval of wallet info via interface"""
+        transfer_event = HyperdriveEvent(block_number=1, wallet_address="a")
+        add_transfer_events([transfer_event], db_session)
+
+        latest_block_number = get_latest_block_number_from_transfer_event(db_session, "a")
+        assert latest_block_number == 1
+
+        transfer_event_1 = HyperdriveEvent(block_number=2, wallet_address="a")
+        transfer_event_2 = HyperdriveEvent(block_number=3, wallet_address="b")
+        add_transfer_events([transfer_event_1, transfer_event_2], db_session)
+        latest_block_number = get_latest_block_number_from_transfer_event(db_session, "a")
+        assert latest_block_number == 2
+        latest_block_number = get_latest_block_number_from_transfer_event(db_session, "b")
+        assert latest_block_number == 3

--- a/src/agent0/chainsync/db/hyperdrive/interface_test.py
+++ b/src/agent0/chainsync/db/hyperdrive/interface_test.py
@@ -411,14 +411,14 @@ class TestHyperdriveEventsInterface:
     @pytest.mark.docker
     def test_latest_block_number(self, db_session):
         """Testing retrieval of wallet info via interface"""
-        transfer_event = TradeEvent(block_number=1, wallet_address="a")
+        transfer_event = TradeEvent(block_number=1, hyperdrive_address="a", transaction_hash="a", wallet_address="a")
         add_transfer_events([transfer_event], db_session)
 
         latest_block_number = get_latest_block_number_from_trade_event(db_session, "a")
         assert latest_block_number == 1
 
-        transfer_event_1 = TradeEvent(block_number=2, wallet_address="a")
-        transfer_event_2 = TradeEvent(block_number=3, wallet_address="b")
+        transfer_event_1 = TradeEvent(block_number=2, hyperdrive_address="a", transaction_hash="a", wallet_address="a")
+        transfer_event_2 = TradeEvent(block_number=3, hyperdrive_address="a", transaction_hash="a", wallet_address="b")
         add_transfer_events([transfer_event_1, transfer_event_2], db_session)
         latest_block_number = get_latest_block_number_from_trade_event(db_session, "a")
         assert latest_block_number == 2

--- a/src/agent0/chainsync/db/hyperdrive/interface_test.py
+++ b/src/agent0/chainsync/db/hyperdrive/interface_test.py
@@ -22,21 +22,13 @@ from .interface import (
     get_current_wallet,
     get_latest_block_number_from_pool_info_table,
     get_latest_block_number_from_table,
-    get_latest_block_number_from_transfer_event,
+    get_latest_block_number_from_trade_event,
     get_pool_config,
     get_pool_info,
     get_transactions,
     get_wallet_deltas,
 )
-from .schema import (
-    CheckpointInfo,
-    CurrentWallet,
-    HyperdriveEvent,
-    HyperdriveTransaction,
-    PoolConfig,
-    PoolInfo,
-    WalletDelta,
-)
+from .schema import CheckpointInfo, CurrentWallet, HyperdriveTransaction, PoolConfig, PoolInfo, TradeEvent, WalletDelta
 
 
 # These tests are using fixtures defined in conftest.py
@@ -419,16 +411,16 @@ class TestHyperdriveEventsInterface:
     @pytest.mark.docker
     def test_latest_block_number(self, db_session):
         """Testing retrieval of wallet info via interface"""
-        transfer_event = HyperdriveEvent(block_number=1, wallet_address="a")
+        transfer_event = TradeEvent(block_number=1, wallet_address="a")
         add_transfer_events([transfer_event], db_session)
 
-        latest_block_number = get_latest_block_number_from_transfer_event(db_session, "a")
+        latest_block_number = get_latest_block_number_from_trade_event(db_session, "a")
         assert latest_block_number == 1
 
-        transfer_event_1 = HyperdriveEvent(block_number=2, wallet_address="a")
-        transfer_event_2 = HyperdriveEvent(block_number=3, wallet_address="b")
+        transfer_event_1 = TradeEvent(block_number=2, wallet_address="a")
+        transfer_event_2 = TradeEvent(block_number=3, wallet_address="b")
         add_transfer_events([transfer_event_1, transfer_event_2], db_session)
-        latest_block_number = get_latest_block_number_from_transfer_event(db_session, "a")
+        latest_block_number = get_latest_block_number_from_trade_event(db_session, "a")
         assert latest_block_number == 2
-        latest_block_number = get_latest_block_number_from_transfer_event(db_session, "b")
+        latest_block_number = get_latest_block_number_from_trade_event(db_session, "b")
         assert latest_block_number == 3

--- a/src/agent0/chainsync/db/hyperdrive/schema.py
+++ b/src/agent0/chainsync/db/hyperdrive/schema.py
@@ -5,7 +5,6 @@ from decimal import Decimal
 from typing import Any, Union
 
 from sqlalchemy import ARRAY, BigInteger, Boolean, DateTime, Integer, Numeric, String
-from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
 from agent0.chainsync.db.base import Base
@@ -152,8 +151,6 @@ class TradeEvent(Base):
     """
     The change in base tokens for the event with respect to the wallet address.
     """
-    event_json: Mapped[Union[dict[str, Any], None]] = mapped_column(JSONB, default=None)
-    """The raw event data is stored here in a json format."""
 
 
 # TODO: either make a more general TokenDelta, or rename this to HyperdriveDelta

--- a/src/agent0/chainsync/db/hyperdrive/schema.py
+++ b/src/agent0/chainsync/db/hyperdrive/schema.py
@@ -98,7 +98,7 @@ class PoolInfo(Base):
     vault_shares: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
 
 
-class HyperdriveEvent(Base):
+class TradeEvent(Base):
     """Table for storing any transfer events emitted by the Hyperdrive contract.
     This table only contains events of "registered" wallet addresses, which are any agents
     that are managed by agent0. This table does not store all wallet addresses that have
@@ -110,7 +110,7 @@ class HyperdriveEvent(Base):
           to execute trades.
     """
 
-    __tablename__ = "hyperdrive_transfer_events"
+    __tablename__ = "trade_event"
     # Indices
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False, autoincrement=True)
     """The unique identifier for the entry to the table."""

--- a/src/agent0/chainsync/db/hyperdrive/schema.py
+++ b/src/agent0/chainsync/db/hyperdrive/schema.py
@@ -2,9 +2,10 @@
 
 from datetime import datetime
 from decimal import Decimal
-from typing import Union
+from typing import Any, Union
 
 from sqlalchemy import ARRAY, BigInteger, Boolean, DateTime, Integer, Numeric, String
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
 from agent0.chainsync.db.base import Base
@@ -28,7 +29,10 @@ class PoolConfig(Base):
 
     __tablename__ = "pool_config"
 
-    contract_address: Mapped[str] = mapped_column(String, primary_key=True)
+    # Indices
+    hyperdrive_address: Mapped[str] = mapped_column(String, primary_key=True)
+
+    # Pool config parameters
     base_token: Mapped[Union[str, None]] = mapped_column(String, default=None)
     vault_shares_token: Mapped[Union[str, None]] = mapped_column(String, default=None)
     linker_factory: Mapped[Union[str, None]] = mapped_column(String, default=None)
@@ -94,7 +98,66 @@ class PoolInfo(Base):
     vault_shares: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
 
 
+class HyperdriveEvent(Base):
+    """Table for storing any transfer events emitted by the Hyperdrive contract.
+    This table only contains events of "registered" wallet addresses, which are any agents
+    that are managed by agent0. This table does not store all wallet addresses that have
+    interacted with all Hyperdrive contracts.
+    TODO this table would take the place of the `WalletDelta` table with the following updates:
+    - We explicitly fill this table with all addresses that have interacted with all hyperdrive pools.
+        - This is very slow on existing pools, which makes it useful for simulations and
+          any managed chains to run a dashboard on, but not so much for connections to remote chains
+          to execute trades.
+    """
+
+    __tablename__ = "hyperdrive_transfer_events"
+    # Indices
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False, autoincrement=True)
+    """The unique identifier for the entry to the table."""
+    hyperdrive_address: Mapped[str] = mapped_column(String, index=True)
+    """The hyperdrive address for the entry."""
+    transaction_hash: Mapped[str] = mapped_column(String, index=True)
+    """The transaction hash for the entry."""
+    block_number: Mapped[int] = mapped_column(BigInteger, index=True)
+    """The block number for the entry."""
+    wallet_address: Mapped[str] = mapped_column(String, index=True)
+    """The wallet address for the entry."""
+
+    # Fields
+    event_type: Mapped[Union[str, None]] = mapped_column(String, index=True, default=None)
+    """
+    The underlying event type for the entry. Can be one of the following:
+    `OpenLong`, `OpenShort`, `CloseLong`, `CloseShort`, `AddLiquidity`, 
+    `RemoveLiquidity`, `RedeemWithdrawalShares`, or `TransferSingle`.
+    """
+    token_type: Mapped[Union[str, None]] = mapped_column(String, index=True, default=None)
+    """
+    The underlying token type for the entry. Can be one of the following:
+    `LONG`, `SHORT, `LP`, or `WITHDRAWAL_SHARE`.
+    """
+    # While time here is in epoch seconds, we use Numeric to allow for
+    # (1) lossless storage and (2) allow for NaNs
+    maturity_time: Mapped[Union[int, None]] = mapped_column(Numeric, default=None)
+    """The maturity time of the token"""
+    token_id: Mapped[Union[str, None]] = mapped_column(String, default=None)
+    """
+    The id for the token itself, which consists of the `token_type`, appended 
+    with `maturity_time` for LONG and SHORT. For example, `LONG-1715126400`.
+    """
+    token_delta: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    """
+    The change in tokens with respect to the wallet address.
+    """
+    base_delta: Mapped[Union[Decimal, None]] = mapped_column(FIXED_NUMERIC, default=None)
+    """
+    The change in base tokens for the event with respect to the wallet address.
+    """
+    event_json: Mapped[Union[dict[str, Any], None]] = mapped_column(JSONB, default=None)
+    """The raw event data is stored here in a json format."""
+
+
 # TODO: either make a more general TokenDelta, or rename this to HyperdriveDelta
+# TODO: this table might be able to be deprecated in favor of hyperdrive events.
 class WalletDelta(Base):
     """Table/dataclass schema for wallet deltas."""
 
@@ -114,6 +177,7 @@ class WalletDelta(Base):
     maturity_time: Mapped[Union[int, None]] = mapped_column(Numeric, default=None)
 
 
+# TODO this table maybe isn't needed, use events table instead
 class HyperdriveTransaction(Base):
     """Table/dataclass schema for Transactions.
 

--- a/src/agent0/chainsync/db/hyperdrive/schema.py
+++ b/src/agent0/chainsync/db/hyperdrive/schema.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 from decimal import Decimal
-from typing import Any, Union
+from typing import Union
 
 from sqlalchemy import ARRAY, BigInteger, Boolean, DateTime, Integer, Numeric, String
 from sqlalchemy.orm import Mapped, mapped_column

--- a/src/agent0/chainsync/db/hyperdrive/schema_test.py
+++ b/src/agent0/chainsync/db/hyperdrive/schema_test.py
@@ -107,7 +107,7 @@ class TestPoolConfigTable:
         db_session.add(pool_config)
         db_session.commit()
 
-        retrieved_pool_config = db_session.query(PoolConfig).filter_by(contract_address="0").first()
+        retrieved_pool_config = db_session.query(PoolConfig).filter_by(hyperdrive_address="0").first()
         assert retrieved_pool_config is not None
         assert float(retrieved_pool_config.initial_vault_share_price) == 3.2
 
@@ -121,7 +121,7 @@ class TestPoolConfigTable:
         db_session.delete(pool_config)
         db_session.commit()
 
-        deleted_pool_config = db_session.query(PoolConfig).filter_by(contract_address="0").first()
+        deleted_pool_config = db_session.query(PoolConfig).filter_by(hyperdrive_address="0").first()
         assert deleted_pool_config is None
 
 

--- a/src/agent0/chainsync/db/hyperdrive/schema_test.py
+++ b/src/agent0/chainsync/db/hyperdrive/schema_test.py
@@ -103,7 +103,7 @@ class TestPoolConfigTable:
     @pytest.mark.docker
     def test_create_pool_config(self, db_session):
         """Create and entry"""
-        pool_config = PoolConfig(contract_address="0", initial_vault_share_price=Decimal("3.2"))
+        pool_config = PoolConfig(hyperdrive_address="0", initial_vault_share_price=Decimal("3.2"))
         db_session.add(pool_config)
         db_session.commit()
 
@@ -114,7 +114,7 @@ class TestPoolConfigTable:
     @pytest.mark.docker
     def test_delete_pool_config(self, db_session):
         """Delete an entry"""
-        pool_config = PoolConfig(contract_address="0", initial_vault_share_price=Decimal("3.2"))
+        pool_config = PoolConfig(hyperdrive_address="0", initial_vault_share_price=Decimal("3.2"))
         db_session.add(pool_config)
         db_session.commit()
 

--- a/src/agent0/chainsync/df_to_db.py
+++ b/src/agent0/chainsync/df_to_db.py
@@ -1,3 +1,5 @@
+"""Helper function to add a dataframe to a database."""
+
 import logging
 from typing import Type
 

--- a/src/agent0/chainsync/df_to_db.py
+++ b/src/agent0/chainsync/df_to_db.py
@@ -1,0 +1,45 @@
+import logging
+from typing import Type
+
+import pandas as pd
+from sqlalchemy import exc
+from sqlalchemy.orm import Session
+
+from agent0.chainsync.db.base import Base
+
+MAX_BATCH_SIZE = 10000
+
+
+def df_to_db(insert_df: pd.DataFrame, schema_obj: Type[Base], session: Session):
+    """Helper function to add a dataframe to a database.
+
+    Arguments
+    ---------
+    insert_df: pd.DataFrame
+        The dataframe to insert
+    schema_obj: Type[Base]
+        The schema object to use
+    session: Session
+        The initialized session object
+    """
+    table_name = schema_obj.__tablename__
+
+    # dataframe to_sql needs data types from the schema object
+    dtype = {c.name: c.type for c in schema_obj.__table__.columns}
+    # Pandas doesn't play nice with types
+    insert_df.to_sql(
+        table_name,
+        con=session.connection(),
+        if_exists="append",
+        method="multi",
+        index=False,
+        dtype=dtype,  # type: ignore
+        chunksize=MAX_BATCH_SIZE,
+    )
+    # commit the transaction
+    try:
+        session.commit()
+    except exc.DataError as err:
+        session.rollback()
+        logging.error("Error on adding %s: %s", table_name, err)
+        raise err

--- a/src/agent0/chainsync/df_to_db.py
+++ b/src/agent0/chainsync/df_to_db.py
@@ -18,11 +18,11 @@ def df_to_db(insert_df: pd.DataFrame, schema_obj: Type[Base], session: Session):
     Arguments
     ---------
     insert_df: pd.DataFrame
-        The dataframe to insert
+        The dataframe to insert.
     schema_obj: Type[Base]
-        The schema object to use
+        The schema object to use.
     session: Session
-        The initialized session object
+        The initialized session object.
     """
     table_name = schema_obj.__tablename__
 

--- a/src/agent0/core/hyperdrive/interactive/hyperdrive.py
+++ b/src/agent0/core/hyperdrive/interactive/hyperdrive.py
@@ -9,6 +9,7 @@ from typing import Any, Literal, Type, overload
 
 import nest_asyncio
 import numpy as np
+import pandas as pd
 from eth_account.account import Account
 from eth_account.signers.local import LocalAccount
 from eth_typing import ChecksumAddress
@@ -255,6 +256,10 @@ class Hyperdrive:
         # TODO move the db to the chain class and use it here
         # to get wallets
         return build_wallet_positions_from_chain(agent, self.interface)
+
+    def _get_trade_events(self, agent: HyperdrivePolicyAgent) -> pd.DataFrame:
+        # TODO move the db to the chain class and use it here to get events
+        raise NotImplementedError
 
     def _add_funds(
         self,

--- a/src/agent0/core/hyperdrive/interactive/hyperdrive.py
+++ b/src/agent0/core/hyperdrive/interactive/hyperdrive.py
@@ -16,7 +16,13 @@ from fixedpointmath import FixedPoint
 from numpy.random._generator import Generator
 from web3 import Web3
 
-from agent0.core.hyperdrive import HyperdriveActionType, HyperdrivePolicyAgent, TradeResult, TradeStatus
+from agent0.core.hyperdrive import (
+    HyperdriveActionType,
+    HyperdrivePolicyAgent,
+    HyperdriveWallet,
+    TradeResult,
+    TradeStatus,
+)
 from agent0.core.hyperdrive.agent import (
     add_liquidity_trade,
     build_wallet_positions_from_chain,
@@ -234,7 +240,6 @@ class Hyperdrive:
 
         agent = HyperdrivePolicyAgent(Account().from_key(private_key), initial_budget=FixedPoint(0), policy=policy_obj)
 
-        self._sync_wallet(agent)
         return agent
 
     def _set_max_approval(self, agent: HyperdrivePolicyAgent) -> None:
@@ -246,9 +251,10 @@ class Hyperdrive:
             str(self.interface.hyperdrive_contract.address),
         )
 
-    def _sync_wallet(self, agent: HyperdrivePolicyAgent) -> None:
-        # TODO add sync from db
-        agent.wallet = build_wallet_positions_from_chain(agent, self.interface)
+    def _get_positions(self, agent: HyperdrivePolicyAgent) -> HyperdriveWallet:
+        # TODO move the db to the chain class and use it here
+        # to get wallets
+        return build_wallet_positions_from_chain(agent, self.interface)
 
     def _add_funds(
         self,

--- a/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
@@ -63,17 +63,6 @@ class HyperdriveAgent:
         self.agent = self._pool._init_agent(policy, policy_config, private_key)
 
     @property
-    def wallet(self) -> HyperdriveWallet:
-        """Returns the agent's current wallet.
-
-        Returns
-        -------
-        HyperdriveWallet
-            The agent's current wallet.
-        """
-        return self.agent.wallet
-
-    @property
     def checksum_address(self) -> ChecksumAddress:
         """Return the checksum address of the account."""
         return self.agent.checksum_address
@@ -249,6 +238,18 @@ class HyperdriveAgent:
 
         """
         self._pool._set_max_approval(self.agent)
+
+    def get_positions(self) -> HyperdriveWallet:
+        """Returns the agent's current wallet.
+
+        Returns
+        -------
+        HyperdriveWallet
+            The agent's current wallet.
+        """
+
+        # Update the db with this wallet
+        return self._pool._get_positions(self.agent)
 
     def sync_wallet_from_chain(self) -> None:
         """Explicitly syncs the wallet to the current state of the chain.

--- a/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pandas as pd
 from fixedpointmath import FixedPoint
 
 if TYPE_CHECKING:
@@ -250,3 +251,15 @@ class HyperdriveAgent:
 
         # Update the db with this wallet
         return self._pool._get_positions(self.agent)
+
+    def get_trade_events(self) -> pd.DataFrame:
+        """Returns the agent's current wallet.
+
+        Returns
+        -------
+        HyperdriveWallet
+            The agent's current wallet.
+        """
+
+        # Update the db with this wallet
+        return self._pool._get_trade_events(self.agent)

--- a/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
@@ -250,12 +250,3 @@ class HyperdriveAgent:
 
         # Update the db with this wallet
         return self._pool._get_positions(self.agent)
-
-    def sync_wallet_from_chain(self) -> None:
-        """Explicitly syncs the wallet to the current state of the chain.
-
-        Uses on chain events to generate current wallet positions.
-
-        .. note:: This function can be slow, use it sparingly.
-        """
-        self._pool._sync_wallet(self.agent)

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
@@ -18,6 +18,7 @@ from eth_account.account import Account
 from eth_account.signers.local import LocalAccount
 from eth_typing import BlockNumber, ChecksumAddress
 from fixedpointmath import FixedPoint
+from hexbytes import HexBytes
 from IPython.display import IFrame
 from sqlalchemy_utils.functions import drop_database
 from web3._utils.threads import Timeout
@@ -38,15 +39,19 @@ from agent0.chainsync.db.hyperdrive import (
     get_pool_analysis,
     get_pool_config,
     get_pool_info,
+    get_positions_from_db,
     get_ticker,
     get_total_wallet_pnl_over_time,
     get_wallet_deltas,
     get_wallet_pnl,
+    trade_events_to_db,
 )
 from agent0.chainsync.exec import acquire_data, data_analysis
+from agent0.core.base import Quantity, TokenType
 from agent0.core.base.make_key import make_private_key
-from agent0.core.hyperdrive import HyperdrivePolicyAgent, TradeResult, TradeStatus
+from agent0.core.hyperdrive import HyperdrivePolicyAgent, HyperdriveWallet, TradeResult, TradeStatus
 from agent0.core.hyperdrive.agent import build_wallet_positions_from_db
+from agent0.core.hyperdrive.agent.hyperdrive_wallet import Long, Short
 from agent0.core.hyperdrive.crash_report import get_anvil_state_dump
 from agent0.core.hyperdrive.policies import HyperdriveBasePolicy
 from agent0.ethpy.hyperdrive import (
@@ -1081,12 +1086,47 @@ class LocalHyperdrive(Hyperdrive):
             add_addr_to_username(name, [agent.address], self.db_session)
         return agent
 
-    def _sync_wallet(self, agent: HyperdrivePolicyAgent) -> None:
-        # TODO add sync from db
-        super()._sync_wallet(agent)
-        # Ensure db is up to date
-        if not self.chain.experimental_data_threading:
-            self._run_blocking_data_pipeline()
+    def _get_positions(self, agent: HyperdrivePolicyAgent) -> HyperdriveWallet:
+        # Update the db with this wallet
+        trade_events_to_db([self.interface], agent.checksum_address, self.db_session)
+        # Query for the wallet object from the db
+        wallet_positions = get_positions_from_db(self.db_session, agent.checksum_address)
+        # Convert to hyperdrive wallet object
+        long_obj: dict[int, Long] = {}
+        short_obj: dict[int, Short] = {}
+        lp_balance: FixedPoint = FixedPoint(0)
+        withdrawal_shares_balance: FixedPoint = FixedPoint(0)
+        for _, row in wallet_positions.iterrows():
+            # Sanity checks
+            assert row["hyperdrive_address"] == self.interface.hyperdrive_address
+            assert row["wallet_address"] == agent.checksum_address
+            if row["token_id"] == "LP":
+                lp_balance = FixedPoint(row["balance"])
+            elif row["token_id"] == "WITHDRAWAL_SHARE":
+                withdrawal_shares_balance = FixedPoint(row["balance"])
+            elif "LONG" in row["token_id"]:
+                maturity_time = int(row["token_id"].split("-")[1])
+                long_obj[maturity_time] = Long(balance=FixedPoint(row["balance"]), maturity_time=maturity_time)
+            elif "SHORT" in row["token_id"]:
+                maturity_time = int(row["token_id"].split("-")[1])
+                short_obj[maturity_time] = Short(balance=FixedPoint(row["balance"]), maturity_time=maturity_time)
+
+        # We do a balance of call to get base balance.
+        base_balance = FixedPoint(
+            scaled_value=self.interface.base_token_contract.functions.balanceOf(agent.checksum_address).call()
+        )
+
+        return HyperdriveWallet(
+            address=HexBytes(agent.checksum_address),
+            balance=Quantity(
+                amount=base_balance,
+                unit=TokenType.BASE,
+            ),
+            lp_tokens=lp_balance,
+            withdraw_shares=withdrawal_shares_balance,
+            longs=long_obj,
+            shorts=short_obj,
+        )
 
     def _add_funds(
         self,

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
@@ -1086,9 +1086,15 @@ class LocalHyperdrive(Hyperdrive):
             add_addr_to_username(name, [agent.address], self.db_session)
         return agent
 
-    def _get_positions(self, agent: HyperdrivePolicyAgent) -> HyperdriveWallet:
+    def _sync_events(self, agent: HyperdrivePolicyAgent) -> None:
         # Update the db with this wallet
+        # TODO this function can be optimized to cache.
         trade_events_to_db([self.interface], agent.checksum_address, self.db_session)
+
+    def _get_positions(self, agent: HyperdrivePolicyAgent) -> HyperdriveWallet:
+
+        self._sync_events(agent)
+
         # Query for the wallet object from the db
         wallet_positions = get_positions_from_db(self.db_session, agent.checksum_address)
         # Convert to hyperdrive wallet object

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
@@ -42,6 +42,7 @@ from agent0.chainsync.db.hyperdrive import (
     get_positions_from_db,
     get_ticker,
     get_total_wallet_pnl_over_time,
+    get_trade_events,
     get_wallet_deltas,
     get_wallet_pnl,
     trade_events_to_db,
@@ -1092,7 +1093,6 @@ class LocalHyperdrive(Hyperdrive):
         trade_events_to_db([self.interface], agent.checksum_address, self.db_session)
 
     def _get_positions(self, agent: HyperdrivePolicyAgent) -> HyperdriveWallet:
-
         self._sync_events(agent)
 
         # Query for the wallet object from the db
@@ -1135,6 +1135,10 @@ class LocalHyperdrive(Hyperdrive):
             longs=long_obj,
             shorts=short_obj,
         )
+
+    def _get_trade_events(self, agent: HyperdrivePolicyAgent) -> pd.DataFrame:
+        self._sync_events(agent)
+        return get_trade_events(self.db_session, agent.checksum_address)
 
     def _add_funds(
         self,

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
@@ -1096,7 +1096,9 @@ class LocalHyperdrive(Hyperdrive):
         self._sync_events(agent)
 
         # Query for the wallet object from the db
-        wallet_positions = get_positions_from_db(self.db_session, agent.checksum_address)
+        wallet_positions = get_positions_from_db(
+            self.db_session, agent.checksum_address, hyperdrive_address=self.interface.hyperdrive_address
+        )
         # Convert to hyperdrive wallet object
         long_obj: dict[int, Long] = {}
         short_obj: dict[int, Short] = {}

--- a/src/agent0/hyperfuzz/system_fuzz/run_fuzz_bots.py
+++ b/src/agent0/hyperfuzz/system_fuzz/run_fuzz_bots.py
@@ -336,7 +336,7 @@ def run_fuzz_bots(
 
         # Check agent funds and refund if necessary
         assert len(agents) > 0
-        average_agent_base = sum(agent.wallet.balance.amount for agent in agents) / FixedPoint(len(agents))
+        average_agent_base = sum(agent.get_positions().balance.amount for agent in agents) / FixedPoint(len(agents))
         # Update agent funds
         if average_agent_base < minimum_avg_agent_base:
             logging.info("Refunding agents...")

--- a/src/agent0/hyperfuzz/unit_fuzz/fuzz_present_value.py
+++ b/src/agent0/hyperfuzz/unit_fuzz/fuzz_present_value.py
@@ -91,12 +91,12 @@ def fuzz_present_value(
         HyperdriveActionType.REMOVE_LIQUIDITY,
     ]:
         # Keep the agent flush
-        if agent.wallet.balance.amount < FixedPoint("1e10"):
-            agent.add_funds(base=FixedPoint("1e10") - agent.wallet.balance.amount)
+        if agent.get_positions().balance.amount < FixedPoint("1e10"):
+            agent.add_funds(base=FixedPoint("1e10") - agent.get_positions().balance.amount)
 
         # Set up trade amount bounds
         min_trade = interactive_hyperdrive.interface.pool_config.minimum_transaction_amount
-        max_budget = agent.wallet.balance.amount
+        max_budget = agent.get_positions().balance.amount
         trade_amount = None
 
         # Execute the trade
@@ -110,7 +110,7 @@ def fuzz_present_value(
                 )
                 trade_event = agent.open_long(base=trade_amount)
             case HyperdriveActionType.CLOSE_LONG:
-                maturity_time, open_trade = next(iter(agent.wallet.longs.items()))
+                maturity_time, open_trade = next(iter(agent.get_positions().longs.items()))
                 trade_event = agent.close_long(maturity_time=maturity_time, bonds=open_trade.balance)
             case HyperdriveActionType.OPEN_SHORT:
                 max_trade = interactive_hyperdrive.interface.calc_max_short(
@@ -121,7 +121,7 @@ def fuzz_present_value(
                 )
                 trade_event = agent.open_short(trade_amount)
             case HyperdriveActionType.CLOSE_SHORT:
-                maturity_time, open_trade = next(iter(agent.wallet.shorts.items()))
+                maturity_time, open_trade = next(iter(agent.get_positions().shorts.items()))
                 trade_event = agent.close_short(maturity_time=maturity_time, bonds=open_trade.balance)
             case HyperdriveActionType.ADD_LIQUIDITY:
                 # recompute initial present value for liquidity actions
@@ -130,7 +130,11 @@ def fuzz_present_value(
                 )
                 trade_amount = FixedPoint(
                     scaled_value=int(
-                        np.floor(rng.uniform(low=min_trade.scaled_value, high=agent.wallet.balance.amount.scaled_value))
+                        np.floor(
+                            rng.uniform(
+                                low=min_trade.scaled_value, high=agent.get_positions().balance.amount.scaled_value
+                            )
+                        )
                     )
                 )
                 trade_event = agent.add_liquidity(trade_amount)
@@ -139,8 +143,8 @@ def fuzz_present_value(
                 check_data["initial_present_value"] = interactive_hyperdrive.interface.calc_present_value(
                     interactive_hyperdrive.interface.current_pool_state
                 )
-                trade_amount = agent.wallet.lp_tokens
-                trade_event = agent.remove_liquidity(agent.wallet.lp_tokens)
+                trade_amount = agent.get_positions().lp_tokens
+                trade_event = agent.remove_liquidity(agent.get_positions().lp_tokens)
             case _:
                 raise ValueError(f"Invalid {trade_type=}")
 

--- a/src/agent0/hyperfuzz/unit_fuzz/fuzz_profit_check.py
+++ b/src/agent0/hyperfuzz/unit_fuzz/fuzz_profit_check.py
@@ -90,7 +90,7 @@ def fuzz_profit_check(chain_config: LocalChain.Config | None = None):
 
     # Generate funded trading agent
     long_agent = interactive_hyperdrive.init_agent(base=long_trade_amount, eth=FixedPoint(100), name="alice")
-    long_agent_initial_balance = long_agent.wallet.balance.amount
+    long_agent_initial_balance = long_agent.get_positions().balance.amount
 
     # Advance time to be right after a checkpoint boundary
     logging.info("Advance time...")
@@ -134,7 +134,7 @@ def fuzz_profit_check(chain_config: LocalChain.Config | None = None):
     # the short trade amount is in bonds, but we know we will need much less base
     # we can play it safe by initializing with that much base
     short_agent = interactive_hyperdrive.init_agent(base=short_trade_amount, eth=FixedPoint(100), name="bob")
-    short_agent_initial_balance = short_agent.wallet.balance.amount
+    short_agent_initial_balance = short_agent.get_positions().balance.amount
 
     # Advance time to be right after a checkpoint boundary
     logging.info("Advance time...")
@@ -165,10 +165,10 @@ def fuzz_profit_check(chain_config: LocalChain.Config | None = None):
     check_data = {
         "long_trade_amount": long_trade_amount,
         "long_agent_initial_balance": long_agent_initial_balance,
-        "long_agent_final_balance": long_agent.wallet.balance.amount,
+        "long_agent_final_balance": long_agent.get_positions().balance.amount,
         "long_events": {"open": open_long_event, "close": close_long_event},
         "short_trade_amount": short_trade_amount,
-        "short_agent_final_balance": short_agent.wallet.balance.amount,
+        "short_agent_final_balance": short_agent.get_positions().balance.amount,
         "short_agent_initial_balance": short_agent_initial_balance,
         "short_events": {"open": open_short_event, "close": close_short_event},
     }

--- a/src/agent0/traiderdaive/gym_environments/full_hyperdrive_env.py
+++ b/src/agent0/traiderdaive/gym_environments/full_hyperdrive_env.py
@@ -345,7 +345,7 @@ class FullHyperdriveEnv(gym.Env):
 
                 if open_order:
                     # If the wallet has enough money
-                    if volume_adjusted <= self.rl_bot.wallet.balance.amount:
+                    if volume_adjusted <= self.rl_bot.get_positions().balance.amount:
                         try:
                             if trade_type == TradeTypes.LONG:
                                 self.rl_bot.open_long(base=volume_adjusted)
@@ -382,12 +382,12 @@ class FullHyperdriveEnv(gym.Env):
         try:
             if add_lp:
                 self.rl_bot.add_liquidity(add_lp_volume)
-            if remove_lp and remove_lp_volume <= self.rl_bot.wallet.lp_tokens:
+            if remove_lp and remove_lp_volume <= self.rl_bot.get_positions().lp_tokens:
                 self.rl_bot.remove_liquidity(remove_lp_volume)
             # Always try and remove withdrawal shares
-            if self.rl_bot.wallet.withdraw_shares > 0:
+            if self.rl_bot.get_positions().withdraw_shares > 0:
                 # TODO error handling or check when withdrawal shares are not withdrawable
-                self.rl_bot.redeem_withdraw_share(self.rl_bot.wallet.withdraw_shares)
+                self.rl_bot.redeem_withdraw_share(self.rl_bot.get_positions().withdraw_shares)
         except Exception as err:  # pylint: disable=broad-except
             # TODO use logging here
             print(f"Warning: Failed to LP: {err=}")

--- a/src/agent0/traiderdaive/gym_environments/simple_hyperdrive_env.py
+++ b/src/agent0/traiderdaive/gym_environments/simple_hyperdrive_env.py
@@ -250,7 +250,7 @@ class SimpleHyperdriveEnv(gym.Env):
         assert self._current_position is not None
         terminated = False
 
-        agent_wallet = self.rl_bot.wallet
+        agent_wallet = self.rl_bot.get_positions()
 
         self._current_position = self._current_position.opposite()
         if self._current_position == CurrentPosition.LONG:

--- a/tests/bot_to_db_test.py
+++ b/tests/bot_to_db_test.py
@@ -109,7 +109,7 @@ class TestBotToDb:
         base_token_addr = fast_hyperdrive_fixture._deployed_hyperdrive.base_token_contract.address
         vault_shares_token_addr = fast_hyperdrive_fixture._deployed_hyperdrive.vault_shares_token_contract.address
         expected_pool_config = {
-            "contract_address": fast_hyperdrive_fixture.get_hyperdrive_address(),
+            "hyperdrive_address": fast_hyperdrive_fixture.get_hyperdrive_address(),
             "base_token": base_token_addr,
             "vault_shares_token": vault_shares_token_addr,
             "initial_vault_share_price": _to_unscaled_decimal(FixedPoint("1")),


### PR DESCRIPTION
This PR is the first of a series of PRs to support multi-pool trading in agent0.

In this PR, we move away from exposing the `agent.wallet` object (as we're deprecating doing bookkeeping on the wallet itself in python) in favor of using the `agent.get_positions()` function. This function (1) does a query of the chain to gather events and adds them to a `TradeEvent` db table, and (2) queries from the `TradeEvent` table to get the current positions a wallet has.

The `TradeEvent` table handles all events on any hyperdrive tokens (i.e., long/short/lp). There's a bit of overlap with the `WalletDelta` table, with the main exception that the `TradeEvent` table is lazy - the table only gets updated when `agent.get_positions()` gets called, and only with the events from `agent`. In addition, the table handles both trade events (e.g., `OpenLong`) and single transfer trades (e.g., wallet to wallet transfers of tokens). We likely can deprecate the `WalletDelta` table with a special call to gather all trade events from a Hyperdrive pool, which fills the `TradeEvent` table with every wallet that has made a trade on the pool.

There are a couple of places that can be optimized. Currently, we query the chain for events for every `get_positions` call (from the latest entry in the db to latest block). Some bookkeeping is needed to e.g., don't get events from the logs if a user calls `get_positions` on the same block.

As a temporary fix, we also remove `agent.wallet` from remote chains, and `get_positions` gathers all events from the remote chain each time it's called. This will get fixed once the database is exposed in the underlying chain object, with the remote wallet also using the `TradeEvent` table to gather wallet positions.

Final note: the failing test here is fixed in https://github.com/delvtech/agent0/pull/1462.

## Changes
- Removing interactive wallet in favor of using `get_positions()`.
- Added `TradeEvent` table to database, with supporting ingestion (`trade_events_to_db`) and query (`get_positions_from_db` and `get_trade_events`) interface functions.
- Changed all interactive `agent.wallet` calls to `agent.get_positions()`
- Renamed `contract_address` to `hyperdrive_address` in `PoolConfig` db table.