### PR TITLE
lp share price fuzz testing updates

### DIFF
--- a/scripts/local_fuzz_bots.py
+++ b/scripts/local_fuzz_bots.py
@@ -118,6 +118,3 @@ def parse_arguments(argv: Sequence[str] | None = None) -> Args:
 
 if __name__ == "__main__":
     main()
-
-if __name__ == "__main__":
-    main()

--- a/scripts/local_fuzz_bots.py
+++ b/scripts/local_fuzz_bots.py
@@ -103,7 +103,7 @@ def parse_arguments(argv: Sequence[str] | None = None) -> Args:
     """
     parser = argparse.ArgumentParser(description="Runs a loop to check Hyperdrive invariants at each block.")
     parser.add_argument(
-        "--lp_share_price_test",
+        "--lp-share-price-test",
         default=False,
         action="store_true",
         help="Runs the lp share price fuzz with specific fee and rate parameters.",

--- a/scripts/local_fuzz_bots.py
+++ b/scripts/local_fuzz_bots.py
@@ -15,7 +15,13 @@ from agent0.hyperlogs.rollbar_utilities import initialize_rollbar
 
 
 def main(argv: Sequence[str] | None = None) -> None:
-    """Runs local fuzz bots."""
+    """Runs local fuzz bots.
+
+    Arguments
+    ---------
+    argv: Sequence[str]
+        A sequence containing the uri to the database server and the test epsilon.
+    """
     # TODO consolidate setup into single function
 
     parsed_args = parse_arguments(argv)

--- a/scripts/local_fuzz_bots.py
+++ b/scripts/local_fuzz_bots.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import argparse
 import random
+import sys
+from typing import NamedTuple, Sequence
 
 import numpy as np
 
@@ -11,16 +14,26 @@ from agent0.hyperfuzz.system_fuzz import generate_fuzz_hyperdrive_config, run_lo
 from agent0.hyperlogs.rollbar_utilities import initialize_rollbar
 
 
-def main() -> None:
+def main(argv: Sequence[str] | None = None) -> None:
     """Runs local fuzz bots."""
     # TODO consolidate setup into single function
+
+    parsed_args = parse_arguments(argv)
 
     log_to_rollbar = initialize_rollbar("localfuzzbots")
 
     rng_seed = random.randint(0, 10000000)
     rng = np.random.default_rng(rng_seed)
 
-    local_chain_config = LocalChain.Config(chain_port=11111, db_port=22222, block_timestamp_interval=12)
+    # Set different ports if we're doing lp share price test
+    if parsed_args.lp_share_price_test:
+        chain_port = 11111
+        db_port = 22222
+    else:
+        chain_port = 33333
+        db_port = 44444
+
+    local_chain_config = LocalChain.Config(chain_port=chain_port, db_port=db_port, block_timestamp_interval=12)
 
     while True:
         # Build interactive local hyperdrive
@@ -29,7 +42,9 @@ def main() -> None:
         chain = LocalChain(local_chain_config)
 
         # Fuzz over config values
-        hyperdrive_config = generate_fuzz_hyperdrive_config(rng, log_to_rollbar, rng_seed)
+        hyperdrive_config = generate_fuzz_hyperdrive_config(
+            rng, log_to_rollbar, rng_seed, lp_share_price_test=parsed_args.lp_share_price_test
+        )
         hyperdrive_pool = LocalHyperdrive(chain, hyperdrive_config)
 
         # TODO submit multiple transactions per block
@@ -43,10 +58,66 @@ def main() -> None:
             random_advance_time=True,
             random_variable_rate=True,
             num_iterations=3000,
+            lp_share_price_test=parsed_args.lp_share_price_test,
         )
 
         chain.cleanup()
 
+
+class Args(NamedTuple):
+    """Command line arguments for the invariant checker."""
+
+    lp_share_price_test: bool
+
+
+def namespace_to_args(namespace: argparse.Namespace) -> Args:
+    """Converts argprase.Namespace to Args.
+
+    Arguments
+    ---------
+    namespace: argparse.Namespace
+        Object for storing arg attributes.
+
+    Returns
+    -------
+    Args
+        Formatted arguments
+    """
+    return Args(
+        lp_share_price_test=namespace.lp_share_price_test,
+    )
+
+
+def parse_arguments(argv: Sequence[str] | None = None) -> Args:
+    """Parses input arguments.
+
+    Arguments
+    ---------
+    argv: Sequence[str]
+        The argv values returned from argparser.
+
+    Returns
+    -------
+    Args
+        Formatted arguments
+    """
+    parser = argparse.ArgumentParser(description="Runs a loop to check Hyperdrive invariants at each block.")
+    parser.add_argument(
+        "--lp_share_price_test",
+        default=False,
+        action="store_true",
+        help="Runs the lp share price fuzz with specific fee and rate parameters.",
+    )
+
+    # Use system arguments if none were passed
+    if argv is None:
+        argv = sys.argv
+
+    return namespace_to_args(parser.parse_args())
+
+
+if __name__ == "__main__":
+    main()
 
 if __name__ == "__main__":
     main()

--- a/src/agent0/hyperfuzz/system_fuzz/invariant_checks.py
+++ b/src/agent0/hyperfuzz/system_fuzz/invariant_checks.py
@@ -355,9 +355,8 @@ def _check_lp_share_price(
 
 def _check_initial_lp_profitable(pool_state: PoolState, epsilon: FixedPoint | None = None) -> InvariantCheckResults:
 
-    # There's a rounding difference of 1 wei due to rounding lp_rate down
     if epsilon is None:
-        epsilon = FixedPoint(scaled_value=1)
+        epsilon = FixedPoint(".005")
 
     failed = False
     exception_message = ""

--- a/src/agent0/hyperfuzz/system_fuzz/invariant_checks.py
+++ b/src/agent0/hyperfuzz/system_fuzz/invariant_checks.py
@@ -27,6 +27,7 @@ def run_invariant_checks(
     raise_error_on_failure: bool = False,
     log_to_rollbar: bool = True,
     pool_name: str | None = None,
+    lp_share_price_test: bool | None = None,
 ) -> None:
     """Run the invariant checks.
 
@@ -54,6 +55,9 @@ def run_invariant_checks(
         If True, log to rollbar if any invariant check fails.
     pool_name: str | None
         The name of the pool for crash reporting information.
+    lp_share_price_test: bool | None, optional
+        If True, only test the lp share price. If False, skips the lp share price test.
+        If None (default), runs all tests.
     """
     # TODO cleanup
     # pylint: disable=too-many-locals
@@ -65,17 +69,35 @@ def run_invariant_checks(
     exception_message: list[str] = ["Continuous Fuzz Bots Invariant Checks"]
     exception_data: dict[str, Any] = {}
 
-    results: list[InvariantCheckResults] = [
-        _check_eth_balances(pool_state),
-        _check_base_balances(pool_state, interface.base_is_eth),
-        _check_total_shares(pool_state),
-        _check_minimum_share_reserves(pool_state),
-        _check_solvency(pool_state),
-        _check_present_value_greater_than_idle_shares(interface, pool_state),
-        _check_lp_share_price(interface, test_epsilon, pool_state),
-        _check_checkpointing_should_never_fail(interface, pool_state),
-        _check_initial_lp_profitable(pool_state),
-    ]
+    results: list[InvariantCheckResults]
+    if lp_share_price_test is None:
+        results = [
+            _check_lp_share_price(interface, test_epsilon, pool_state),
+            _check_eth_balances(pool_state),
+            _check_base_balances(pool_state, interface.base_is_eth),
+            _check_total_shares(pool_state),
+            _check_minimum_share_reserves(pool_state),
+            _check_solvency(pool_state),
+            _check_present_value_greater_than_idle_shares(interface, pool_state),
+            _check_checkpointing_should_never_fail(interface, pool_state),
+            _check_initial_lp_profitable(pool_state),
+        ]
+    else:
+        if lp_share_price_test:
+            results = [
+                _check_lp_share_price(interface, test_epsilon, pool_state),
+            ]
+        else:
+            results = [
+                _check_eth_balances(pool_state),
+                _check_base_balances(pool_state, interface.base_is_eth),
+                _check_total_shares(pool_state),
+                _check_minimum_share_reserves(pool_state),
+                _check_solvency(pool_state),
+                _check_present_value_greater_than_idle_shares(interface, pool_state),
+                _check_checkpointing_should_never_fail(interface, pool_state),
+                _check_initial_lp_profitable(pool_state),
+            ]
 
     for failed, message, data in results:
         any_check_failed = failed | any_check_failed
@@ -356,7 +378,7 @@ def _check_lp_share_price(
 def _check_initial_lp_profitable(pool_state: PoolState, epsilon: FixedPoint | None = None) -> InvariantCheckResults:
 
     if epsilon is None:
-        epsilon = FixedPoint(".005")
+        epsilon = FixedPoint("0.005")
 
     failed = False
     exception_message = ""


### PR DESCRIPTION
- LP share price now is a separate run with the `--lp-share-price-test` flag that sets its own fuzz parameters.
  - If this flag is set, we only run the lp share price test with 0 - 10% variable rate and no fees.
  - If this flag isn't set, we skip the lp share price test

- Updating lp profitability invariant check with more epsilon