### PR TITLE
Deployment cleanup

### DIFF
--- a/src/agent0/core/hyperdrive/interactive/chain.py
+++ b/src/agent0/core/hyperdrive/interactive/chain.py
@@ -139,9 +139,8 @@ class Chain:
         ---------
         rpc_uri: str
             The uri for the chain to connect to, e.g., `http://localhost:8545`.
-
-        config: Chain.Config
-            The chain configuration.
+        config: Chain.Config | None, optional
+            The chain configuration. Will use defaults if not provided.
         """
         if config is None:
             config = self.Config()

--- a/src/agent0/core/hyperdrive/interactive/local_chain.py
+++ b/src/agent0/core/hyperdrive/interactive/local_chain.py
@@ -77,15 +77,24 @@ class LocalChain(Chain):
         crash_log_ticker: bool = False
         """Whether to log the trade ticker in crash reports. Defaults to False."""
 
-    def __init__(self, config: Config | None = None, fork_uri: str | None = None, fork_block_number: int | None = None):
+    def __init__(
+        self,
+        config: Config | None = None,
+        fork_uri: str | None = None,
+        fork_block_number: int | None = None,
+    ):
         """Initialize the Chain class that connects to an existing chain.
 
         Also launch a postgres docker container for gathering data.
 
         Arguments
         ---------
-        config: Config | None
-            The local chain configuration.
+        config: Config | None, optional
+            The local chain configuration. Will use defaults if not provided.
+        fork_uri: str | None, optional
+            The URI of the fork to connect to. Will start a chain from scratch if not set.
+        fork_block_number: int | None, optional
+            The block number to fork at if fork_uri is set. Defaults to latest.
         """
         if config is None:
             config = self.Config()

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
@@ -18,7 +18,7 @@ from agent0.chainsync.db.hyperdrive import (
     get_trade_events,
 )
 from agent0.chainsync.exec import acquire_data, analyze_data
-from agent0.ethpy.hyperdrive import DeployedHyperdrivePool, deploy_hyperdrive_from_factory
+from agent0.ethpy.hyperdrive import DeployedHyperdriveFactory, DeployedHyperdrivePool, deploy_hyperdrive_from_factory
 from agent0.hypertypes import FactoryConfig, Fees, PoolDeployConfig
 
 from .event_types import CreateCheckpoint
@@ -307,7 +307,7 @@ class LocalHyperdrive(Hyperdrive):
 
         return deploy_hyperdrive_from_factory(
             chain.rpc_uri,
-            chain.get_deployer_account_private_key(),
+            chain.get_deployer_account(),
             config.initial_liquidity,
             config.initial_variable_rate,
             config.initial_fixed_apr,

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
@@ -18,7 +18,7 @@ from agent0.chainsync.db.hyperdrive import (
     get_trade_events,
 )
 from agent0.chainsync.exec import acquire_data, analyze_data
-from agent0.ethpy.hyperdrive import DeployedHyperdriveFactory, DeployedHyperdrivePool, deploy_hyperdrive_from_factory
+from agent0.ethpy.hyperdrive import DeployedHyperdrivePool, deploy_hyperdrive_factory, deploy_hyperdrive_from_factory
 from agent0.hypertypes import FactoryConfig, Fees, PoolDeployConfig
 
 from .event_types import CreateCheckpoint
@@ -305,14 +305,21 @@ class LocalHyperdrive(Hyperdrive):
             fees=config._fees,  # pylint: disable=protected-access
         )
 
+        # TODO move deploying factory to be part of a parent, where deploying hyperdrive
+        # only uses the factory
+
+        deployed_hyperdrive_factory = deploy_hyperdrive_factory(
+            chain.rpc_uri, chain.get_deployer_account(), factory_deploy_config
+        )
+
         return deploy_hyperdrive_from_factory(
             chain.rpc_uri,
             chain.get_deployer_account(),
+            deployed_hyperdrive_factory,
             config.initial_liquidity,
             config.initial_variable_rate,
             config.initial_fixed_apr,
             config.initial_time_stretch_apr,
-            factory_deploy_config,
             pool_deploy_config,
         )
 

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive_test.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive_test.py
@@ -1047,12 +1047,13 @@ def test_share_price_compounding_annus(fast_chain_fixture: LocalChain):
     )
     interactive_hyperdrive = LocalHyperdrive(fast_chain_fixture, interactive_config)
     hyperdrive_interface = interactive_hyperdrive.interface
+    beginning_share_price = hyperdrive_interface.current_pool_state.pool_info.lp_share_price
     logging.info(f"Variable rate: {hyperdrive_interface.current_pool_state.variable_rate}")
     logging.info(f"Starting share price: {hyperdrive_interface.current_pool_state.pool_info.lp_share_price}")
     fast_chain_fixture.advance_time(YEAR_IN_SECONDS, create_checkpoints=False)
     ending_share_price = hyperdrive_interface.current_pool_state.pool_info.lp_share_price
     logging.info(f"Ending   share price: {ending_share_price}")
-    assert ending_share_price - 1 == initial_variable_rate
+    assert ending_share_price - beginning_share_price == initial_variable_rate
 
 
 @pytest.mark.anvil

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive_test.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive_test.py
@@ -1049,7 +1049,7 @@ def test_share_price_compounding_annus(fast_chain_fixture: LocalChain):
     hyperdrive_interface = interactive_hyperdrive.interface
     beginning_share_price = hyperdrive_interface.current_pool_state.pool_info.lp_share_price
     logging.info(f"Variable rate: {hyperdrive_interface.current_pool_state.variable_rate}")
-    logging.info(f"Starting share price: {hyperdrive_interface.current_pool_state.pool_info.lp_share_price}")
+    logging.info(f"Starting share price: {beginning_share_price}")
     fast_chain_fixture.advance_time(YEAR_IN_SECONDS, create_checkpoints=False)
     ending_share_price = hyperdrive_interface.current_pool_state.pool_info.lp_share_price
     logging.info(f"Ending   share price: {ending_share_price}")

--- a/src/agent0/ethpy/hyperdrive/__init__.py
+++ b/src/agent0/ethpy/hyperdrive/__init__.py
@@ -6,7 +6,7 @@ from .addresses import (
     get_hyperdrive_registry_from_artifacts,
 )
 from .assets import BASE_TOKEN_SYMBOL, AssetIdPrefix, decode_asset_id, encode_asset_id
-from .deploy import DeployedHyperdrivePool, deploy_hyperdrive_from_factory
+from .deploy import DeployedHyperdriveFactory, DeployedHyperdrivePool, deploy_hyperdrive_from_factory
 from .get_expected_hyperdrive_version import get_expected_hyperdrive_version
 from .interface import HyperdriveReadInterface, HyperdriveReadWriteInterface
 from .receipt_breakdown import ReceiptBreakdown

--- a/src/agent0/ethpy/hyperdrive/__init__.py
+++ b/src/agent0/ethpy/hyperdrive/__init__.py
@@ -6,7 +6,12 @@ from .addresses import (
     get_hyperdrive_registry_from_artifacts,
 )
 from .assets import BASE_TOKEN_SYMBOL, AssetIdPrefix, decode_asset_id, encode_asset_id
-from .deploy import DeployedHyperdriveFactory, DeployedHyperdrivePool, deploy_hyperdrive_from_factory
+from .deploy import (
+    DeployedHyperdriveFactory,
+    DeployedHyperdrivePool,
+    deploy_hyperdrive_factory,
+    deploy_hyperdrive_from_factory,
+)
 from .get_expected_hyperdrive_version import get_expected_hyperdrive_version
 from .interface import HyperdriveReadInterface, HyperdriveReadWriteInterface
 from .receipt_breakdown import ReceiptBreakdown

--- a/src/agent0/ethpy/hyperdrive/deploy.py
+++ b/src/agent0/ethpy/hyperdrive/deploy.py
@@ -28,6 +28,7 @@ from agent0.hypertypes import (
     ERC4626Target3DeployerContract,
     FactoryConfig,
     HyperdriveFactoryContract,
+    HyperdriveRegistryContract,
     IHyperdriveContract,
     LPMathContract,
     MockERC4626Contract,
@@ -47,10 +48,19 @@ from agent0.hypertypes.types.ERC4626Target3DeployerContract import erc4626target
 UINT256_MAX = int(2**256 - 1)
 
 
+class DeployedHyperdriveFactory(NamedTuple):
+    """Collection of attributes associated with a locally deployed Hyperdrive factory."""
+
+    deploy_account: LocalAccount
+    factory_contract: HyperdriveFactoryContract
+    deployer_coordinator_contract: ERC4626HyperdriveDeployerCoordinatorContract
+    factory_deploy_config: FactoryConfig
+    registry_contract: HyperdriveRegistryContract
+
+
 class DeployedHyperdrivePool(NamedTuple):
     """Collection of attributes associated with a locally deployed chain with a Hyperdrive pool."""
 
-    web3: Web3
     deploy_account: LocalAccount
     hyperdrive_contract: IHyperdriveContract
     # Keeping the base and vault shares contract generic
@@ -59,59 +69,33 @@ class DeployedHyperdrivePool(NamedTuple):
     deploy_block_number: int
 
 
-def deploy_hyperdrive_from_factory(
+def deploy_hyperdrive_factory(
     rpc_uri: str,
-    deployer_private_key: str,
-    initial_liquidity: FixedPoint,
-    initial_variable_rate: FixedPoint,
-    initial_fixed_apr: FixedPoint,
-    initial_time_stretch_apr: FixedPoint,
+    deployer_account: LocalAccount,
     factory_deploy_config: FactoryConfig,
-    pool_deploy_config: PoolDeployConfig,
-) -> DeployedHyperdrivePool:
-    """Initializes a Hyperdrive pool on an existing chain.
+) -> DeployedHyperdriveFactory:
+    """Deploys the hyperdrive factory and supporting contracts on the rpc_uri chain.
 
     Arguments
     ---------
     rpc_uri: str
-        The URI of the local RPC node.
-    deployer_private_key: str
-        Private key for the funded wallet for deploying Hyperdrive.
-    initial_liquidity: FixedPoint
-        The amount of money to be provided by the `deploy_account` for initial pool liquidity.
-    initial_variable_rate: FixedPoint
-        The starting variable rate for an underlying vault.
-    initial_fixed_apr: FixedPoint
-        The fixed rate of the pool on initialization.
-    initial_time_stretch_apr: FixedPoint
-        The apr to target for the time stretch calculation.
+        The URI of the RPC node.
+    deployer_account: LocalAccount
+        The account that's deploying the contract.
     factory_deploy_config: FactoryConfig
-        The configuration for initializing the hyperdrive factory.
-        The type is generated from the Hyperdrive ABI using Pypechain.
-    pool_deploy_config: PoolDeployConfig
-        The configuration for initializing hyperdrive pool.
+        The factory configuration for initializing the hyperdrive factory.
         The type is generated from the Hyperdrive ABI using Pypechain.
 
     Returns
     -------
-    LocalHyperdriveChain
-        A named tuple with the following fields:
-            web3: Web3
-                Web3 provider object.
-            deploy_account: LocalAccount
-                The local account that deploys and initializes hyperdrive.
-            hyperdrive_contract: Contract
-                Web3 contract instance for the hyperdrive contract.
-            base_token_contract: Contract
-                Web3 contract instance for the base token contract.
-            deploy_block_number: int
-                The block number hyperdrive was deployed at.
+    DeployedHyperdriveFactory
+        Containing the deployed factory, the deploy coordinator contracts, the updated
+        factory config, and the hyperdrive registry contract.
     """
     # Contract calls use the web3.py interface
     web3 = initialize_web3_with_http_provider(rpc_uri, reset_provider=False)
     # Create the pre-funded account on the Delv devnet
-    deploy_account = _initialize_deployment_account(web3, deployer_private_key)
-    deploy_account_addr = Web3.to_checksum_address(deploy_account.address)
+    deploy_account_addr = Web3.to_checksum_address(deployer_account.address)
 
     # Update various configs with the deploy account address
     factory_deploy_config.governance = deploy_account_addr
@@ -121,13 +105,68 @@ def deploy_hyperdrive_from_factory(
     factory_deploy_config.sweepCollector = deploy_account_addr
 
     # Deploy the factory and base token contracts
-    factory_contract, deployer_contract, factory_deploy_config = _deploy_hyperdrive_factory(
+    return _deploy_hyperdrive_factory(
         web3,
-        deploy_account,
+        deployer_account,
         factory_deploy_config,
     )
 
-    base_token_contract, vault_contract = _deploy_base_and_vault(web3, deploy_account, initial_variable_rate)
+
+def deploy_hyperdrive_from_factory(
+    rpc_uri: str,
+    deployer_account: LocalAccount,
+    deployed_factory: DeployedHyperdriveFactory,
+    initial_liquidity: FixedPoint,
+    initial_variable_rate: FixedPoint,
+    initial_fixed_apr: FixedPoint,
+    initial_time_stretch_apr: FixedPoint,
+    pool_deploy_config: PoolDeployConfig,
+) -> DeployedHyperdrivePool:
+    """Initializes a Hyperdrive pool and supporting contracts on an existing chain.
+
+    Arguments
+    ---------
+    rpc_uri: str
+        The URI of the local RPC node.
+    deployer_account: LocalAccount
+        The local account deploying Hyperdrive.
+    deployed_factory: DeployedHyperdriveFactory
+        The factory and supporting contracts that were deployed on the local chain.
+    initial_liquidity: FixedPoint
+        The amount of money to be provided by the `deployer_account` for initial pool liquidity.
+    initial_variable_rate: FixedPoint
+        The starting variable rate for an underlying vault.
+    initial_fixed_apr: FixedPoint
+        The fixed rate of the pool on initialization.
+    initial_time_stretch_apr: FixedPoint
+        The apr to target for the time stretch calculation.
+    pool_deploy_config: PoolDeployConfig
+        The configuration for initializing hyperdrive pool.
+        The type is generated from the Hyperdrive ABI using Pypechain.
+
+    Returns
+    -------
+    DeployedHyperdrivePool
+        A named tuple with the following fields:
+            deploy_account: LocalAccount
+                The local account that deploys and initializes hyperdrive.
+            hyperdrive_contract: IHyperdriveContract
+                Web3 contract instance for the hyperdrive contract.
+            base_token_contract: Contract
+                Web3 contract instance for the base token contract.
+            vault_shares_token_contract: Contract
+                Web3 contract instance for the vault shares token contract.
+            deploy_block_number: int
+                The block number hyperdrive was deployed at.
+    """
+
+    # Contract calls use the web3.py interface
+    web3 = initialize_web3_with_http_provider(rpc_uri, reset_provider=False)
+
+    # Create the pre-funded account on the Delv devnet
+    deploy_account_addr = Web3.to_checksum_address(deployer_account.address)
+
+    base_token_contract, vault_contract = _deploy_base_and_vault(web3, deployer_account, initial_variable_rate)
 
     # Update pool deploy config with factory settings
     pool_deploy_config.baseToken = base_token_contract.address
@@ -135,15 +174,15 @@ def deploy_hyperdrive_from_factory(
     pool_deploy_config.governance = deploy_account_addr
     pool_deploy_config.feeCollector = deploy_account_addr
     pool_deploy_config.sweepCollector = deploy_account_addr
-    pool_deploy_config.linkerFactory = factory_deploy_config.linkerFactory
-    pool_deploy_config.linkerCodeHash = factory_deploy_config.linkerCodeHash
+    pool_deploy_config.linkerFactory = deployed_factory.factory_deploy_config.linkerFactory
+    pool_deploy_config.linkerCodeHash = deployed_factory.factory_deploy_config.linkerCodeHash
 
     # Mint base and approve the initial liquidity amount for the hyperdrive factory
     _mint_and_approve(
         web3=web3,
-        funding_account=deploy_account,
+        funding_account=deployer_account,
         funding_contract=base_token_contract,
-        contract_to_approve=deployer_contract,
+        contract_to_approve=deployed_factory.deployer_coordinator_contract,
         mint_amount=initial_liquidity,
     )
 
@@ -151,19 +190,32 @@ def deploy_hyperdrive_from_factory(
     hyperdrive_checksum_address = Web3.to_checksum_address(
         _deploy_and_initialize_hyperdrive_pool(
             web3,
-            deployer_contract.address,
-            deploy_account,
+            deployed_factory.deployer_coordinator_contract.address,
+            deployer_account,
             initial_liquidity,
             initial_fixed_apr,
             initial_time_stretch_apr,
             pool_deploy_config,
-            factory_contract,
+            deployed_factory.factory_contract,
         )
     )
+
+    # Register this pool with the registry contract
+    register_function = deployed_factory.registry_contract.functions.setHyperdriveInfo(hyperdrive_checksum_address, 1)
+    function_name = register_function.fn_name
+    function_args = register_function.args
+    receipt = smart_contract_transact(
+        web3,
+        deployed_factory.registry_contract,
+        deployer_account,
+        function_name,
+        *function_args,
+    )
+    assert receipt["status"] == 1, f"Failed to register Hyperdrive contract.\n{receipt=}"
+
     # Get block number when hyperdrive was deployed
     return DeployedHyperdrivePool(
-        web3,
-        deploy_account=deploy_account,
+        deploy_account=deployer_account,
         hyperdrive_contract=IHyperdriveContract.factory(web3)(hyperdrive_checksum_address),
         base_token_contract=base_token_contract,
         vault_shares_token_contract=vault_contract,
@@ -201,7 +253,7 @@ def _deploy_hyperdrive_factory(
     web3: Web3,
     deploy_account: LocalAccount,
     factory_deploy_config: FactoryConfig,
-) -> tuple[HyperdriveFactoryContract, ERC4626HyperdriveDeployerCoordinatorContract, FactoryConfig]:
+) -> DeployedHyperdriveFactory:
     """Deploys the hyperdrive factory contract on the rpc_uri chain.
 
     Arguments
@@ -262,7 +314,7 @@ def _deploy_hyperdrive_factory(
     target1_contract = ERC4626Target1DeployerContract.deploy(w3=web3, account=deploy_account_addr)
     target2_contract = ERC4626Target2DeployerContract.deploy(w3=web3, account=deploy_account_addr)
     target3_contract = ERC4626Target3DeployerContract.deploy(w3=web3, account=deploy_account_addr)
-    deployer_contract = ERC4626HyperdriveDeployerCoordinatorContract.deploy(
+    deployer_coordinator_contract = ERC4626HyperdriveDeployerCoordinatorContract.deploy(
         w3=web3,
         account=deploy_account_addr,
         constructorArgs=ERC4626HyperdriveDeployerCoordinatorContract.ConstructorArgs(
@@ -274,7 +326,9 @@ def _deploy_hyperdrive_factory(
             target3Deployer=target3_contract.address,
         ),
     )
-    add_deployer_coordinator_function = factory_contract.functions.addDeployerCoordinator(deployer_contract.address)
+    add_deployer_coordinator_function = factory_contract.functions.addDeployerCoordinator(
+        deployer_coordinator_contract.address
+    )
     function_name = add_deployer_coordinator_function.fn_name
     function_args = add_deployer_coordinator_function.args
     receipt = smart_contract_transact(
@@ -285,7 +339,21 @@ def _deploy_hyperdrive_factory(
         *function_args,
     )
     assert receipt["status"] == 1, f"Failed adding the Hyperdrive deployer to the factory.\n{receipt=}"
-    return factory_contract, deployer_contract, factory_deploy_config
+
+    # Deploy the hyperdrive registry contract
+    registry_contract = HyperdriveRegistryContract.deploy(
+        w3=web3,
+        account=deploy_account_addr,
+        constructorArgs=HyperdriveRegistryContract.ConstructorArgs(name="HyperdriveRegistry"),
+    )
+
+    return DeployedHyperdriveFactory(
+        deploy_account=deploy_account,
+        factory_contract=factory_contract,
+        deployer_coordinator_contract=deployer_coordinator_contract,
+        factory_deploy_config=factory_deploy_config,
+        registry_contract=registry_contract,
+    )
 
 
 def _deploy_base_and_vault(

--- a/src/agent0/ethpy/hyperdrive/deploy.py
+++ b/src/agent0/ethpy/hyperdrive/deploy.py
@@ -51,7 +51,6 @@ UINT256_MAX = int(2**256 - 1)
 class DeployedHyperdriveFactory(NamedTuple):
     """Collection of attributes associated with a locally deployed Hyperdrive factory."""
 
-    deploy_account: LocalAccount
     factory_contract: HyperdriveFactoryContract
     deployer_coordinator_contract: ERC4626HyperdriveDeployerCoordinatorContract
     factory_deploy_config: FactoryConfig
@@ -61,7 +60,6 @@ class DeployedHyperdriveFactory(NamedTuple):
 class DeployedHyperdrivePool(NamedTuple):
     """Collection of attributes associated with a locally deployed chain with a Hyperdrive pool."""
 
-    deploy_account: LocalAccount
     hyperdrive_contract: IHyperdriveContract
     # Keeping the base and vault shares contract generic
     base_token_contract: Contract
@@ -215,7 +213,6 @@ def deploy_hyperdrive_from_factory(
 
     # Get block number when hyperdrive was deployed
     return DeployedHyperdrivePool(
-        deploy_account=deployer_account,
         hyperdrive_contract=IHyperdriveContract.factory(web3)(hyperdrive_checksum_address),
         base_token_contract=base_token_contract,
         vault_shares_token_contract=vault_contract,
@@ -348,7 +345,6 @@ def _deploy_hyperdrive_factory(
     )
 
     return DeployedHyperdriveFactory(
-        deploy_account=deploy_account,
         factory_contract=factory_contract,
         deployer_coordinator_contract=deployer_coordinator_contract,
         factory_deploy_config=factory_deploy_config,

--- a/src/agent0/ethpy/hyperdrive/deploy.py
+++ b/src/agent0/ethpy/hyperdrive/deploy.py
@@ -209,7 +209,8 @@ def deploy_hyperdrive_from_factory(
         function_name,
         *function_args,
     )
-    assert receipt["status"] == 1, f"Failed to register Hyperdrive contract.\n{receipt=}"
+    if receipt["status"] != 1:
+        raise ValueError(f"Failed to register Hyperdrive contract.\n{receipt=}")
 
     # Get block number when hyperdrive was deployed
     return DeployedHyperdrivePool(
@@ -335,7 +336,8 @@ def _deploy_hyperdrive_factory(
         function_name,
         *function_args,
     )
-    assert receipt["status"] == 1, f"Failed adding the Hyperdrive deployer to the factory.\n{receipt=}"
+    if receipt["status"] != 1:
+        raise ValueError(f"Failed adding the Hyperdrive deployer to the factory.\n{receipt=}")
 
     # Deploy the hyperdrive registry contract
     registry_contract = HyperdriveRegistryContract.deploy(
@@ -531,7 +533,8 @@ def _deploy_and_initialize_hyperdrive_pool(
             function_name,
             *function_args,
         )
-        assert receipt["status"] == 1, f"Failed calling deployTarget on target {target_index}.\n{receipt=}"
+        if receipt["status"] != 1:
+            raise ValueError(f"Failed calling deployTarget on target {target_index}.\n{receipt=}")
 
     deploy_and_init_function = factory_contract.functions.deployAndInitialize(
         deploymentId=deployment_id,

--- a/src/agent0/ethpy/hyperdrive/interface/read_interface.py
+++ b/src/agent0/ethpy/hyperdrive/interface/read_interface.py
@@ -6,7 +6,6 @@ import copy
 import logging
 from typing import TYPE_CHECKING, cast
 
-from eth_account import Account
 from fixedpointmath import FixedPoint
 from web3.exceptions import BadFunctionCallOutput, ContractLogicError
 from web3.types import BlockData, BlockIdentifier, Timestamp
@@ -181,8 +180,6 @@ class HyperdriveReadInterface:
 
     def _create_deployed_hyperdrive_pool(self) -> DeployedHyperdrivePool:
         return DeployedHyperdrivePool(
-            web3=self.web3,
-            deploy_account=Account().from_key("0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"),
             hyperdrive_contract=self.hyperdrive_contract,
             base_token_contract=self.base_token_contract,
             vault_shares_token_contract=self.vault_shares_token_contract,

--- a/src/agent0/ethpy/hyperdrive/interface/read_interface_test.py
+++ b/src/agent0/ethpy/hyperdrive/interface/read_interface_test.py
@@ -7,6 +7,8 @@ from dataclasses import fields
 from datetime import datetime
 from typing import TYPE_CHECKING, cast
 
+from eth_account import Account
+from eth_account.signers.local import LocalAccount
 from fixedpointmath import FixedPoint
 
 from agent0.hypertypes import PoolConfig
@@ -210,7 +212,10 @@ class TestHyperdriveReadInterface:
         expected_timestretch_fp = FixedPoint(1) / (
             FixedPoint("5.24592") / (FixedPoint("0.04665") * (initial_fixed_rate * FixedPoint(100)))
         )
-        deploy_account = local_hyperdrive_pool.deploy_account
+        # This deploy account is defined from the fixture, which is using anvil account0.
+        deploy_account: LocalAccount = Account().from_key(
+            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+        )
         base_token_address = local_hyperdrive_pool.base_token_contract.address
         vault_shares_token_address = local_hyperdrive_pool.vault_shares_token_contract.address
         expected_pool_config = {


### PR DESCRIPTION
PR to clean up hyperdrive deployment.

- Splitting up factory deployment and hyperdrive deployment from factory.
- Factory deployment also deploys a registry.
- Cleaning up named tuple outputs for deploy functions