### PR TITLE
Short examples and ux fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ pool_info = hyperdrive.get_pool_info(coerce_float=True)
 pool_info.plot(x="block_number", y="longs_outstanding", kind="line")
 ```
 
-See our [tutorial notebook](examples/tutorial.ipynb) for more information, including details on executing trades on remote chains.
+See our [tutorial notebook](examples/tutorial.ipynb) and [examples notebook](examples/short_examples.ipynb) for more information, including details on executing trades on remote chains.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ from agent0 import LocalHyperdrive, LocalChain
 # Initialize
 chain = LocalChain()
 hyperdrive = LocalHyperdrive(chain)
-hyperdrive_agent0 = hyperdrive.init_agent(base=FixedPoint(100_000), eth=FixedPoint(10))
+hyperdrive_agent0 = chain.init_agent(base=FixedPoint(100_000), eth=FixedPoint(10), pool=hyperdrive)
 
 # Run trades
 chain.advance_time(datetime.timedelta(weeks=1))
@@ -48,8 +48,8 @@ close_event = hyperdrive_agent0.close_long(
 )
 
 # Analyze
-pool_state = hyperdrive.get_pool_state(coerce_float=True)
-pool_state.plot(x="block_number", y="longs_outstanding", kind="line")
+pool_info = hyperdrive.get_pool_info(coerce_float=True)
+pool_info.plot(x="block_number", y="longs_outstanding", kind="line")
 ```
 
 See our [tutorial notebook](examples/tutorial.ipynb) for more information, including details on executing trades on remote chains.

--- a/examples/short_examples.ipynb
+++ b/examples/short_examples.ipynb
@@ -65,12 +65,12 @@
     "for pool in registered_pools:\n",
     "    # Close all mature longs\n",
     "    for long in agent.get_longs(pool=pool):\n",
-    "        if long.maturity_time > chain.block_time():\n",
+    "        if long.maturity_time <= chain.block_time():\n",
     "            print(f\"Close long-{long.maturity_time} on {pool.name}\")\n",
     "            agent.close_long(maturity_time=long.maturity_time, bonds=long.balance, pool=pool)\n",
     "    # Close all mature shorts\n",
     "    for short in agent.get_shorts(pool=pool):\n",
-    "        if short.maturity_time > chain.block_time():\n",
+    "        if short.maturity_time <= chain.block_time():\n",
     "            print(f\"Close short-{short.maturity_time} on {pool.name}\")\n",
     "            agent.close_short(maturity_time=short.maturity_time, bonds=short.balance, pool=pool)"
    ]
@@ -78,6 +78,72 @@
   {
    "cell_type": "markdown",
    "metadata": {},
+   "source": [
+    "## Write policies in Python\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from agent0 import HyperdriveBasePolicy, open_long_trade\n",
+    "from fixedpointmath import FixedPoint\n",
+    "from dataclasses import dataclass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class OpenLongPolicy(HyperdriveBasePolicy):\n",
+    "    @dataclass(kw_only=True)\n",
+    "    class Config(HyperdriveBasePolicy.Config):\n",
+    "        fixed_rate_threshold: FixedPoint\n",
+    "        open_long_amount: FixedPoint\n",
+    "\n",
+    "    def action(self, interface, wallet):\n",
+    "        \"\"\"Get agent actions for teh current block\n",
+    "\n",
+    "        Action fn returns the trades to be executed\n",
+    "        at a given moment in time.\n",
+    "        \"\"\"\n",
+    "        done_trading = False  # Never done trading\n",
+    "\n",
+    "        # If no longs in wallet, we check our fixed rate\n",
+    "        # threshold and open the long if threshold reached.\n",
+    "        if len(wallet.longs) == 0:\n",
+    "            if interface.calc_spot_rate() > self.config.fixed_rate_threshold:\n",
+    "                return [open_long_trade(self.config.open_long_amount)], done_trading\n",
+    "\n",
+    "        # We don't do any trades otherwise\n",
+    "        return [], done_trading"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agent.set_active(\n",
+    "    policy=OpenLongPolicy,\n",
+    "    policy_config=OpenLongPolicy.Config(\n",
+    "        fixed_rate_threshold=FixedPoint(0.06),\n",
+    "        open_long_amount=FixedPoint(\"100_000\"),\n",
+    "    ),\n",
+    ")\n",
+    "agent.execute_policy_action(pool=registered_pools[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": []
   }
  ],

--- a/examples/short_examples.ipynb
+++ b/examples/short_examples.ipynb
@@ -139,13 +139,6 @@
     ")\n",
     "agent.execute_policy_action(pool=registered_pools[0])"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/short_examples.ipynb
+++ b/examples/short_examples.ipynb
@@ -58,6 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# PRIVATE_KEY = \"0xPRIVATE_KEY\"\n",
     "PRIVATE_KEY = os.getenv(\"PRIVATE_KEY\")\n",
     "\n",
     "# Initialize agent with private key for transactions\n",

--- a/examples/tweet_examples.ipynb
+++ b/examples/tweet_examples.ipynb
@@ -1,0 +1,59 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv(\".env\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from agent0 import Chain, Hyperdrive\n",
+    "import os\n",
+    "\n",
+    "# PRIVATE_KEY = \"0xPRIVATE_KEY\"\n",
+    "# RPC_URI = \"https://sepolia.rpc.url\"\n",
+    "\n",
+    "PRIVATE_KEY = os.getenv(\"PRIVATE_KEY\")\n",
+    "RPC_URI = os.getenv(\"RPC_URI\")\n",
+    "\n",
+    "# Address of Hyperdrive Sepolia registry\n",
+    "REGISTRY_ADDRESS = \"0x4ba58147e50e57e71177cfedb1fac0303f216104\"\n",
+    "\n",
+    "## View open positions in all pools\n",
+    "chain = Chain(RPC_URI)\n",
+    "agent = chain.init_agent(private_key=PRIVATE_KEY)\n",
+    "agent.get_positions(registry_address=REGISTRY_ADDRESS)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/tweet_examples.ipynb
+++ b/examples/tweet_examples.ipynb
@@ -12,6 +12,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Query all your positions\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -20,19 +27,29 @@
     "from agent0 import Chain, Hyperdrive\n",
     "import os\n",
     "\n",
-    "# PRIVATE_KEY = \"0xPRIVATE_KEY\"\n",
+    "# PUBLIC_ADDRESS = \"0xPUBLIC_ADDRESS\"\n",
     "# RPC_URI = \"https://sepolia.rpc.url\"\n",
-    "\n",
-    "PRIVATE_KEY = os.getenv(\"PRIVATE_KEY\")\n",
+    "PUBLIC_ADDRESS = os.getenv(\"PUBLIC_ADDRESS\")\n",
     "RPC_URI = os.getenv(\"RPC_URI\")\n",
     "\n",
     "# Address of Hyperdrive Sepolia registry\n",
     "REGISTRY_ADDRESS = \"0x4ba58147e50e57e71177cfedb1fac0303f216104\"\n",
     "\n",
-    "## View open positions in all pools\n",
+    "## View open and closed positions in all pools\n",
     "chain = Chain(RPC_URI)\n",
-    "agent = chain.init_agent(private_key=PRIVATE_KEY)\n",
-    "agent.get_positions(registry_address=REGISTRY_ADDRESS)"
+    "agent = chain.init_agent(public_address=PUBLIC_ADDRESS)\n",
+    "registered_pools = Hyperdrive.get_hyperdrive_pools_from_registry(\n",
+    "    chain,\n",
+    "    registry_address=REGISTRY_ADDRESS,\n",
+    ")\n",
+    "agent.get_positions(pool_filter=registered_pools, show_closed_positions=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Automate withdrawing funds from matured positions\n"
    ]
   },
   {
@@ -40,6 +57,27 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": [
+    "PRIVATE_KEY = os.getenv(\"PRIVATE_KEY\")\n",
+    "\n",
+    "# Initialize agent with private key for transactions\n",
+    "agent = chain.init_agent(private_key=PRIVATE_KEY)\n",
+    "for pool in registered_pools:\n",
+    "    # Close all mature longs\n",
+    "    for long in agent.get_longs(pool=pool):\n",
+    "        if long.maturity_time > chain.block_time():\n",
+    "            print(f\"Close long-{long.maturity_time} on {pool.name}\")\n",
+    "            agent.close_long(maturity_time=long.maturity_time, bonds=long.balance, pool=pool)\n",
+    "    # Close all mature shorts\n",
+    "    for short in agent.get_shorts(pool=pool):\n",
+    "        if short.maturity_time > chain.block_time():\n",
+    "            print(f\"Close short-{short.maturity_time} on {pool.name}\")\n",
+    "            agent.close_short(maturity_time=short.maturity_time, bonds=short.balance, pool=pool)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": []
   }
  ],
@@ -50,7 +88,15 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
    "version": "3.10.11"
   }
  },

--- a/src/agent0/chainsync/db/hyperdrive/interface.py
+++ b/src/agent0/chainsync/db/hyperdrive/interface.py
@@ -595,7 +595,7 @@ def get_all_traders(session: Session, hyperdrive_address: str | None = None) -> 
 # pylint: disable=too-many-arguments
 def get_position_snapshot(
     session: Session,
-    hyperdrive_address: str | None = None,
+    hyperdrive_address: list[str] | str | None = None,
     start_block: int | None = None,
     end_block: int | None = None,
     wallet_address: list[str] | str | None = None,
@@ -607,8 +607,8 @@ def get_position_snapshot(
     ---------
     session: Session
         The initialized session object.
-    hyperdrive_address: str | None, optional
-        The hyperdrive pool address to filter the query on. Defaults to returning all position snapshots.
+    hyperdrive_address: list[str] | str | None, optional
+        The hyperdrive pool address(es) to filter the query on. Defaults to returning all position snapshots.
     start_block: int | None, optional
         The starting block to filter the query on. start_block integers
         matches python slicing notation, e.g., list[:3], list[:-3].
@@ -630,7 +630,9 @@ def get_position_snapshot(
     """
     query = session.query(PositionSnapshot)
 
-    if hyperdrive_address is not None:
+    if isinstance(hyperdrive_address, list):
+        query = query.filter(PositionSnapshot.hyperdrive_address.in_(hyperdrive_address))
+    elif hyperdrive_address is not None:
         query = query.filter(PositionSnapshot.hyperdrive_address == hyperdrive_address)
 
     latest_block = get_latest_block_number_from_table(PositionSnapshot, session)

--- a/src/agent0/core/hyperdrive/interactive/chain.py
+++ b/src/agent0/core/hyperdrive/interactive/chain.py
@@ -7,7 +7,7 @@ import logging
 import os
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, Type
+from typing import TYPE_CHECKING, Any, Type
 
 import docker
 import numpy as np
@@ -25,11 +25,12 @@ from agent0.chainsync.db.hyperdrive import get_hyperdrive_addr_to_name
 from agent0.chainsync.postgres_config import build_postgres_config_from_env
 from agent0.core.hyperdrive.policies import HyperdriveBasePolicy
 from agent0.ethpy.base import initialize_web3_with_http_provider
-from agent0.ethpy.hyperdrive import get_hyperdrive_addresses_from_registry
 from agent0.hyperlogs import close_logging, setup_logging
 
-from .hyperdrive import Hyperdrive
 from .hyperdrive_agent import HyperdriveAgent
+
+if TYPE_CHECKING:
+    from .hyperdrive import Hyperdrive
 
 
 class Chain:
@@ -341,30 +342,6 @@ class Chain:
     def is_local_chain(self) -> bool:
         """Returns if this object is a local chain."""
         return False
-
-    def get_registered_pools(self, registry_address: str) -> list[Hyperdrive]:
-        """Returns hyperdrive objects for all availabie pools
-
-        Arguments
-        ---------
-        registry_address: str, optional
-            The registry address to query all positions across registered pools. Can't be used with pool_filter.
-
-        Returns
-        -------
-        list[Hyperdrive]
-            The hyperdrive objects for all registered pools
-        """
-        # Get all pools from registry
-        hyperdrive_addresses = get_hyperdrive_addresses_from_registry(registry_address, self._web3)
-        if len(hyperdrive_addresses) == 0:
-            raise ValueError("Registry does not have any hyperdrive pools registered.")
-        # Generate hyperdrive pool objects here
-        registered_pools = []
-        for hyperdrive_name, hyperdrive_address in hyperdrive_addresses.items():
-            registered_pools.append(Hyperdrive(self, hyperdrive_address, name=hyperdrive_name))
-
-        return registered_pools
 
     ################
     # Agent functions

--- a/src/agent0/core/hyperdrive/interactive/chain.py
+++ b/src/agent0/core/hyperdrive/interactive/chain.py
@@ -7,7 +7,7 @@ import logging
 import os
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Type
+from typing import Any, Type
 
 import docker
 import numpy as np
@@ -25,12 +25,11 @@ from agent0.chainsync.db.hyperdrive import get_hyperdrive_addr_to_name
 from agent0.chainsync.postgres_config import build_postgres_config_from_env
 from agent0.core.hyperdrive.policies import HyperdriveBasePolicy
 from agent0.ethpy.base import initialize_web3_with_http_provider
+from agent0.ethpy.hyperdrive import get_hyperdrive_addresses_from_registry
 from agent0.hyperlogs import close_logging, setup_logging
 
+from .hyperdrive import Hyperdrive
 from .hyperdrive_agent import HyperdriveAgent
-
-if TYPE_CHECKING:
-    from .hyperdrive import Hyperdrive
 
 
 class Chain:
@@ -342,6 +341,30 @@ class Chain:
     def is_local_chain(self) -> bool:
         """Returns if this object is a local chain."""
         return False
+
+    def get_registered_pools(self, registry_address: str) -> list[Hyperdrive]:
+        """Returns hyperdrive objects for all availabie pools
+
+        Arguments
+        ---------
+        registry_address: str, optional
+            The registry address to query all positions across registered pools. Can't be used with pool_filter.
+
+        Returns
+        -------
+        list[Hyperdrive]
+            The hyperdrive objects for all registered pools
+        """
+        # Get all pools from registry
+        hyperdrive_addresses = get_hyperdrive_addresses_from_registry(registry_address, self._web3)
+        if len(hyperdrive_addresses) == 0:
+            raise ValueError("Registry does not have any hyperdrive pools registered.")
+        # Generate hyperdrive pool objects here
+        registered_pools = []
+        for hyperdrive_name, hyperdrive_address in hyperdrive_addresses.items():
+            registered_pools.append(Hyperdrive(self, hyperdrive_address, name=hyperdrive_name))
+
+        return registered_pools
 
     ################
     # Agent functions

--- a/src/agent0/core/hyperdrive/interactive/chain.py
+++ b/src/agent0/core/hyperdrive/interactive/chain.py
@@ -338,6 +338,11 @@ class Chain:
             raise AssertionError("The provided block has no timestamp")
         return block_timestamp
 
+    @property
+    def is_local_chain(self) -> bool:
+        """Returns if this object is a local chain."""
+        return False
+
     ################
     # Agent functions
     ################

--- a/src/agent0/core/hyperdrive/interactive/chain.py
+++ b/src/agent0/core/hyperdrive/interactive/chain.py
@@ -371,7 +371,8 @@ class Chain:
 
     def init_agent(
         self,
-        private_key: str,
+        private_key: str | None = None,
+        public_address: str | None = None,
         pool: Hyperdrive | None = None,
         policy: Type[HyperdriveBasePolicy] | None = None,
         policy_config: HyperdriveBasePolicy.Config | None = None,
@@ -384,8 +385,13 @@ class Chain:
 
         Arguments
         ---------
-        private_key: str
+        private_key: str, optional
             The private key of the associated account.
+            Must be supplied to allow this agent to do any transactions.
+        public_address: str | None, optional
+            The public address of the associated account. This allows this agent
+            to be used for analyzing data.
+            Can't be used in conjunction with private_key.
         pool: LocalHyperdrive, optional
             An optional pool to set as the active pool.
         policy: HyperdrivePolicy, optional
@@ -411,6 +417,7 @@ class Chain:
             policy=policy,
             policy_config=policy_config,
             private_key=private_key,
+            public_address=public_address,
         )
         return out_agent
 

--- a/src/agent0/core/hyperdrive/interactive/hyperdrive.py
+++ b/src/agent0/core/hyperdrive/interactive/hyperdrive.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import nest_asyncio
 import pandas as pd
@@ -15,7 +16,8 @@ from agent0.ethpy.hyperdrive import (
     get_hyperdrive_addresses_from_registry,
 )
 
-from .chain import Chain
+if TYPE_CHECKING:
+    from .chain import Chain
 
 # In order to support both scripts and jupyter notebooks with underlying async functions,
 # we use the nest_asyncio package so that we can execute asyncio.run within a running event loop.
@@ -106,10 +108,7 @@ class Hyperdrive:
         # held by the chain object, we want to ensure that we dont mix and match
         # local vs non-local hyperdrive objects. Hence, we ensure that any hyperdrive
         # objects must come from a base Chain object and not a LocalChain.
-        # We use `type` instead of `isinstance` to explicitly check for
-        # the base Chain type instead of any subclass.
-        # pylint: disable=unidiomatic-typecheck
-        if type(chain) != Chain:
+        if chain.is_local_chain:
             raise TypeError("The chain parameter must be a Chain object, not a LocalChain.")
 
         self._initialize(chain, hyperdrive_address, name)

--- a/src/agent0/core/hyperdrive/interactive/hyperdrive.py
+++ b/src/agent0/core/hyperdrive/interactive/hyperdrive.py
@@ -40,7 +40,7 @@ class Hyperdrive:
     def get_hyperdrive_addresses_from_registry(
         cls,
         chain: Chain,
-        registry_contract_addr: str,
+        registry_address: str,
     ) -> dict[str, ChecksumAddress]:
         """Gather deployed Hyperdrive pool addresses.
 
@@ -48,7 +48,7 @@ class Hyperdrive:
         ---------
         chain: Chain
             The Chain object connected to a chain.
-        registry_contract_addr: str
+        registry_address: str
             The address of the Hyperdrive factory contract.
 
         Returns
@@ -57,7 +57,37 @@ class Hyperdrive:
             A dictionary keyed by the pool's name, valued by the pool's address
         """
         # pylint: disable=protected-access
-        return get_hyperdrive_addresses_from_registry(registry_contract_addr, chain._web3)
+        return get_hyperdrive_addresses_from_registry(registry_address, chain._web3)
+
+    @classmethod
+    def get_hyperdrive_pools_from_registry(
+        cls,
+        chain: Chain,
+        registry_address: str,
+    ) -> list[Hyperdrive]:
+        """Gather deployed Hyperdrive pool addresses.
+
+        Arguments
+        ---------
+        chain: Chain
+            The Chain object connected to a chain.
+        registry_address: str
+            The address of the Hyperdrive registry contract.
+
+        Returns
+        -------
+        list[Hyperdrive]
+            The hyperdrive objects for all registered pools
+        """
+        hyperdrive_addresses = cls.get_hyperdrive_addresses_from_registry(chain, registry_address)
+        if len(hyperdrive_addresses) == 0:
+            raise ValueError("Registry does not have any hyperdrive pools registered.")
+        # Generate hyperdrive pool objects here
+        registered_pools = []
+        for hyperdrive_name, hyperdrive_address in hyperdrive_addresses.items():
+            registered_pools.append(Hyperdrive(chain, hyperdrive_address, name=hyperdrive_name))
+
+        return registered_pools
 
     def _initialize(self, chain: Chain, hyperdrive_address: ChecksumAddress, name: str | None):
         self.chain = chain

--- a/src/agent0/core/hyperdrive/interactive/hyperdrive.py
+++ b/src/agent0/core/hyperdrive/interactive/hyperdrive.py
@@ -78,6 +78,7 @@ class Hyperdrive:
             )
 
         add_hyperdrive_addr_to_name(name, self.hyperdrive_address, self.chain.db_session)
+        self.name = name
 
     def __init__(
         self,

--- a/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
@@ -988,8 +988,12 @@ class HyperdriveAgent:
             raise ValueError("Pool filter and registry address cannot both be specified.")
 
         if registry_address is not None:
+            # TODO cache these objects
+
             # Get all pools from registry
             hyperdrive_addresses = get_hyperdrive_addresses_from_registry(registry_address, self.chain._web3)
+            if len(hyperdrive_addresses) == 0:
+                raise ValueError("Registry does not have any hyperdrive pools registered.")
             # Generate hyperdrive pool objects here
             pool_filter = []
             for hyperdrive_name, hyperdrive_address in hyperdrive_addresses.items():

--- a/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
@@ -135,8 +135,10 @@ class HyperdriveAgent:
 
     # Expose account and address for type narrowing in local agent
     @property
-    def account(self) -> LocalAccount | None:
+    def account(self) -> LocalAccount:
         """Returns the `LocalAccount` associated with the agent."""
+        if self._account is None:
+            raise ValueError("Must initialize agent with private key to access agent's LocalAccount.")
         return self._account
 
     @property

--- a/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
@@ -120,18 +120,24 @@ class HyperdriveAgent:
         if private_key is not None and public_address is not None:
             raise ValueError("Either private_key or public_address must be provided, but not both.")
 
-        self.account: LocalAccount | None = None
+        self._account: LocalAccount | None = None
         self.address: ChecksumAddress
         if private_key is not None:
-            self.account = Account().from_key(private_key)
-            assert self.account is not None
-            self.address = self.account.address
+            self._account = Account().from_key(private_key)
+            assert self._account is not None
+            self.address = self._account.address
         elif public_address is not None:
             self.address = Web3.to_checksum_address(public_address)
 
         # Register the username if it was provided
         if name is not None:
             add_addr_to_username(name, [self.address], self.chain.db_session)
+
+    # Expose account and address for type narrowing in local agent
+    @property
+    def account(self) -> LocalAccount | None:
+        """Returns the `LocalAccount` associated with the agent."""
+        return self._account
 
     @property
     def policy_done_trading(self) -> bool:

--- a/src/agent0/core/hyperdrive/interactive/local_chain.py
+++ b/src/agent0/core/hyperdrive/interactive/local_chain.py
@@ -198,6 +198,11 @@ class LocalChain(Chain):
         """
         return self.get_deployer_account().address
 
+    @property
+    def is_local_chain(self) -> bool:
+        """Returns if this object is a local chain."""
+        return True
+
     ##########
     # Advance time functions
     ##########

--- a/src/agent0/core/hyperdrive/interactive/local_chain.py
+++ b/src/agent0/core/hyperdrive/interactive/local_chain.py
@@ -203,21 +203,6 @@ class LocalChain(Chain):
         """Returns if this object is a local chain."""
         return True
 
-    def get_registered_pools(self, registry_address: str) -> list[Hyperdrive]:
-        """Returns hyperdrive objects for all availabie pools
-
-        Arguments
-        ---------
-        registry_address: str, optional
-            The registry address to query all positions across registered pools. Can't be used with pool_filter.
-
-        Returns
-        -------
-        list[Hyperdrive]
-            The hyperdrive objects for all registered pools
-        """
-        raise NotImplementedError("Local chain doesn't support managing a registry yet.")
-
     ##########
     # Advance time functions
     ##########

--- a/src/agent0/core/hyperdrive/interactive/local_chain.py
+++ b/src/agent0/core/hyperdrive/interactive/local_chain.py
@@ -569,6 +569,7 @@ class LocalChain(Chain):
     def init_agent(
         self,
         private_key: str | None = None,
+        public_address: str | None = None,
         pool: Hyperdrive | None = None,
         policy: Type[HyperdriveBasePolicy] | None = None,
         policy_config: HyperdriveBasePolicy.Config | None = None,
@@ -582,6 +583,8 @@ class LocalChain(Chain):
         ---------
         private_key: str, optional
             The private key of the associated account. Default is auto-generated.
+        public_address: str | None, optional
+            Must be None for local agents.
         pool: LocalHyperdrive, optional
             An optional pool to set as the active pool.
         policy: HyperdrivePolicy, optional
@@ -608,6 +611,9 @@ class LocalChain(Chain):
         if pool is not None and not isinstance(pool, LocalHyperdrive):
             raise TypeError("Pool must be an instance of LocalHyperdrive for LocalChain")
 
+        if public_address is not None:
+            raise ValueError("Can't pass in public key for local agents.")
+
         if self._has_saved_snapshot:  # pylint: disable=protected-access
             logging.warning(
                 "Adding new agent with existing snapshot. "
@@ -629,6 +635,7 @@ class LocalChain(Chain):
             policy=policy,
             policy_config=policy_config,
             private_key=private_key,
+            public_address=None,
         )
         self._chain_agents.append(out_agent)
         return out_agent

--- a/src/agent0/core/hyperdrive/interactive/local_chain.py
+++ b/src/agent0/core/hyperdrive/interactive/local_chain.py
@@ -203,6 +203,21 @@ class LocalChain(Chain):
         """Returns if this object is a local chain."""
         return True
 
+    def get_registered_pools(self, registry_address: str) -> list[Hyperdrive]:
+        """Returns hyperdrive objects for all availabie pools
+
+        Arguments
+        ---------
+        registry_address: str, optional
+            The registry address to query all positions across registered pools. Can't be used with pool_filter.
+
+        Returns
+        -------
+        list[Hyperdrive]
+            The hyperdrive objects for all registered pools
+        """
+        raise NotImplementedError("Local chain doesn't support managing a registry yet.")
+
     ##########
     # Advance time functions
     ##########

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive_agent.py
@@ -499,28 +499,33 @@ class LocalHyperdriveAgent(HyperdriveAgent):
 
     def get_positions(
         self,
-        pool_filter: Hyperdrive | None = None,
+        pool_filter: Hyperdrive | list[Hyperdrive] | None = None,
         show_closed_positions: bool = False,
         coerce_float: bool = False,
+        registry_address: str | None = None,
     ) -> pd.DataFrame:
         """Returns all of the agent's positions across all hyperdrive pools.
 
         Arguments
         ---------
-        pool_filter: LocalHyperdrive, optional
-            The hyperdrive pool to query. Defaults to None, which will query all pools.
+        pool_filter: LocalHyperdrive | list[Hyperdrive], optional
+            The hyperdrive pool(s) to query. Defaults to None, which will query all pools.
         show_closed_positions: bool, optional
             Whether to show positions closed positions (i.e., positions with zero balance). Defaults to False.
             When False, will only return currently open positions. Useful for gathering currently open positions.
             When True, will also return any closed positions. Useful for calculating overall pnl of all positions.
         coerce_float: bool, optional
             Whether to coerce underlying Decimal values to float when as_df is True. Defaults to False.
+        registry_address: str, optional
+            Must be None when calling from local hyperdrive agent.
 
         Returns
         -------
         pd.DataFrame
             The agent's positions across all hyperdrive pools.
         """
+        if registry_address is not None:
+            raise ValueError("registry_address not used with local agents")
         # Explicit type checking
         if pool_filter is not None and not isinstance(pool_filter, LocalHyperdrive):
             raise TypeError("Pool must be an instance of LocalHyperdrive for a LocalHyperdriveAgent")
@@ -557,10 +562,10 @@ class LocalHyperdriveAgent(HyperdriveAgent):
             raise TypeError("Pool must be an instance of LocalHyperdrive for a LocalHyperdriveAgent")
         return self._get_trade_events(pool=pool, all_token_deltas=all_token_deltas, coerce_float=coerce_float)
 
-    def _sync_events(self, pool: Hyperdrive) -> None:
+    def _sync_events(self, pool: Hyperdrive | list[Hyperdrive]) -> None:
         # No need to sync in local hyperdrive, we sync when we run the data pipeline
         pass
 
-    def _sync_snapshot(self, pool: Hyperdrive) -> None:
+    def _sync_snapshot(self, pool: Hyperdrive | list[Hyperdrive]) -> None:
         # No need to sync in local hyperdrive, we sync when we run the data pipeline
         pass

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive_agent.py
@@ -47,7 +47,8 @@ class LocalHyperdriveAgent(HyperdriveAgent):
         pool: Hyperdrive | None,
         policy: Type[HyperdriveBasePolicy] | None,
         policy_config: HyperdriveBasePolicy.Config | None,
-        private_key: str | None = None,
+        private_key: str | None,
+        public_address: str | None,
     ) -> None:
         """Constructor for the interactive hyperdrive agent.
 
@@ -79,10 +80,19 @@ class LocalHyperdriveAgent(HyperdriveAgent):
         if pool is not None and not isinstance(pool, LocalHyperdrive):
             raise TypeError("Pool must be an instance of LocalHyperdrive for a LocalHyperdriveAgent")
 
+        if public_address is not None:
+            raise ValueError("LocalHyperdriveAgent does not support public_address")
+
         agent_private_key = make_private_key() if private_key is None else private_key
 
         super().__init__(
-            name=name, chain=chain, pool=pool, policy=policy, policy_config=policy_config, private_key=agent_private_key
+            name=name,
+            chain=chain,
+            pool=pool,
+            policy=policy,
+            policy_config=policy_config,
+            private_key=agent_private_key,
+            public_address=None,
         )
 
         self.chain = chain

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive_agent.py
@@ -167,6 +167,14 @@ class LocalHyperdriveAgent(HyperdriveAgent):
 
         super().set_active(pool=pool, policy=policy, policy_config=policy_config)
 
+    # Expose account and address for type narrowing in local agent
+    @property
+    def account(self) -> LocalAccount:
+        """Returns the `LocalAccount` associated with the agent."""
+        # Account should always be set in local agents
+        assert self._account is not None
+        return self._account
+
     ################
     # Trades
     ################


### PR DESCRIPTION
This PR adds `examples/short_examples.ipynb` that runs through quick examples on using agent0 to:
- Analyze positions
- Close all mature positions
- Write a quick policy

This involves the following changes:
- Agents now can be passed in a public address instead of a private address for analysis functions.
- Adding a `get_hyperdrive_pools_from_registry` that returns a list of `Hyperdrive` objects given a registry address.
- `agent.get_positions` now allows a list of `pool_filters`.