### PR TITLE
Updates to FullHyperdriveEnv in traiderdaive to fix stale references

### DIFF
--- a/src/agent0/traiderdaive/gym_environments/full_hyperdrive_env.py
+++ b/src/agent0/traiderdaive/gym_environments/full_hyperdrive_env.py
@@ -531,7 +531,6 @@ class FullHyperdriveEnv(gym.Env):
             long_orders = rl_bot_wallet[rl_bot_wallet["token_id"] == "LONG"]
             # Ensure data is the same as the action space
             long_orders = long_orders.sort_values("maturity_time")
-            # long_orders["pnl"] = long_orders["unrealized_"]
             long_orders = long_orders[["token_balance", "pnl", "normalized_time_remaining"]].values.flatten()
 
             short_orders = rl_bot_wallet[rl_bot_wallet["token_type"] == "LONG"]

--- a/src/agent0/traiderdaive/gym_environments/full_hyperdrive_env.py
+++ b/src/agent0/traiderdaive/gym_environments/full_hyperdrive_env.py
@@ -10,7 +10,6 @@ from typing import Any
 
 import gymnasium as gym
 import numpy as np
-import pandas as pd
 from fixedpointmath import FixedPoint
 from gymnasium import spaces
 from scipy.special import expit

--- a/src/agent0/traiderdaive/gym_environments/full_hyperdrive_env.py
+++ b/src/agent0/traiderdaive/gym_environments/full_hyperdrive_env.py
@@ -294,7 +294,7 @@ class FullHyperdriveEnv(gym.Env):
 
         # Get current wallet positions
         # We need exact decimals here to avoid rounding errors
-        rl_bot_wallet = self._get_rl_wallet_positions(coerce_float=False)
+        rl_bot_wallet = self.rl_bot.get_positions(coerce_float=False)
 
         # TODO should likely try and handle these trades as fast as possible, or eventually
         # allow for reordering.
@@ -354,7 +354,7 @@ class FullHyperdriveEnv(gym.Env):
                 return True
 
         # Get current wallet positions again after closing trades
-        rl_bot_wallet = self._get_rl_wallet_positions(coerce_float=False)
+        rl_bot_wallet = self.rl_bot.get_positions(coerce_float=False)
 
         # Open trades
         min_tx_amount = self.interactive_hyperdrive.config.minimum_transaction_amount * 2
@@ -492,13 +492,6 @@ class FullHyperdriveEnv(gym.Env):
         # TODO return aux info here
         return {}
 
-    def _get_rl_wallet_positions(self, coerce_float: bool) -> pd.DataFrame:
-        # TODO can we use self.rl_bot.get_positions()?
-        current_wallet = self.interactive_hyperdrive.get_positions(coerce_float=coerce_float)
-        # Filter for rl bot
-        rl_bot_wallet = current_wallet[current_wallet["wallet_address"] == self.rl_bot.address]
-        return rl_bot_wallet
-
     def _get_observation(self) -> dict[str, np.ndarray]:
         # Get the latest pool state feature from the db
         pool_state_df = self.interactive_hyperdrive.get_pool_info(coerce_float=True)
@@ -516,7 +509,7 @@ class FullHyperdriveEnv(gym.Env):
         out_obs["lp_orders"] = np.zeros(2)
 
         # Observation data uses floats
-        rl_bot_wallet = self._get_rl_wallet_positions(coerce_float=True)
+        rl_bot_wallet = self.rl_bot.get_positions(coerce_float=True)
 
         if not rl_bot_wallet.empty:
             position_duration = self.interactive_hyperdrive.config.position_duration


### PR DESCRIPTION
Updates keys to reflect new schema changes.
Updates observation step to handle an empty bot wallet on first iteration.
Makes explicit which columns from pool_info to use in observation space.
Changes reward calculation to change in pnl from t-1 -> t (for now).
Remove method that filters for rl bot's wallet from all positions in favor of DB query. 