### PR TITLE
pin numpy to 1.26.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "matplotlib",
     "mplfinance",
     "nest_asyncio",
-    "numpy",
+    "numpy==1.26.4",
     "pandas",
     "pandas-stubs",
     "psycopg[binary]",


### PR DESCRIPTION
otherwise, uv resolves to numpy 2.0 which forces web3 to install a really old version