### PR TITLE
Redeem withdrawal shares not subject to min tx amount

### DIFF
--- a/src/agent0/core/base/config/budget.py
+++ b/src/agent0/core/base/config/budget.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import numpy as np
 from fixedpointmath import FixedPoint, clip
-from numpy.random._generator import Generator
+from numpy.random import Generator
 
 
 @dataclass

--- a/src/agent0/core/base/policies/base.py
+++ b/src/agent0/core/base/policies/base.py
@@ -12,7 +12,7 @@ from numpy.random import default_rng
 from agent0.core.base.types import Freezable
 
 if TYPE_CHECKING:
-    from numpy.random._generator import Generator
+    from numpy.random import Generator
 
     from agent0.core.base.agent import EthWallet
     from agent0.core.base.types import Trade

--- a/src/agent0/core/base/policies/no_action.py
+++ b/src/agent0/core/base/policies/no_action.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING
 from .base import BasePolicy, MarketInterface, Wallet
 
 if TYPE_CHECKING:
-    from numpy.random._generator import Generator
-
     from agent0.core.base.types import Trade
 
 

--- a/src/agent0/core/hyperdrive/interactive/chain.py
+++ b/src/agent0/core/hyperdrive/interactive/chain.py
@@ -15,7 +15,7 @@ import pandas as pd
 from docker import DockerClient
 from docker.errors import NotFound
 from docker.models.containers import Container
-from numpy.random._generator import Generator
+from numpy.random import Generator
 from web3.types import BlockData, Timestamp
 
 from agent0.chainsync import PostgresConfig

--- a/src/agent0/core/hyperdrive/interactive/exec/execute_agent_trades.py
+++ b/src/agent0/core/hyperdrive/interactive/exec/execute_agent_trades.py
@@ -7,7 +7,7 @@ import logging
 from copy import deepcopy
 
 from eth_account.signers.local import LocalAccount
-from numpy.random._generator import Generator
+from numpy.random import Generator
 from web3.types import Nonce
 
 from agent0.core.base import MarketType, Trade

--- a/src/agent0/core/hyperdrive/policies/random.py
+++ b/src/agent0/core/hyperdrive/policies/random.py
@@ -433,6 +433,8 @@ class Random(HyperdriveBasePolicy):
             A list with a single Trade element for redeeming the LP withdraw shares.
         """
         # take a guess at the trade amount, which should be about 10% of the agent’s budget
+        # TODO we may want to use a different mean/std here, as this is based on the agent's base balance
+        # but we're trying to redeem withdraw shares here.
         initial_trade_amount = FixedPoint(
             self.rng.normal(loc=float(wallet.balance.amount) * 0.1, scale=float(wallet.balance.amount) * 0.01)
         )
@@ -440,10 +442,10 @@ class Random(HyperdriveBasePolicy):
             wallet.withdraw_shares,
             interface.current_pool_state.pool_info.withdrawal_shares_ready_to_withdraw,
         )
-        # minimum_transaction_amount <= trade_amount <= withdraw_shares
-        trade_amount = max(
-            interface.pool_config.minimum_transaction_amount, min(shares_available_to_withdraw, initial_trade_amount)
-        )
+
+        # trade_amount <= withdraw_shares
+        trade_amount = min(shares_available_to_withdraw, initial_trade_amount)
+
         # return a trade using a specification that is parsable by the rest of the sim framework
         return [
             redeem_withdraw_shares_trade(

--- a/src/agent0/hyperfuzz/system_fuzz/run_fuzz_bots.py
+++ b/src/agent0/hyperfuzz/system_fuzz/run_fuzz_bots.py
@@ -6,7 +6,7 @@ import logging
 from typing import Callable
 
 from fixedpointmath import FixedPoint
-from numpy.random._generator import Generator
+from numpy.random import Generator
 
 from agent0 import Chain, Hyperdrive, LocalChain, LocalHyperdrive, PolicyZoo
 from agent0.core.base.make_key import make_private_key

--- a/src/agent0/hyperfuzz/unit_fuzz/helpers/advance_time.py
+++ b/src/agent0/hyperfuzz/unit_fuzz/helpers/advance_time.py
@@ -1,6 +1,6 @@
 """Helpers for advancing time wrt checkpoint boundaries"""
 
-from numpy.random._generator import Generator
+from numpy.random import Generator
 
 from agent0.core.hyperdrive.interactive import LocalChain, LocalHyperdrive
 

--- a/src/agent0/hyperfuzz/unit_fuzz/helpers/close_random_trades.py
+++ b/src/agent0/hyperfuzz/unit_fuzz/helpers/close_random_trades.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from numpy.random._generator import Generator
+from numpy.random import Generator
 
 from agent0.core.hyperdrive.interactive.event_types import OpenLong, OpenShort
 from agent0.core.hyperdrive.interactive.local_hyperdrive_agent import LocalHyperdriveAgent

--- a/src/agent0/hyperfuzz/unit_fuzz/helpers/execute_random_trades.py
+++ b/src/agent0/hyperfuzz/unit_fuzz/helpers/execute_random_trades.py
@@ -6,7 +6,7 @@ from typing import Literal, overload
 
 import numpy as np
 from fixedpointmath import FixedPoint
-from numpy.random._generator import Generator
+from numpy.random import Generator
 
 from agent0.core.hyperdrive import HyperdriveActionType
 from agent0.core.hyperdrive.interactive import LocalChain, LocalHyperdrive

--- a/src/agent0/hyperfuzz/unit_fuzz/helpers/setup_fuzz.py
+++ b/src/agent0/hyperfuzz/unit_fuzz/helpers/setup_fuzz.py
@@ -6,7 +6,7 @@ import logging
 
 import numpy as np
 from fixedpointmath import FixedPoint
-from numpy.random._generator import Generator
+from numpy.random import Generator
 
 from agent0.core.hyperdrive.interactive import LocalChain, LocalHyperdrive
 

--- a/src/agent0/hyperlogs/json_encoder.py
+++ b/src/agent0/hyperlogs/json_encoder.py
@@ -13,7 +13,7 @@ import numpy as np
 import pandas as pd
 from fixedpointmath import FixedPoint
 from hexbytes import HexBytes
-from numpy.random._generator import Generator
+from numpy.random import Generator
 from web3.datastructures import AttributeDict, MutableAttributeDict
 
 


### PR DESCRIPTION
This fixes a bug with random bots trying to withdraw the minimum transaction amount when this amount > withdrawal shares in wallet.

Hyperdrive does not restrict redeeming withdrawal shares to the minimum transaction amount