### PR TITLE
Fixing setting nonce in agent0

### DIFF
--- a/src/agent0/core/hyperdrive/interactive/exec/execute_agent_trades.py
+++ b/src/agent0/core/hyperdrive/interactive/exec/execute_agent_trades.py
@@ -149,7 +149,9 @@ async def async_execute_agent_trades(
     # To do this, we need to manually set the nonce, so we get the base transaction count here
     # and pass in an incrementing nonce per call
     # TODO figure out which exception here to retry on
-    base_nonce = retry_call(DEFAULT_READ_RETRY_COUNT, None, interface.web3.eth.get_transaction_count, account.address)
+    base_nonce = retry_call(
+        DEFAULT_READ_RETRY_COUNT, None, interface.web3.eth.get_transaction_count, account.address, "pending"
+    )
 
     # Here, gather returns results based on original order of trades due to nonce getting explicitly set based
     # on iterating through the list
@@ -234,7 +236,9 @@ async def async_execute_single_trade(
 
     # TODO we likely need to bookkeep nonces here to avoid a race condition when this function
     # is being called asynchronously
-    nonce = retry_call(DEFAULT_READ_RETRY_COUNT, None, interface.web3.eth.get_transaction_count, account.address)
+    nonce = retry_call(
+        DEFAULT_READ_RETRY_COUNT, None, interface.web3.eth.get_transaction_count, account.address, "pending"
+    )
 
     try:
         receipt_or_exception = await _async_match_contract_call_to_trade(

--- a/src/agent0/ethpy/base/transactions.py
+++ b/src/agent0/ethpy/base/transactions.py
@@ -427,7 +427,7 @@ def build_transaction(
         txn_options_priority_fee_multiple = DEFAULT_PRIORITY_FEE_MULTIPLE
     signer_checksum_address = Web3.to_checksum_address(signer.address)
     # TODO figure out which exception here to retry on
-    base_nonce = retry_call(read_retry_count, None, web3.eth.get_transaction_count, signer_checksum_address)
+    base_nonce = retry_call(read_retry_count, None, web3.eth.get_transaction_count, signer_checksum_address, "pending")
     if nonce is None:
         nonce = base_nonce
     # We explicitly check to ensure explicit nonce is larger than what web3 is reporting
@@ -954,7 +954,7 @@ async def async_eth_transfer(
     if read_retry_count is None:
         read_retry_count = DEFAULT_READ_RETRY_COUNT
     signer_checksum_address = Web3.to_checksum_address(signer.address)
-    base_nonce = retry_call(read_retry_count, None, web3.eth.get_transaction_count, signer_checksum_address)
+    base_nonce = retry_call(read_retry_count, None, web3.eth.get_transaction_count, signer_checksum_address, "pending")
     if nonce is None:
         nonce = base_nonce
     # We explicitly check to ensure explicit nonce is larger than what web3 is reporting
@@ -1024,7 +1024,7 @@ def eth_transfer(
     signer_checksum_address = Web3.to_checksum_address(signer.address)
     if nonce is None:
         # TODO figure out which exception here to retry on
-        nonce = retry_call(read_retry_count, None, web3.eth.get_transaction_count, signer_checksum_address)
+        nonce = retry_call(read_retry_count, None, web3.eth.get_transaction_count, signer_checksum_address, "pending")
     unsent_txn: TxParams = {
         "from": signer_checksum_address,
         "to": to_address,

--- a/src/agent0/hypertypes/types/ERC20ForwarderFactoryContract.py
+++ b/src/agent0/hypertypes/types/ERC20ForwarderFactoryContract.py
@@ -554,7 +554,7 @@ class ERC20ForwarderFactoryContract(Contract):
 
         # otherwise use the account provided.
         deployment_tx = constructor_fn.build_transaction()
-        current_nonce = w3.eth.get_transaction_count(account.address)
+        current_nonce = w3.eth.get_transaction_count(account.address, "pending")
         deployment_tx.update({"nonce": current_nonce})
 
         # Sign the transaction with local account private key

--- a/src/agent0/hypertypes/types/ERC20MintableContract.py
+++ b/src/agent0/hypertypes/types/ERC20MintableContract.py
@@ -2547,7 +2547,7 @@ class ERC20MintableContract(Contract):
 
         # otherwise use the account provided.
         deployment_tx = constructor_fn.build_transaction()
-        current_nonce = w3.eth.get_transaction_count(account.address)
+        current_nonce = w3.eth.get_transaction_count(account.address, "pending")
         deployment_tx.update({"nonce": current_nonce})
 
         # Sign the transaction with local account private key

--- a/src/agent0/hypertypes/types/ERC4626HyperdriveCoreDeployerContract.py
+++ b/src/agent0/hypertypes/types/ERC4626HyperdriveCoreDeployerContract.py
@@ -232,7 +232,7 @@ class ERC4626HyperdriveCoreDeployerContract(Contract):
 
         # otherwise use the account provided.
         deployment_tx = constructor_fn.build_transaction()
-        current_nonce = w3.eth.get_transaction_count(account.address)
+        current_nonce = w3.eth.get_transaction_count(account.address, "pending")
         deployment_tx.update({"nonce": current_nonce})
 
         # Sign the transaction with local account private key

--- a/src/agent0/hypertypes/types/ERC4626HyperdriveDeployerCoordinatorContract.py
+++ b/src/agent0/hypertypes/types/ERC4626HyperdriveDeployerCoordinatorContract.py
@@ -2449,7 +2449,7 @@ class ERC4626HyperdriveDeployerCoordinatorContract(Contract):
 
         # otherwise use the account provided.
         deployment_tx = constructor_fn.build_transaction()
-        current_nonce = w3.eth.get_transaction_count(account.address)
+        current_nonce = w3.eth.get_transaction_count(account.address, "pending")
         deployment_tx.update({"nonce": current_nonce})
 
         # Sign the transaction with local account private key

--- a/src/agent0/hypertypes/types/ERC4626Target0DeployerContract.py
+++ b/src/agent0/hypertypes/types/ERC4626Target0DeployerContract.py
@@ -216,7 +216,7 @@ class ERC4626Target0DeployerContract(Contract):
 
         # otherwise use the account provided.
         deployment_tx = constructor_fn.build_transaction()
-        current_nonce = w3.eth.get_transaction_count(account.address)
+        current_nonce = w3.eth.get_transaction_count(account.address, "pending")
         deployment_tx.update({"nonce": current_nonce})
 
         # Sign the transaction with local account private key

--- a/src/agent0/hypertypes/types/ERC4626Target1DeployerContract.py
+++ b/src/agent0/hypertypes/types/ERC4626Target1DeployerContract.py
@@ -216,7 +216,7 @@ class ERC4626Target1DeployerContract(Contract):
 
         # otherwise use the account provided.
         deployment_tx = constructor_fn.build_transaction()
-        current_nonce = w3.eth.get_transaction_count(account.address)
+        current_nonce = w3.eth.get_transaction_count(account.address, "pending")
         deployment_tx.update({"nonce": current_nonce})
 
         # Sign the transaction with local account private key

--- a/src/agent0/hypertypes/types/ERC4626Target2DeployerContract.py
+++ b/src/agent0/hypertypes/types/ERC4626Target2DeployerContract.py
@@ -216,7 +216,7 @@ class ERC4626Target2DeployerContract(Contract):
 
         # otherwise use the account provided.
         deployment_tx = constructor_fn.build_transaction()
-        current_nonce = w3.eth.get_transaction_count(account.address)
+        current_nonce = w3.eth.get_transaction_count(account.address, "pending")
         deployment_tx.update({"nonce": current_nonce})
 
         # Sign the transaction with local account private key

--- a/src/agent0/hypertypes/types/ERC4626Target3DeployerContract.py
+++ b/src/agent0/hypertypes/types/ERC4626Target3DeployerContract.py
@@ -216,7 +216,7 @@ class ERC4626Target3DeployerContract(Contract):
 
         # otherwise use the account provided.
         deployment_tx = constructor_fn.build_transaction()
-        current_nonce = w3.eth.get_transaction_count(account.address)
+        current_nonce = w3.eth.get_transaction_count(account.address, "pending")
         deployment_tx.update({"nonce": current_nonce})
 
         # Sign the transaction with local account private key

--- a/src/agent0/hypertypes/types/HyperdriveFactoryContract.py
+++ b/src/agent0/hypertypes/types/HyperdriveFactoryContract.py
@@ -7313,7 +7313,7 @@ class HyperdriveFactoryContract(Contract):
 
         # otherwise use the account provided.
         deployment_tx = constructor_fn.build_transaction()
-        current_nonce = w3.eth.get_transaction_count(account.address)
+        current_nonce = w3.eth.get_transaction_count(account.address, "pending")
         deployment_tx.update({"nonce": current_nonce})
 
         # Sign the transaction with local account private key

--- a/src/agent0/hypertypes/types/HyperdriveRegistryContract.py
+++ b/src/agent0/hypertypes/types/HyperdriveRegistryContract.py
@@ -1790,7 +1790,7 @@ class HyperdriveRegistryContract(Contract):
 
         # otherwise use the account provided.
         deployment_tx = constructor_fn.build_transaction()
-        current_nonce = w3.eth.get_transaction_count(account.address)
+        current_nonce = w3.eth.get_transaction_count(account.address, "pending")
         deployment_tx.update({"nonce": current_nonce})
 
         # Sign the transaction with local account private key

--- a/src/agent0/hypertypes/types/IHyperdriveContract.py
+++ b/src/agent0/hypertypes/types/IHyperdriveContract.py
@@ -6971,7 +6971,7 @@ class IHyperdriveContract(Contract):
 
         # otherwise use the account provided.
         deployment_tx = constructor_fn.build_transaction()
-        current_nonce = w3.eth.get_transaction_count(account.address)
+        current_nonce = w3.eth.get_transaction_count(account.address, "pending")
         deployment_tx.update({"nonce": current_nonce})
 
         # Sign the transaction with local account private key

--- a/src/agent0/hypertypes/types/LPMathContract.py
+++ b/src/agent0/hypertypes/types/LPMathContract.py
@@ -755,7 +755,7 @@ class LPMathContract(Contract):
 
         # otherwise use the account provided.
         deployment_tx = constructor_fn.build_transaction()
-        current_nonce = w3.eth.get_transaction_count(account.address)
+        current_nonce = w3.eth.get_transaction_count(account.address, "pending")
         deployment_tx.update({"nonce": current_nonce})
 
         # Sign the transaction with local account private key

--- a/src/agent0/hypertypes/types/MockERC4626Contract.py
+++ b/src/agent0/hypertypes/types/MockERC4626Contract.py
@@ -3587,7 +3587,7 @@ class MockERC4626Contract(Contract):
 
         # otherwise use the account provided.
         deployment_tx = constructor_fn.build_transaction()
-        current_nonce = w3.eth.get_transaction_count(account.address)
+        current_nonce = w3.eth.get_transaction_count(account.address, "pending")
         deployment_tx.update({"nonce": current_nonce})
 
         # Sign the transaction with local account private key


### PR DESCRIPTION
Using `eth_transaction_count` should be querying the `pending` block, not `latest` block to set nonce. This allows a single account to send multiple transactions on the same block with proper nonce setting.

This matches default `web3py` behavior.