### PR TITLE
Allow for lazy pnl calculation

### DIFF
--- a/src/agent0/chainsync/analysis/__init__.py
+++ b/src/agent0/chainsync/analysis/__init__.py
@@ -1,4 +1,4 @@
 """Analysis for trading."""
 
-from .calc_position_value import calc_closeout_value, calc_single_closeout
+from .calc_position_value import calc_closeout_value, calc_single_closeout, fill_pnl_values
 from .db_to_analysis import db_to_analysis, snapshot_positions_to_db

--- a/src/agent0/chainsync/dashboard/build_dashboard_dfs.py
+++ b/src/agent0/chainsync/dashboard/build_dashboard_dfs.py
@@ -94,12 +94,10 @@ def build_pool_dashboard(
     # Adds user lookup to the ticker
     out_dfs["display_ticker"] = build_ticker_for_pool_page(trade_events, user_map, block_to_timestamp)
 
-    # Since this table is updated every block, we try and lag behind one block
-    # for position snapshots to avoid getting a currently updating block.
     latest_wallet_pnl = get_position_snapshot(
         session,
         hyperdrive_address=hyperdrive_address,
-        start_block=-1,
+        latest_entry=True,
         end_block=None,
         coerce_float=False,
     )
@@ -178,12 +176,10 @@ def build_wallet_dashboard(
         trade_events, user_map, hyperdrive_addr_mapping, block_to_timestamp
     )
 
-    # Since this table is updated every block, we try and lag behind one block
-    # for position snapshots to avoid getting a currently updating block.
     position_snapshot = get_position_snapshot(
         session,
         wallet_address=wallet_addresses,
-        start_block=-1,
+        latest_entry=True,
         end_block=None,
         coerce_float=False,
     )

--- a/src/agent0/core/hyperdrive/interactive/hyperdrive.py
+++ b/src/agent0/core/hyperdrive/interactive/hyperdrive.py
@@ -177,8 +177,10 @@ class Hyperdrive:
         ---------
         coerce_float: bool
             If True, will coerce underlying Decimals to floats.
-        calc_pnl: bool
-            Whether to return the pnl for the current position. Only used if the chain config's `calc_pnl` is False.
+        calc_pnl: bool, optional
+            If the chain config's `calc_pnl` flag is False, passing in `calc_pnl=True` to this function allows for
+            a one-off pnl calculation for the current positions. Ignored if the chain's `calc_pnl` flag is set to True,
+            as every position snapshot will return pnl information.
         show_closed_positions: bool
             Whether to show positions closed positions (i.e., positions with zero balance). Defaults to False.
             When False, will only return currently open positions. Useful for gathering currently open positions.

--- a/src/agent0/core/hyperdrive/interactive/hyperdrive.py
+++ b/src/agent0/core/hyperdrive/interactive/hyperdrive.py
@@ -163,7 +163,9 @@ class Hyperdrive:
 
         self._initialize(chain, hyperdrive_address, name)
 
-    def get_positions(self, show_closed_positions: bool = False, coerce_float: bool = False) -> pd.DataFrame:
+    def get_positions(
+        self, show_closed_positions: bool = False, calc_pnl: bool = False, coerce_float: bool = False
+    ) -> pd.DataFrame:
         """Gets all current positions of this pool and their corresponding pnl
         and returns as a pandas dataframe.
 
@@ -175,6 +177,8 @@ class Hyperdrive:
         ---------
         coerce_float: bool
             If True, will coerce underlying Decimals to floats.
+        calc_pnl: bool
+            Whether to return the pnl for the current position. Only used if the chain config's `calc_pnl` is False.
         show_closed_positions: bool
             Whether to show positions closed positions (i.e., positions with zero balance). Defaults to False.
             When False, will only return currently open positions. Useful for gathering currently open positions.

--- a/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
@@ -980,8 +980,10 @@ class HyperdriveAgent:
             Whether to show positions closed positions (i.e., positions with zero balance). Defaults to False.
             When False, will only return currently open positions. Useful for gathering currently open positions.
             When True, will also return any closed positions. Useful for calculating overall pnl of all positions.
-        calc_pnl: bool
-            Whether to return the pnl for the current position. Only used if the chain config's `calc_pnl` is False.
+        calc_pnl: bool, optional
+            If the chain config's `calc_pnl` flag is False, passing in `calc_pnl=True` to this function allows for
+            a one-off pnl calculation for the current positions. Ignored if the chain's `calc_pnl` flag is set to True,
+            as every position snapshot will return pnl information.
         coerce_float: bool, optional
             Whether to coerce underlying Decimal values to float when as_df is True. Defaults to False.
 

--- a/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
@@ -1030,8 +1030,16 @@ class HyperdriveAgent:
         # we do a one off calculation to get the pnl here.
         if not self.chain.config.calc_pnl and calc_pnl:
             if isinstance(pool_filter, list):
-                # FIXME
-                pass
+                out = []
+                for pool in pool_filter:
+                    out.append(
+                        fill_pnl_values(
+                            position_snapshot[position_snapshot["hyperdrive_address"] == pool.hyperdrive_address],
+                            self.chain.db_session,
+                            pool.interface,
+                        )
+                    )
+                position_snapshot = pd.concat(out, axis=0)
             else:
                 position_snapshot = fill_pnl_values(position_snapshot, self.chain.db_session, pool_filter.interface)
 

--- a/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
@@ -1005,15 +1005,13 @@ class HyperdriveAgent:
 
     def _get_positions(
         self,
-        pool_filter: Hyperdrive | list[Hyperdrive] | None,
+        pool_filter: Hyperdrive | list[Hyperdrive],
         show_closed_positions: bool,
         calc_pnl: bool,
         coerce_float: bool,
     ) -> pd.DataFrame:
         # Query the snapshot for the most recent positions.
-        if pool_filter is None:
-            hyperdrive_address = None
-        elif isinstance(pool_filter, list):
+        if isinstance(pool_filter, list):
             hyperdrive_address = [str(pool.hyperdrive_address) for pool in pool_filter]
         else:
             hyperdrive_address = str(pool_filter.hyperdrive_address)
@@ -1031,13 +1029,11 @@ class HyperdriveAgent:
         # If the config's calc_pnl is not set, but we pass in `calc_pnl = True` to this function,
         # we do a one off calculation to get the pnl here.
         if not self.chain.config.calc_pnl and calc_pnl:
-            if pool_filter is None:
-                # FIXME
-                pass
             if isinstance(pool_filter, list):
                 # FIXME
                 pass
-            position_snapshot = fill_pnl_values(position_snapshot, self.chain.db_session, pool_filter.interface)
+            else:
+                position_snapshot = fill_pnl_values(position_snapshot, self.chain.db_session, pool_filter.interface)
 
         # Add usernames
         position_snapshot = self.chain._add_username_to_dataframe(position_snapshot, "wallet_address")

--- a/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
@@ -1020,7 +1020,7 @@ class HyperdriveAgent:
 
         position_snapshot = get_position_snapshot(
             session=self.chain.db_session,
-            start_block=-1,
+            latest_entry=True,
             wallet_address=self.address,
             hyperdrive_address=hyperdrive_address,
             coerce_float=coerce_float,

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
@@ -517,7 +517,7 @@ class LocalHyperdrive(Hyperdrive):
         position_snapshot = get_position_snapshot(
             self.chain.db_session,
             hyperdrive_address=self.interface.hyperdrive_address,
-            start_block=-1,
+            latest_entry=True,
             coerce_float=coerce_float,
         ).drop("id", axis=1)
         if not show_closed_positions:

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
@@ -503,8 +503,10 @@ class LocalHyperdrive(Hyperdrive):
             When False, will only return currently open positions. Useful for gathering currently open positions.
             When True, will also return any closed positions. Useful for calculating overall pnl of all positions.
             Defaults to False.
-        calc_pnl: bool
-            Whether to return the pnl for the current position. Only used if the chain config's `calc_pnl` is False.
+        calc_pnl: bool, optional
+            If the chain config's `calc_pnl` flag is False, passing in `calc_pnl=True` to this function allows for
+            a one-off pnl calculation for the current positions. Ignored if the chain's `calc_pnl` flag is set to True,
+            as every position snapshot will return pnl information.
         coerce_float: bool
             If True, will coerce underlying Decimals to floats.
             Defaults to False.

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive_agent.py
@@ -535,8 +535,10 @@ class LocalHyperdriveAgent(HyperdriveAgent):
             Whether to show positions closed positions (i.e., positions with zero balance). Defaults to False.
             When False, will only return currently open positions. Useful for gathering currently open positions.
             When True, will also return any closed positions. Useful for calculating overall pnl of all positions.
-        calc_pnl: bool
-            Whether to return the pnl for the current position. Only used if the chain config's `calc_pnl` is False.
+        calc_pnl: bool, optional
+            If the chain config's `calc_pnl` flag is False, passing in `calc_pnl=True` to this function allows for
+            a one-off pnl calculation for the current positions. Ignored if the chain's `calc_pnl` flag is set to True,
+            as every position snapshot will return pnl information.
         coerce_float: bool, optional
             Whether to coerce underlying Decimal values to float when as_df is True. Defaults to False.
         registry_address: str, optional

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive_agent.py
@@ -521,6 +521,7 @@ class LocalHyperdriveAgent(HyperdriveAgent):
         self,
         pool_filter: Hyperdrive | list[Hyperdrive] | None = None,
         show_closed_positions: bool = False,
+        calc_pnl: bool = False,
         coerce_float: bool = False,
         registry_address: str | None = None,
     ) -> pd.DataFrame:
@@ -555,7 +556,10 @@ class LocalHyperdriveAgent(HyperdriveAgent):
             elif not isinstance(pool_filter, LocalHyperdrive):
                 raise TypeError("Pool must be an instance of LocalHyperdrive for a LocalHyperdriveAgent")
         return self._get_positions(
-            pool_filter=pool_filter, show_closed_positions=show_closed_positions, coerce_float=coerce_float
+            pool_filter=pool_filter,
+            show_closed_positions=show_closed_positions,
+            calc_pnl=calc_pnl,
+            coerce_float=coerce_float,
         )
 
     def get_trade_events(

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive_agent.py
@@ -535,6 +535,8 @@ class LocalHyperdriveAgent(HyperdriveAgent):
             Whether to show positions closed positions (i.e., positions with zero balance). Defaults to False.
             When False, will only return currently open positions. Useful for gathering currently open positions.
             When True, will also return any closed positions. Useful for calculating overall pnl of all positions.
+        calc_pnl: bool
+            Whether to return the pnl for the current position. Only used if the chain config's `calc_pnl` is False.
         coerce_float: bool, optional
             Whether to coerce underlying Decimal values to float when as_df is True. Defaults to False.
         registry_address: str, optional
@@ -545,8 +547,12 @@ class LocalHyperdriveAgent(HyperdriveAgent):
         pd.DataFrame
             The agent's positions across all hyperdrive pools.
         """
+        # pylint: disable=too-many-arguments
+
         if registry_address is not None:
             raise ValueError("registry_address not used with local agents")
+
+        pool_filter_arg: Hyperdrive | list[Hyperdrive]
         # Explicit type checking
         if pool_filter is not None:
             if isinstance(pool_filter, list):
@@ -555,14 +561,15 @@ class LocalHyperdriveAgent(HyperdriveAgent):
                         raise TypeError("Pool must be an instance of LocalHyperdrive for a LocalHyperdriveAgent")
             elif not isinstance(pool_filter, LocalHyperdrive):
                 raise TypeError("Pool must be an instance of LocalHyperdrive for a LocalHyperdriveAgent")
+            pool_filter_arg = pool_filter
         else:
             # TODO Typing is complaining list[LocalHyperdrive] is not a list[Hyperdrive]
             # but LocalHyperdrive is a subclass of Hyperdrive
             # Proper fix here is to switch `list` to `Sequence`
-            pool_filter: list[Hyperdrive] = self.chain._deployed_hyperdrive_pools  # type: ignore # pylint: disable=protected-access
+            pool_filter_arg = self.chain._deployed_hyperdrive_pools  # type: ignore # pylint: disable=protected-access
 
         return self._get_positions(
-            pool_filter=pool_filter,
+            pool_filter=pool_filter_arg,
             show_closed_positions=show_closed_positions,
             calc_pnl=calc_pnl,
             coerce_float=coerce_float,

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive_agent.py
@@ -555,6 +555,12 @@ class LocalHyperdriveAgent(HyperdriveAgent):
                         raise TypeError("Pool must be an instance of LocalHyperdrive for a LocalHyperdriveAgent")
             elif not isinstance(pool_filter, LocalHyperdrive):
                 raise TypeError("Pool must be an instance of LocalHyperdrive for a LocalHyperdriveAgent")
+        else:
+            # TODO Typing is complaining list[LocalHyperdrive] is not a list[Hyperdrive]
+            # but LocalHyperdrive is a subclass of Hyperdrive
+            # Proper fix here is to switch `list` to `Sequence`
+            pool_filter: list[Hyperdrive] = self.chain._deployed_hyperdrive_pools  # type: ignore # pylint: disable=protected-access
+
         return self._get_positions(
             pool_filter=pool_filter,
             show_closed_positions=show_closed_positions,

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive_test.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive_test.py
@@ -1305,6 +1305,16 @@ def test_lazy_calc_pnl():
     positions = lazy_calc_pnl_agent.get_positions(calc_pnl=False)
     # Should have 6 positions, 3 per pool
     assert len(positions) == 6
+    # The unrealized value and pnl should be nans
+    assert positions[["unrealized_value", "pnl"]].isna().all().all()
+
+    # PNLs between the two agents should be identical for both if we calc pnl
+    calc_pnl_positions = calc_pnl_agent.get_positions()
+    lazy_calc_pnl_positions = lazy_calc_pnl_agent.get_positions(calc_pnl=True)
+    # TODO the comparison below assumes both get_positions will return in the same order
+    #
+    pass
+
     pass
 
     # Run get_positions from both agents and compare lazy vs non-lazy


### PR DESCRIPTION
This PR allows for only calculating pnl when calling `get_positions` for speed. To utilize this, set `calc_pnl = False` in the `Chain.Config`. If this configuration is set to False, `get_positions` accepts a `calc_pnl` argument, which fills the pnl values in the resulting dataframe.

Includes a bugfix to `get_positions` when getting positions from multiple pools.