### PR TITLE
Allows backfilling pool info in the case of forking a pool

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,9 +21,6 @@ jobs:
           python-version: "3.10"
           token: ${{github.token}}
 
-      - name: install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
-
       - name: install requirements
         run: |
           python -m venv --upgrade-deps .venv

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -21,9 +21,6 @@ jobs:
           python-version: "3.10"
           token: ${{github.token}}
 
-      - name: install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
-
       - name: install requirements
         run: |
           python -m venv --upgrade-deps .venv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,9 +40,6 @@ jobs:
           python-version: "3.10"
           token: ${{github.token}}
 
-      - name: install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
-
       - name: install requirements
         run: |
           python -m venv --upgrade-deps .venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
     "sqlalchemy",
     "sqlalchemy-utils",
     "streamlit",
+    "tqdm",
     "web3",
 ]
 

--- a/src/agent0/chainsync/analysis/calc_position_value.py
+++ b/src/agent0/chainsync/analysis/calc_position_value.py
@@ -234,6 +234,8 @@ def fill_pnl_values(
     if len(in_df) == 0:
         return in_df
 
+    out_df = in_df.copy()
+
     checkpoint_info = get_checkpoint_info(
         db_session, hyperdrive_address=interface.hyperdrive_address, coerce_float=False
     )
@@ -243,6 +245,6 @@ def fill_pnl_values(
         interface,
         coerce_float=coerce_float,
     )
-    in_df["unrealized_value"] = values_df
-    in_df["pnl"] = in_df["unrealized_value"] + in_df["realized_value"]
-    return in_df
+    out_df["unrealized_value"] = values_df
+    out_df["pnl"] = in_df["unrealized_value"] + in_df["realized_value"]
+    return out_df

--- a/src/agent0/chainsync/analysis/calc_position_value.py
+++ b/src/agent0/chainsync/analysis/calc_position_value.py
@@ -246,5 +246,5 @@ def fill_pnl_values(
         coerce_float=coerce_float,
     )
     out_df["unrealized_value"] = values_df
-    out_df["pnl"] = in_df["unrealized_value"] + in_df["realized_value"]
+    out_df["pnl"] = out_df["unrealized_value"] + out_df["realized_value"]
     return out_df

--- a/src/agent0/core/hyperdrive/interactive/local_chain.py
+++ b/src/agent0/core/hyperdrive/interactive/local_chain.py
@@ -646,9 +646,6 @@ class LocalChain(Chain):
         if pool is not None and not isinstance(pool, LocalHyperdrive):
             raise TypeError("Pool must be an instance of LocalHyperdrive for LocalChain")
 
-        if public_address is not None:
-            raise ValueError("Can't pass in public key for local agents.")
-
         if self._has_saved_snapshot:  # pylint: disable=protected-access
             logging.warning(
                 "Adding new agent with existing snapshot. "
@@ -670,7 +667,7 @@ class LocalChain(Chain):
             policy=policy,
             policy_config=policy_config,
             private_key=private_key,
-            public_address=None,
+            public_address=public_address,
         )
         self._chain_agents.append(out_agent)
         return out_agent

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
@@ -451,6 +451,19 @@ class LocalHyperdrive(Hyperdrive):
             raise ValueError("Pool config doesn't exist in the db.")
         return pool_config.iloc[0]
 
+    def backfill_pool_info(self, from_block: int) -> None:
+        """Backfills pool info from a give block.
+
+        In the case of forking, pool info is only available from the time of the fork.
+        This function allows for a user to explicitly backfill pool from a given block.
+
+        Arguments
+        ---------
+        from_block: int
+            The block number to start backfilling from.
+        """
+        pass
+
     def get_pool_info(self, coerce_float: bool = False) -> pd.DataFrame:
         """Get the pool info (and additional info) per block and returns as a pandas dataframe.
 

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
@@ -180,7 +180,7 @@ class LocalHyperdrive(Hyperdrive):
         name: str | None = None,
         deploy: bool = True,
         hyperdrive_address: ChecksumAddress | str | None = None,
-        backfill_data_block: int | None = None,
+        backfill_data_start_block: int | None = None,
     ):
         """Constructor for the interactive hyperdrive agent.
 
@@ -198,7 +198,7 @@ class LocalHyperdrive(Hyperdrive):
         deploy: bool, optional
             If True, will deploy a new hyperdrive contract.
             If False, will connect to an existing hyperdrive contract (in cases of forking)
-        backfill_data_block: int | None, optional
+        backfill_data_start_block: int | None, optional
             In the case of attaching to an existing hyperdrive contract from a fork with `deploy = False`,
             this parameter controls the block to start backfilling the data from.
             The default is to not backfill and start from the current block.
@@ -255,10 +255,10 @@ class LocalHyperdrive(Hyperdrive):
             self._data_start_block = self._deploy_block_number
             self._analysis_start_block = self._deploy_block_number
         else:
-            if backfill_data_block is None:
+            if backfill_data_start_block is None:
                 self._data_start_block = chain.block_number()
             else:
-                self._data_start_block = max(self._deploy_block_number, backfill_data_block)
+                self._data_start_block = max(self._deploy_block_number, backfill_data_start_block)
             # Always start analysis at the current block
             self._analysis_start_block = chain.block_number()
 
@@ -293,7 +293,7 @@ class LocalHyperdrive(Hyperdrive):
         # Run the data pipeline in background threads if experimental mode
         self.data_pipeline_timeout = self.config.data_pipeline_timeout
 
-        if backfill_data_block is not None:
+        if backfill_data_start_block is not None:
             logging.info("Backfilling data from block %s to %s", self._data_start_block, chain.block_number())
             self._run_blocking_data_pipeline(progress_bar=True)
         else:

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive_agent.py
@@ -80,10 +80,9 @@ class LocalHyperdriveAgent(HyperdriveAgent):
         if pool is not None and not isinstance(pool, LocalHyperdrive):
             raise TypeError("Pool must be an instance of LocalHyperdrive for a LocalHyperdriveAgent")
 
-        if public_address is not None:
-            raise ValueError("LocalHyperdriveAgent does not support public_address")
-
-        agent_private_key = make_private_key() if private_key is None else private_key
+        agent_private_key = None
+        if public_address is None:
+            agent_private_key = make_private_key() if private_key is None else private_key
 
         super().__init__(
             name=name,
@@ -92,7 +91,7 @@ class LocalHyperdriveAgent(HyperdriveAgent):
             policy=policy,
             policy_config=policy_config,
             private_key=agent_private_key,
-            public_address=None,
+            public_address=public_address,
         )
 
         self.chain = chain

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive_test.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive_test.py
@@ -1312,10 +1312,14 @@ def test_lazy_calc_pnl():
     calc_pnl_positions = calc_pnl_agent.get_positions(show_closed_positions=True)
     lazy_calc_pnl_positions = lazy_calc_pnl_agent.get_positions(show_closed_positions=True, calc_pnl=True)
     # To ensure the positions are identical between the two positions,
-    # we sort by token_id and token_balance
-    assert calc_pnl_positions.sort_values(["token_id", "token_balance"])[["unrealized_value", "pnl"]].equals(
-        lazy_calc_pnl_positions.sort_values(["token_id", "token_balance"])[["unrealized_value", "pnl"]]
-    )
+    # we sort by token_id and token_balance, then reset index
+    calc_pnl_comp_values = calc_pnl_positions.sort_values(["token_id", "token_balance"])[
+        ["unrealized_value", "pnl"]
+    ].reset_index(drop=True)
+    lazy_calc_pnl_comp_values = lazy_calc_pnl_positions.sort_values(["token_id", "token_balance"])[
+        ["unrealized_value", "pnl"]
+    ].reset_index(drop=True)
+    assert calc_pnl_comp_values.equals(lazy_calc_pnl_comp_values)
 
     # Lazy calc pnl from pool shouldn't have unrealized value or pnl columns
     positions = lazy_calc_pnl_pool_1.get_positions(show_closed_positions=True, calc_pnl=False)

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive_test.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive_test.py
@@ -1387,8 +1387,8 @@ def test_fork():
 
 
 @pytest.mark.anvil
-def test_fork_backfill_pool_info():
-    """Tests forking a chain."""
+def test_fork_backfill():
+    """Tests backfilling data from a forked chain."""
 
     # Set up orig chain
     chain = LocalChain(config=LocalChain.Config(chain_port=6000, db_port=6001))
@@ -1412,7 +1412,7 @@ def test_fork_backfill_pool_info():
         fork_chain,
         deploy=False,
         hyperdrive_address=pool.hyperdrive_address,
-        backfill_data=True,
+        backfill_data_start_block=0,
     )
     assert fork_pool.get_pool_info().equals(pool.get_pool_info())
 

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive_test.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive_test.py
@@ -1419,7 +1419,7 @@ def test_fork_backfill():
         config=LocalChain.Config(chain_port=6002, db_port=6003),
     )
     # Set deploy = False since we're attaching to an existing chain
-    # We set backfill data to True
+    # We set backfill data start block to backfill all data
     fork_pool = LocalHyperdrive(
         fork_chain,
         deploy=False,

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive_test.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive_test.py
@@ -1262,12 +1262,8 @@ def test_deploy_nonstandard_timestretch(fast_chain_fixture: LocalChain, time_str
 def test_lazy_calc_pnl():
     """Tests lazy calc pnl values."""
     # Spin up 2 identical chains, pools, and agents, with trades.
-    calc_pnl_chain = LocalChain(
-        config=LocalChain.Config(chain_port=6000, db_port=6001, calc_pnl=True, chain_genesis_timestamp=1719258840)
-    )
-    lazy_calc_pnl_chain = LocalChain(
-        config=LocalChain.Config(chain_port=6002, db_port=6003, calc_pnl=False, chain_genesis_timestamp=1719258840)
-    )
+    calc_pnl_chain = LocalChain(config=LocalChain.Config(chain_port=6000, db_port=6001, calc_pnl=True))
+    lazy_calc_pnl_chain = LocalChain(config=LocalChain.Config(chain_port=6002, db_port=6003, calc_pnl=False))
 
     # Since we added support for querying from multiple pools, we need to create multiple pools here
     calc_pnl_pool_1 = LocalHyperdrive(calc_pnl_chain, LocalHyperdrive.Config())

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive_test.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive_test.py
@@ -1407,12 +1407,14 @@ def test_fork_backfill_pool_info():
         config=LocalChain.Config(chain_port=6002, db_port=6003),
     )
     # Set deploy = False since we're attaching to an existing chain
+    # We set backfill data to True
     fork_pool = LocalHyperdrive(
         fork_chain,
         deploy=False,
         hyperdrive_address=pool.hyperdrive_address,
+        backfill_data=True,
     )
-    pass
+    assert fork_pool.get_pool_info().equals(pool.get_pool_info())
 
     chain.cleanup()
     fork_chain.cleanup()

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive_test.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive_test.py
@@ -1384,3 +1384,35 @@ def test_fork():
 
     chain.cleanup()
     fork_chain.cleanup()
+
+
+@pytest.mark.anvil
+def test_fork_backfill_pool_info():
+    """Tests forking a chain."""
+
+    # Set up orig chain
+    chain = LocalChain(config=LocalChain.Config(chain_port=6000, db_port=6001))
+    pool = LocalHyperdrive(chain, LocalHyperdrive.Config())
+    agent = chain.init_agent(
+        base=FixedPoint(10_000),
+        eth=FixedPoint(10),
+        pool=pool,
+    )
+    _ = agent.add_liquidity(FixedPoint(1_000))
+    _ = agent.open_long(FixedPoint(1_000))
+    _ = agent.open_short(FixedPoint(1_000))
+
+    fork_chain = LocalChain(
+        fork_uri=chain.rpc_uri,
+        config=LocalChain.Config(chain_port=6002, db_port=6003),
+    )
+    # Set deploy = False since we're attaching to an existing chain
+    fork_pool = LocalHyperdrive(
+        fork_chain,
+        deploy=False,
+        hyperdrive_address=pool.hyperdrive_address,
+    )
+    pass
+
+    chain.cleanup()
+    fork_chain.cleanup()


### PR DESCRIPTION
Includes cool progress bar when doing slow backfilling.
![image](https://github.com/delvtech/agent0/assets/1431723/6ace5ab9-b056-4d75-a933-2a9f6beb7123)

Also includes the following minor fixes:
- Removing unnecessary uv installation in CI.
- Fixing a bug with `test_lazy_calc_pnl` dataframe comparison where pandas `equals` was comparing based on index after sort.