### PR TITLE
Fuzz logging level

### DIFF
--- a/src/agent0/core/hyperdrive/interactive/chain.py
+++ b/src/agent0/core/hyperdrive/interactive/chain.py
@@ -73,8 +73,8 @@ class Chain:
         """Whether to log crash reports to rollbar. Defaults to False."""
         rollbar_log_prefix: str | None = None
         """Additional prefix for this hyperdrive to log to rollbar."""
-        crash_log_level: int = logging.CRITICAL
-        """The log level to log crashes at. Defaults to critical."""
+        crash_log_level: int = logging.ERROR
+        """The log level to log crashes at. Defaults to error."""
         crash_report_additional_info: dict[str, Any] | None = None
         """Additional information to include in the crash report."""
         always_execute_policy_post_action: bool = False

--- a/src/agent0/core/hyperdrive/policies/random.py
+++ b/src/agent0/core/hyperdrive/policies/random.py
@@ -171,7 +171,7 @@ class Random(HyperdriveBasePolicy):
             # TODO get these parameters from config
             log_hyperdrive_crash_report(
                 crash_report,
-                logging.ERROR,
+                logging.WARNING,
                 crash_report_to_file=True,
                 crash_report_file_prefix="",
                 log_to_rollbar=True,
@@ -277,7 +277,7 @@ class Random(HyperdriveBasePolicy):
             # TODO get these parameters from config
             log_hyperdrive_crash_report(
                 crash_report,
-                logging.ERROR,
+                logging.WARNING,
                 crash_report_to_file=True,
                 crash_report_file_prefix="",
                 log_to_rollbar=True,


### PR DESCRIPTION
- Don't pause on lp_rate failure in local fuzz runs (still log to rollbar)
- Change default logging level to ERROR instead of CRITICAL
- Change logging of rust `calc_max_*` errors from to WARNING instead of ERROR

There are still errors being logged as ERROR that we expect, e.g., `InsufficientLiquidity` or `CircuitBreakerTriggered` on a contract call. Need follow up PR to handle these, or log as less severe.