### PR TITLE
Various fuzz fixes

### DIFF
--- a/scripts/checkpoint_bots.py
+++ b/scripts/checkpoint_bots.py
@@ -244,7 +244,7 @@ def run_checkpoint_bot(
                 fail_count = 0
             except Exception as e:  # pylint: disable=broad-except
                 if fail_count < FAIL_COUNT_THRESHOLD:
-                    logging_str = f"Checkpoint transaction failed."
+                    logging_str = "Checkpoint transaction failed."
                     log_level = logging.WARNING
                     logging.warning(logging_str + f" {repr(e)}")
                 else:

--- a/scripts/checkpoint_bots.py
+++ b/scripts/checkpoint_bots.py
@@ -246,11 +246,10 @@ def run_checkpoint_bot(
                 if fail_count < FAIL_COUNT_THRESHOLD:
                     logging_str = "Checkpoint transaction failed."
                     log_level = logging.WARNING
-                    term_logging_str = logging_str + f" {repr(e)}"
                 else:
                     logging_str = f"Checkpoint transaction failed over {FAIL_COUNT_THRESHOLD} times."
                     log_level = logging.CRITICAL
-                    term_logging_str = logging_str + f" {repr(e)}"
+                term_logging_str = logging_str + f" {repr(e)}"
                 logging.log(log_level, term_logging_str)
 
                 if log_to_rollbar:

--- a/scripts/checkpoint_bots.py
+++ b/scripts/checkpoint_bots.py
@@ -246,11 +246,12 @@ def run_checkpoint_bot(
                 if fail_count < FAIL_COUNT_THRESHOLD:
                     logging_str = "Checkpoint transaction failed."
                     log_level = logging.WARNING
-                    logging.warning(logging_str + f" {repr(e)}")
+                    term_logging_str = logging_str + f" {repr(e)}"
                 else:
                     logging_str = f"Checkpoint transaction failed over {FAIL_COUNT_THRESHOLD} times."
                     log_level = logging.CRITICAL
-                    logging.critical(logging_str + f" {repr(e)}")
+                    term_logging_str = logging_str + f" {repr(e)}"
+                logging.log(log_level, term_logging_str)
 
                 if log_to_rollbar:
                     log_rollbar_exception(

--- a/scripts/invariant_checks.py
+++ b/scripts/invariant_checks.py
@@ -65,7 +65,9 @@ def main(argv: Sequence[str] | None = None) -> None:
     log_to_rollbar = initialize_rollbar(rollbar_environment_name)
 
     # Keeps track of the last time we checked for a new pool
-    last_pool_check_block_number = 0
+    # Set this to a negative number to ensure we always check on the first iteration
+    # We only use this as a float to define negative infinity
+    last_pool_check_block_number: int | float = float("-inf")
     # Keeps track of the last time we executed an invariant check
     batch_check_start_block = chain.block_number()
 

--- a/scripts/invariant_checks.py
+++ b/scripts/invariant_checks.py
@@ -89,7 +89,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         # If a block hasn't ticked, we sleep
         if batch_check_start_block > batch_check_end_block:
             # take a nap
-            time.sleep(1)
+            time.sleep(3)
             continue
 
         # Look at the number of blocks we need to iterate through

--- a/scripts/invariant_checks.py
+++ b/scripts/invariant_checks.py
@@ -67,7 +67,6 @@ def main(argv: Sequence[str] | None = None) -> None:
     # Keeps track of the last time we checked for a new pool
     last_pool_check_block_number = 0
     # Keeps track of the last time we executed an invariant check
-    # Start from the current block - 1 to ensure we check on the first iteration
     batch_check_start_block = chain.block_number()
 
     # Run the loop forever

--- a/scripts/invariant_checks.py
+++ b/scripts/invariant_checks.py
@@ -100,9 +100,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         last_executed_block_number = latest_block_number
         # Loop through all deployed pools and run invariant checks
 
-        print(f"{start_block_number=} {latest_block_number=}")
         for check_block in range(start_block_number, latest_block_number + 1):
-            print(f"{check_block=}")
             if (latest_block_number - start_block_number) > LOOKBACK_BLOCK_LIMIT:
                 error_message = "Unable to keep up with invariant checks."
                 logging.error(error_message)

--- a/scripts/invariant_checks.py
+++ b/scripts/invariant_checks.py
@@ -81,6 +81,8 @@ def main(argv: Sequence[str] | None = None) -> None:
             deployed_pools = Hyperdrive.get_hyperdrive_pools_from_registry(chain, registry_address)
             last_pool_check_block_number = latest_block_number
 
+        # TODO ensure we check on every block, and wait for a new mined block
+        # Throw a critical if it gets behind
         if not latest_block_number > last_executed_block_number:
             # take a nap
             time.sleep(parsed_args.invariance_check_sleep_time)
@@ -92,10 +94,12 @@ def main(argv: Sequence[str] | None = None) -> None:
         for hyperdrive_obj in deployed_pools:
             name = hyperdrive_obj.name
             logging.info("Running invariance check on %s", name)
-            run_invariant_checks(
+            # This returns the list of all exceptions for failed checks,
+            # we ignore them here since we don't want to stop the script,
+            # we just log them.
+            _ = run_invariant_checks(
                 latest_block=latest_block,
                 interface=hyperdrive_obj.interface,
-                raise_error_on_failure=False,
                 log_to_rollbar=log_to_rollbar,
                 pool_name=name,
             )

--- a/scripts/invariant_checks.py
+++ b/scripts/invariant_checks.py
@@ -89,11 +89,11 @@ def main(argv: Sequence[str] | None = None) -> None:
             deployed_pools = Hyperdrive.get_hyperdrive_pools_from_registry(chain, registry_address)
             last_pool_check_block_number = latest_block_number
 
-        # TODO ensure we check on every block, and wait for a new mined block
+        # Ensure we check on every block, and wait for a new mined block
         # Throw a critical if it gets behind
         if not latest_block_number > last_executed_block_number:
             # take a nap
-            time.sleep(parsed_args.invariance_check_sleep_time)
+            time.sleep(1)
             continue
 
         # Update block number
@@ -130,7 +130,6 @@ def main(argv: Sequence[str] | None = None) -> None:
 class Args(NamedTuple):
     """Command line arguments for the invariant checker."""
 
-    invariance_check_sleep_time: int
     pool_check_sleep_blocks: int
     infra: bool
     registry_addr: str
@@ -151,7 +150,6 @@ def namespace_to_args(namespace: argparse.Namespace) -> Args:
         Formatted arguments
     """
     return Args(
-        invariance_check_sleep_time=namespace.invariance_check_sleep_time,
         pool_check_sleep_blocks=namespace.pool_check_sleep_blocks,
         infra=namespace.infra,
         registry_addr=namespace.registry_addr,
@@ -173,12 +171,6 @@ def parse_arguments(argv: Sequence[str] | None = None) -> Args:
         Formatted arguments
     """
     parser = argparse.ArgumentParser(description="Runs a loop to check Hyperdrive invariants at each block.")
-    parser.add_argument(
-        "--invariance-check-sleep-time",
-        type=int,
-        default=5,
-        help="Sleep time between invariance checks, in seconds.",
-    )
 
     parser.add_argument(
         "--pool-check-sleep-blocks",

--- a/scripts/invariant_checks.py
+++ b/scripts/invariant_checks.py
@@ -64,12 +64,15 @@ def main(argv: Sequence[str] | None = None) -> None:
     rollbar_environment_name = "invariant_checks"
     log_to_rollbar = initialize_rollbar(rollbar_environment_name)
 
-    # Keeps track of the last time we checked for a new pool
-    # Set this to a negative number to ensure we always check on the first iteration
-    # We only use this as a float to define negative infinity
-    last_pool_check_block_number: int | float = float("-inf")
     # Keeps track of the last time we executed an invariant check
     batch_check_start_block = chain.block_number()
+
+    # Check pools on first iteration
+    logging.info("Checking for new pools...")
+    deployed_pools = Hyperdrive.get_hyperdrive_pools_from_registry(chain, registry_address)
+
+    # Keeps track of the last time we checked for a new pool
+    last_pool_check_block_number = batch_check_start_block
 
     # Run the loop forever
     while True:

--- a/src/agent0/core/hyperdrive/interactive/chain.py
+++ b/src/agent0/core/hyperdrive/interactive/chain.py
@@ -16,7 +16,7 @@ from docker import DockerClient
 from docker.errors import NotFound
 from docker.models.containers import Container
 from numpy.random import Generator
-from web3.types import BlockData, Timestamp
+from web3.types import BlockData, BlockIdentifier, Timestamp
 
 from agent0.chainsync import PostgresConfig
 from agent0.chainsync.dashboard.usernames import build_user_mapping
@@ -319,15 +319,20 @@ class Chain:
         """
         return self._web3.eth.get_block_number()
 
-    def block_data(self) -> BlockData:
+    def block_data(self, block_identifier: BlockIdentifier = "latest") -> BlockData:
         """Get the current block on the chain.
+
+        Parameters
+        ----------
+        block_identifier
+            The identifier of the block to get. Defaults to 'latest'.
 
         Returns
         -------
         int
             The current block number
         """
-        return self._web3.eth.get_block("latest")
+        return self._web3.eth.get_block(block_identifier)
 
     def block_time(self) -> Timestamp:
         """Get the current block time on the chain.

--- a/src/agent0/core/hyperdrive/interactive/chain.py
+++ b/src/agent0/core/hyperdrive/interactive/chain.py
@@ -322,7 +322,7 @@ class Chain:
     def block_data(self, block_identifier: BlockIdentifier = "latest") -> BlockData:
         """Get the current block on the chain.
 
-        Parameters
+        Arguments
         ----------
         block_identifier
             The identifier of the block to get. Defaults to 'latest'.

--- a/src/agent0/ethpy/hyperdrive/interface/read_interface.py
+++ b/src/agent0/ethpy/hyperdrive/interface/read_interface.py
@@ -209,6 +209,16 @@ class HyperdriveReadInterface:
         self._current_pool_state = None
         self.last_state_block_number = -1
 
+        # Best effort to find initialize event and set deploy block
+        self.deploy_block: None | int = None
+        initialize_event = self.get_initialize_events("earliest")
+        if len(initialize_event) == 0:
+            logging.warning("Initialize event not found, can't set deploy_block")
+        elif len(initialize_event) == 1:
+            self.deploy_block = initialize_event[0]["blockNumber"]
+        else:
+            raise ValueError("Multiple initialize events found")
+
     @property
     def current_pool_state(self) -> PoolState:
         """The current state of the pool.

--- a/src/agent0/hyperfuzz/system_fuzz/invariant_checks.py
+++ b/src/agent0/hyperfuzz/system_fuzz/invariant_checks.py
@@ -121,7 +121,7 @@ def run_invariant_checks(
     if crash_report_additional_info is not None:
         exception_data_template.update(crash_report_additional_info)
 
-    exceptions: list[FuzzAssertionException] = []
+    out_exceptions: list[FuzzAssertionException] = []
     for failed, message, data, log_level in results:
         if not failed:
             continue
@@ -136,7 +136,7 @@ def run_invariant_checks(
         assert log_level is not None
         logging.log(log_level, "\n".join(exception_message))
         error = FuzzAssertionException(*exception_message, exception_data=exception_data)
-        exceptions.append(error)
+        out_exceptions.append(error)
         report = build_crash_trade_result(error, interface, additional_info=error.exception_data, pool_state=pool_state)
         report.anvil_state = get_anvil_state_dump(interface.web3)
         rollbar_data = error.exception_data
@@ -157,7 +157,7 @@ def run_invariant_checks(
             rollbar_data=rollbar_data,
             rollbar_log_prefix=rollbar_log_prefix,
         )
-    return exceptions
+    return out_exceptions
 
 
 class InvariantCheckResults(NamedTuple):

--- a/src/agent0/hyperfuzz/system_fuzz/invariant_checks.py
+++ b/src/agent0/hyperfuzz/system_fuzz/invariant_checks.py
@@ -26,12 +26,11 @@ TOTAL_SHARES_EPSILON = 1e-9
 def run_invariant_checks(
     latest_block: BlockData,
     interface: HyperdriveReadInterface,
-    raise_error_on_failure: bool = False,
     log_to_rollbar: bool = True,
     pool_name: str | None = None,
     lp_share_price_test: bool | None = None,
     crash_report_additional_info: dict[str, Any] | None = None,
-) -> None:
+) -> list[FuzzAssertionException]:
     """Run the invariant checks.
 
     # Invariance checks (these should be True):
@@ -50,8 +49,6 @@ def run_invariant_checks(
         The current block to be tested.
     interface: HyperdriveReadInterface
         An instantiated HyperdriveReadInterface object constructed using the script arguments.
-    raise_error_on_failure: bool
-        If True, raise an error if any invariant check fails.
     log_to_rollbar: bool
         If True, log to rollbar if any invariant check fails.
     pool_name: str | None
@@ -61,6 +58,11 @@ def run_invariant_checks(
         If None (default), runs all tests.
     crash_report_additional_info: dict[str, Any] | None
         Additional information to include in the crash report.
+
+    Returns
+    -------
+    list[FuzzAssertionException]
+        A list of FuzzAssertionExceptions, one for each failed invariant check.
     """
     # TODO cleanup
     # pylint: disable=too-many-locals
@@ -68,24 +70,36 @@ def run_invariant_checks(
 
     # Get the variables to check & check each invariant
     pool_state = interface.get_hyperdrive_state(latest_block)
-    any_check_failed = False
-    exception_message: list[str] = ["Continuous Fuzz Bots Invariant Checks"]
-    exception_data: dict[str, Any] = {}
-    if crash_report_additional_info is not None:
-        exception_data.update(crash_report_additional_info)
 
     results: list[InvariantCheckResults]
     if lp_share_price_test is None:
+        # Available log levels:
+        # Critical (pager duty)
+        # Error (not pager duty, important)
+        # Warning (not pager duty, may be important)
+        # Info (not important)
+
         results = [
+            # Critical if lp share price is down,
+            # Warn if lp share price is up
             _check_lp_share_price(interface, pool_state),
+            # Warning
             _check_eth_balances(pool_state),
+            # Info
             _check_base_balances(pool_state, interface.base_is_eth),
+            # Critical (after diving down into steth failure)
             _check_total_shares(pool_state),
+            # Critical
             _check_minimum_share_reserves(pool_state),
+            # Critical
             _check_solvency(pool_state),
+            # Critical
             _check_present_value_greater_than_idle_shares(interface, pool_state),
+            # Critical (after fixing)
             _check_checkpointing_should_never_fail(interface, pool_state),
-            _check_initial_lp_profitable(pool_state),
+            # TODO
+            # If at any point, we can open a long to make share price to 1
+            # Get spot price after long
         ]
     else:
         if lp_share_price_test:
@@ -101,20 +115,28 @@ def run_invariant_checks(
                 _check_solvency(pool_state),
                 _check_present_value_greater_than_idle_shares(interface, pool_state),
                 _check_checkpointing_should_never_fail(interface, pool_state),
-                _check_initial_lp_profitable(pool_state),
             ]
 
-    for failed, message, data in results:
-        any_check_failed = failed | any_check_failed
+    exception_message_base = ["Continuous Fuzz Bots Invariant Checks"]
+    exception_data_template: dict[str, Any] = {}
+    if crash_report_additional_info is not None:
+        exception_data_template.update(crash_report_additional_info)
+
+    exceptions: list[FuzzAssertionException] = []
+    for failed, message, data, log_level in results:
+        if not failed:
+            continue
+        exception_message = exception_message_base.copy()
         if message:
             exception_message.append(message)
+        exception_data = exception_data_template.copy()
         exception_data.update(data)
         exception_data["block_number"] = pool_state.block_number
 
-    # Log additional information if any test failed
-    if any_check_failed:
-        logging.critical("\n".join(exception_message))
+        # Log exception to rollbar
+        logging.log(log_level, "\n".join(exception_message))
         error = FuzzAssertionException(*exception_message, exception_data=exception_data)
+        exceptions.append(error)
         report = build_crash_trade_result(error, interface, additional_info=error.exception_data, pool_state=pool_state)
         report.anvil_state = get_anvil_state_dump(interface.web3)
         rollbar_data = error.exception_data
@@ -128,14 +150,14 @@ def run_invariant_checks(
 
         log_hyperdrive_crash_report(
             report,
+            log_level=log_level,
             crash_report_to_file=True,
             crash_report_file_prefix=crash_report_file_prefix,
             log_to_rollbar=log_to_rollbar,
             rollbar_data=rollbar_data,
             rollbar_log_prefix=rollbar_log_prefix,
         )
-        if raise_error_on_failure:
-            raise error
+    return exceptions
 
 
 class InvariantCheckResults(NamedTuple):
@@ -144,6 +166,7 @@ class InvariantCheckResults(NamedTuple):
     failed: bool
     exception_message: str | None
     exception_data: dict[str, Any]
+    log_level: int | None
 
 
 def _check_eth_balances(pool_state: PoolState) -> InvariantCheckResults:
@@ -151,13 +174,15 @@ def _check_eth_balances(pool_state: PoolState) -> InvariantCheckResults:
     failed = False
     exception_message: str | None = None
     exception_data: dict[str, Any] = {}
+    log_level = None
 
     if pool_state.hyperdrive_eth_balance != FixedPoint(0):
         exception_message = f"{pool_state.hyperdrive_eth_balance} != 0."
         exception_data["invariance_check:actual_hyperdrive_eth_balance"] = pool_state.hyperdrive_eth_balance
         failed = True
+        log_level = logging.WARNING
 
-    return InvariantCheckResults(failed, exception_message, exception_data)
+    return InvariantCheckResults(failed, exception_message, exception_data, log_level=log_level)
 
 
 def _check_base_balances(pool_state: PoolState, is_steth: bool) -> InvariantCheckResults:
@@ -165,19 +190,24 @@ def _check_base_balances(pool_state: PoolState, is_steth: bool) -> InvariantChec
     failed = False
     exception_message: str | None = None
     exception_data: dict[str, Any] = {}
+    log_level = None
 
     # We ignore this test for steth, as the base token here is actually the yield token
     if pool_state.hyperdrive_base_balance != FixedPoint(0) and not is_steth:
         exception_message = f"{pool_state.hyperdrive_base_balance} != 0."
         exception_data["invariance_check:actual_hyperdrive_base_balance"] = pool_state.hyperdrive_base_balance
         failed = True
+        log_level = logging.INFO
 
-    return InvariantCheckResults(failed, exception_message, exception_data)
+    return InvariantCheckResults(failed, exception_message, exception_data, log_level=log_level)
 
 
 def _check_checkpointing_should_never_fail(
     interface: HyperdriveReadInterface, pool_state: PoolState
 ) -> InvariantCheckResults:
+    # TODO Fix this test to check if previous checkpoint should never be 0
+    # TODO add case for first checkpoint
+
     # Creating a checkpoint should never fail
     # TODO: add get_block_transactions() to interface
     # NOTE: This wold be prone to false positives.
@@ -200,6 +230,7 @@ def _check_checkpointing_should_never_fail(
             if txn_to is None:
                 raise AssertionError("Transaction did not have a 'to' key.")
             if txn_to == interface.hyperdrive_contract.address and pool_state.checkpoint.vault_share_price <= 0:
+                # Check here if transaction was successful
                 exception_message = (
                     f"A transaction was created but no checkpoint was minted.\n"
                     f"{pool_state.checkpoint.vault_share_price=}\n"
@@ -215,6 +246,7 @@ def _check_solvency(pool_state: PoolState) -> InvariantCheckResults:
     failed = False
     exception_message: str | None = None
     exception_data: dict[str, Any] = {}
+    log_level = None
 
     solvency = (
         pool_state.pool_info.share_reserves
@@ -229,8 +261,9 @@ def _check_solvency(pool_state: PoolState) -> InvariantCheckResults:
         )
         exception_data["invariance_check:solvency"] = solvency
         failed = True
+        log_level = logging.CRITICAL
 
-    return InvariantCheckResults(failed, exception_message, exception_data)
+    return InvariantCheckResults(failed, exception_message, exception_data, log_level)
 
 
 def _check_minimum_share_reserves(pool_state: PoolState) -> InvariantCheckResults:
@@ -238,6 +271,7 @@ def _check_minimum_share_reserves(pool_state: PoolState) -> InvariantCheckResult
     failed = False
     exception_message = ""
     exception_data: dict[str, Any] = {}
+    log_level = logging.CRITICAL
 
     current_share_reserves = pool_state.pool_info.share_reserves
     minimum_share_reserves = pool_state.pool_config.minimum_share_reserves
@@ -252,7 +286,7 @@ def _check_minimum_share_reserves(pool_state: PoolState) -> InvariantCheckResult
         exception_data["invariance_check:minimum_share_reserves"] = minimum_share_reserves
         failed = True
 
-    return InvariantCheckResults(failed, exception_message, exception_data)
+    return InvariantCheckResults(failed, exception_message, exception_data, log_level=log_level)
 
 
 def _check_total_shares(pool_state: PoolState) -> InvariantCheckResults:
@@ -260,6 +294,7 @@ def _check_total_shares(pool_state: PoolState) -> InvariantCheckResults:
     failed = False
     exception_message = ""
     exception_data: dict[str, Any] = {}
+    log_level = None
 
     expected_vault_shares = (
         pool_state.pool_info.share_reserves
@@ -285,8 +320,9 @@ def _check_total_shares(pool_state: PoolState) -> InvariantCheckResults:
         exception_data["invariance_check:actual_vault_shares"] = actual_vault_shares
         exception_data["invariance_check:vault_shares_difference_in_wei"] = difference_in_wei
         failed = True
+        log_level = logging.CRITICAL
 
-    return InvariantCheckResults(failed, exception_message, exception_data)
+    return InvariantCheckResults(failed, exception_message, exception_data, log_level)
 
 
 def _check_present_value_greater_than_idle_shares(
@@ -309,6 +345,7 @@ def _check_present_value_greater_than_idle_shares(
     failed = False
     exception_message = ""
     exception_data: dict[str, Any] = {}
+    log_level = None
 
     # Rust calls here can fail, we log if it does
     try:
@@ -316,7 +353,7 @@ def _check_present_value_greater_than_idle_shares(
         idle_shares = interface.get_idle_shares(pool_state)
     # Catching rust panics here
     except BaseException as e:  # pylint: disable=broad-except
-        return InvariantCheckResults(False, repr(e), exception_data)
+        return InvariantCheckResults(True, repr(e), exception_data, log_level=logging.CRITICAL)
 
     if not present_value >= idle_shares:
         difference_in_wei = abs(present_value.scaled_value - idle_shares.scaled_value)
@@ -325,8 +362,9 @@ def _check_present_value_greater_than_idle_shares(
         exception_data["invariance_check:current_present_value"] = present_value
         exception_data["invariance_check:present_value_difference_in_wei"] = difference_in_wei
         failed = True
+        log_level = logging.CRITICAL
 
-    return InvariantCheckResults(failed, exception_message, exception_data)
+    return InvariantCheckResults(failed, exception_message, exception_data, log_level)
 
 
 def _check_lp_share_price(
@@ -342,6 +380,7 @@ def _check_lp_share_price(
     failed = False
     exception_message = ""
     exception_data: dict[str, Any] = {}
+    log_level = None
 
     block_number = pool_state.block_number
 
@@ -354,7 +393,8 @@ def _check_lp_share_price(
     try:
         previous_pool_state = interface.get_hyperdrive_state(interface.get_block(block_number - 1))
     except BlockNotFound:
-        return InvariantCheckResults(False, exception_message, exception_data)
+        # Not a failure
+        return InvariantCheckResults(False, exception_message, exception_data, log_level)
 
     block_time_delta = pool_state.block_time - previous_pool_state.block_time
     normalized_test_epsilon = LP_SHARE_PRICE_EPSILON * (block_time_delta / 12)
@@ -395,56 +435,32 @@ def _check_lp_share_price(
             closing_mature_position = True
             break
 
-    # Full check
+    # We check if lp share price jumps higher than expected
+    # if we're doing a full check. In this case, we warn
+    difference_in_wei = abs(previous_lp_share_price.scaled_value - current_lp_share_price.scaled_value)
     if not currently_minting_checkpoint and not closing_mature_position:
-        if not isclose(previous_lp_share_price, current_lp_share_price, abs_tol=test_tolerance):
+        if (current_lp_share_price - previous_lp_share_price) >= test_tolerance:
             failed = True
-    # Relaxed check
-    else:
-        if (previous_lp_share_price - current_lp_share_price) >= test_tolerance:
-            failed = True
+            exception_message = (
+                "LP share price went up more than expected: "
+                f"{previous_lp_share_price=}, {current_lp_share_price=}, {difference_in_wei=}"
+            )
+            log_level = logging.WARNING
+
+    # We always check if lp share price jumps lower than expected.
+    # In this case, we throw critical.
+    if (previous_lp_share_price - current_lp_share_price) >= test_tolerance:
+        failed = True
+        exception_message = (
+            "LP share price went down more than expected: "
+            f"{previous_lp_share_price=}, {current_lp_share_price=}, {difference_in_wei=}"
+        )
+        log_level = logging.CRITICAL
 
     if failed:
-        difference_in_wei = abs(previous_lp_share_price.scaled_value - current_lp_share_price.scaled_value)
-        exception_message = f"{previous_lp_share_price=} != {current_lp_share_price=}, {difference_in_wei=}"
         exception_data["invariance_check:initial_lp_share_price"] = previous_lp_share_price
         exception_data["invariance_check:current_lp_share_price"] = current_lp_share_price
         exception_data["invariance_check:lp_share_price_difference_in_wei"] = difference_in_wei
         failed = True
 
-    return InvariantCheckResults(failed, exception_message, exception_data)
-
-
-def _check_initial_lp_profitable(pool_state: PoolState, epsilon: FixedPoint | None = None) -> InvariantCheckResults:
-
-    if epsilon is None:
-        epsilon = FixedPoint("0.005")
-
-    failed = False
-    exception_message = ""
-    exception_data: dict[str, Any] = {}
-
-    # We compare the rate of lp share price vs the rate of vault share price
-    # For this, we need to get the initial and current prices of both
-    initial_vault_share_price = pool_state.pool_config.initial_vault_share_price
-    current_vault_share_price = pool_state.pool_info.vault_share_price
-
-    # LP Share price is always 1 at initialization
-    initial_lp_share_price = FixedPoint(1)
-    current_lp_share_price = pool_state.pool_info.lp_share_price
-
-    # We calculate both rates and compare
-    # The rate calculated here is for the time range of how long the pool has deployed
-    vault_rate = (current_vault_share_price - initial_vault_share_price) / initial_vault_share_price
-    lp_rate = (current_lp_share_price - initial_lp_share_price) / initial_lp_share_price
-
-    difference_in_wei = lp_rate.scaled_value - vault_rate.scaled_value
-
-    if difference_in_wei < (-epsilon.scaled_value):
-        exception_message = f"{lp_rate=} is expected to be >= {vault_rate=}, {difference_in_wei=}"
-        exception_data["invariance_check:lp_rate"] = lp_rate
-        exception_data["invariance_check:vault_rate"] = vault_rate
-        exception_data["invariance_check:lp_vault_rate_difference_in_wei"] = difference_in_wei
-        failed = True
-
-    return InvariantCheckResults(failed, exception_message, exception_data)
+    return InvariantCheckResults(failed, exception_message, exception_data, log_level)

--- a/src/agent0/hyperfuzz/system_fuzz/invariant_checks.py
+++ b/src/agent0/hyperfuzz/system_fuzz/invariant_checks.py
@@ -221,8 +221,9 @@ def _check_previous_checkpoint_exists(
 
     # If deploy block is set and the previous checkpoint time was before hyperdrive was deployed,
     # we ignore this test
-    if interface.deploy_block is not None and (
-        previous_checkpoint_time < interface.get_block_timestamp(interface.get_block(interface.deploy_block))
+    deploy_block = interface.get_deploy_block()
+    if deploy_block is not None and (
+        previous_checkpoint_time < interface.get_block_timestamp(interface.get_block(deploy_block))
     ):
         return InvariantCheckResults(failed=False, exception_message=None, exception_data={}, log_level=None)
 

--- a/src/agent0/hyperfuzz/system_fuzz/invariant_checks.py
+++ b/src/agent0/hyperfuzz/system_fuzz/invariant_checks.py
@@ -351,7 +351,9 @@ def _check_present_value_greater_than_idle_shares(
         idle_shares = interface.get_idle_shares(pool_state)
     # Catching rust panics here
     except BaseException as e:  # pylint: disable=broad-except
-        return InvariantCheckResults(True, repr(e), exception_data, log_level=logging.CRITICAL)
+        return InvariantCheckResults(
+            failed=True, exception_message=repr(e), exception_data=exception_data, log_level=logging.CRITICAL
+        )
 
     if not present_value >= idle_shares:
         difference_in_wei = abs(present_value.scaled_value - idle_shares.scaled_value)
@@ -392,7 +394,9 @@ def _check_lp_share_price(
         previous_pool_state = interface.get_hyperdrive_state(interface.get_block(block_number - 1))
     except BlockNotFound:
         # Not a failure
-        return InvariantCheckResults(False, exception_message, exception_data, log_level)
+        return InvariantCheckResults(
+            failed=False, exception_message=exception_message, exception_data=exception_data, log_level=log_level
+        )
 
     block_time_delta = pool_state.block_time - previous_pool_state.block_time
     normalized_test_epsilon = LP_SHARE_PRICE_EPSILON * (block_time_delta / 12)

--- a/src/agent0/hyperfuzz/system_fuzz/invariant_checks.py
+++ b/src/agent0/hyperfuzz/system_fuzz/invariant_checks.py
@@ -205,10 +205,9 @@ def _check_base_balances(pool_state: PoolState, is_steth: bool) -> InvariantChec
 def _check_previous_checkpoint_exists(
     interface: HyperdriveReadInterface, pool_state: PoolState
 ) -> InvariantCheckResults:
-    # TODO Fix this test to check if previous checkpoint should never be 0
-    # TODO add case for first checkpoint
+    # This test checks if previous checkpoint was minted, and fails if that checkpoint can't be found
+    # (with the exception of the first checkpoint)
 
-    # Previous checkpoint should always exist
     failed = False
     exception_message: str | None = None
     exception_data: dict[str, Any] = {}

--- a/src/agent0/hyperfuzz/system_fuzz/invariant_checks.py
+++ b/src/agent0/hyperfuzz/system_fuzz/invariant_checks.py
@@ -24,7 +24,7 @@ TOTAL_SHARES_EPSILON = 1e-9
 
 
 def run_invariant_checks(
-    latest_block: BlockData,
+    check_block_data: BlockData,
     interface: HyperdriveReadInterface,
     log_to_rollbar: bool = True,
     pool_name: str | None = None,
@@ -44,7 +44,7 @@ def run_invariant_checks(
 
     Arguments
     ---------
-    latest_block: BlockData
+    check_block_data: BlockData
         The current block to be tested.
     interface: HyperdriveReadInterface
         An instantiated HyperdriveReadInterface object constructed using the script arguments.
@@ -68,7 +68,7 @@ def run_invariant_checks(
     # pylint: disable=too-many-arguments
 
     # Get the variables to check & check each invariant
-    pool_state = interface.get_hyperdrive_state(latest_block)
+    pool_state = interface.get_hyperdrive_state(check_block_data)
 
     results: list[InvariantCheckResults]
     if lp_share_price_test is None:

--- a/src/agent0/hyperfuzz/system_fuzz/run_fuzz_bots.py
+++ b/src/agent0/hyperfuzz/system_fuzz/run_fuzz_bots.py
@@ -296,7 +296,7 @@ def run_fuzz_bots(
                     raise AssertionError("Block has no number.")
                 # pylint: disable=protected-access
                 fuzz_exceptions = run_invariant_checks(
-                    latest_block=latest_block,
+                    check_block_data=latest_block,
                     interface=hyperdrive_pool.interface,
                     log_to_rollbar=log_to_rollbar,
                     lp_share_price_test=lp_share_price_test,

--- a/src/agent0/hyperfuzz/system_fuzz/run_fuzz_bots.py
+++ b/src/agent0/hyperfuzz/system_fuzz/run_fuzz_bots.py
@@ -12,6 +12,7 @@ from agent0 import Chain, Hyperdrive, LocalChain, LocalHyperdrive, PolicyZoo
 from agent0.core.base.make_key import make_private_key
 from agent0.core.hyperdrive.interactive.hyperdrive_agent import HyperdriveAgent
 from agent0.ethpy.base import set_anvil_account_balance
+from agent0.hyperfuzz import FuzzAssertionException
 from agent0.hyperfuzz.system_fuzz.invariant_checks import run_invariant_checks
 
 ONE_HOUR_IN_SECONDS = 60 * 60
@@ -294,18 +295,24 @@ def run_fuzz_bots(
                 if latest_block_number is None:
                     raise AssertionError("Block has no number.")
                 # pylint: disable=protected-access
-                try:
-                    run_invariant_checks(
-                        latest_block=latest_block,
-                        interface=hyperdrive_pool.interface,
-                        raise_error_on_failure=raise_error_on_failed_invariance_checks,
-                        log_to_rollbar=log_to_rollbar,
-                        lp_share_price_test=lp_share_price_test,
-                        crash_report_additional_info=hyperdrive_pool._crash_report_additional_info,
-                    )
-                except Exception as exc:  # pylint: disable=broad-exception-caught
-                    if ignore_raise_error_func is None or not ignore_raise_error_func(exc):
-                        raise exc
+                fuzz_exceptions = run_invariant_checks(
+                    latest_block=latest_block,
+                    interface=hyperdrive_pool.interface,
+                    log_to_rollbar=log_to_rollbar,
+                    lp_share_price_test=lp_share_price_test,
+                    crash_report_additional_info=hyperdrive_pool._crash_report_additional_info,
+                )
+                if len(fuzz_exceptions) > 0 and raise_error_on_failed_invariance_checks:
+                    # If we have an ignore function, we filter exceptions
+                    if ignore_raise_error_func is not None:
+                        fuzz_exceptions = [e for e in fuzz_exceptions if not ignore_raise_error_func(e)]
+                    # Do nothing if no exceptions
+                    # If single failure, we raise it by itself
+                    if len(fuzz_exceptions) == 1:
+                        raise fuzz_exceptions[0]
+                    if len(fuzz_exceptions) > 1:
+                        # Otherwise, we raise a new fuzz assertion exception wht the list of exceptions
+                        raise FuzzAssertionException(*fuzz_exceptions)
 
         # Check agent funds and refund if necessary
         assert len(agents) > 0


### PR DESCRIPTION
- Checkpoint bot logs warnings when retrying, and logs criticals if it fails 10 times in a row.
- Invariant check script checks every block.
- Running invariance checks asynchronously.
- Each invariance check controls what log level to log at in rollbar.
- Changing `check_checkpointing_should_never_fail` to `check_previous_checkpoint_exists`, which ensures the previous checkpoint always exists.
- LP share price check throws warning if price is up past threshold, throws critical if price is down past threshold.
- Removing initial lp profitable check.