### PR TITLE
Fuzz updates

### DIFF
--- a/scripts/local_fuzz_bots.py
+++ b/scripts/local_fuzz_bots.py
@@ -20,6 +20,7 @@ from agent0.hyperlogs.rollbar_utilities import initialize_rollbar
 
 
 def _fuzz_ignore_errors(exc: Exception) -> bool:
+    # pylint: disable=too-many-return-statements
     # Ignored fuzz exceptions
     if isinstance(exc, FuzzAssertionException):
         # LP rate invariance check

--- a/scripts/local_fuzz_bots.py
+++ b/scripts/local_fuzz_bots.py
@@ -53,7 +53,23 @@ def _fuzz_ignore_errors(exc: Exception) -> bool:
         ):
             return True
 
-        # Status == 0, but preview was successful error
+        # DistributeExcessIdle error
+        if (
+            isinstance(orig_exception, ContractCustomError)
+            and len(orig_exception.args) > 1
+            and "DistributeExcessIdleFailed raised" in orig_exception.args[1]
+        ):
+            return True
+
+        # DecreasedPresentValueWhenAddingLiquidity error
+        if (
+            isinstance(orig_exception, ContractCustomError)
+            and len(orig_exception.args) > 1
+            and "DecreasedPresentValueWhenAddingLiquidity raised" in orig_exception.args[1]
+        ):
+            return True
+
+        # Status == 0
         if (
             # Lots of conditions to check
             # pylint: disable=too-many-boolean-expressions

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import pandas as pd

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
@@ -291,30 +291,6 @@ class LocalHyperdrive(Hyperdrive):
         chain._add_deployed_pool_to_bookkeeping(self)
         self.chain = chain
 
-        # Add additional deployment info to crash report additional info
-        if self._deployed_hyperdrive_factory is not None:
-            self._crash_report_additional_info.update(
-                {
-                    "factory_deployer_account": self._deployed_hyperdrive_factory.deployer_account.address,
-                    "factory_contract": self._deployed_hyperdrive_factory.factory_contract.address,
-                    "deployer_coor_contract": self._deployed_hyperdrive_factory.deployer_coordinator_contract.address,
-                    "registry_contract": self._deployed_hyperdrive_factory.registry_contract.address,
-                    "factory_deploy_config": asdict(self._deployed_hyperdrive_factory.factory_deploy_config),
-                }
-            )
-
-        if self._deployed_hyperdrive_pool is not None:
-            self._crash_report_additional_info.update(
-                {
-                    "pool_deployer_account": self._deployed_hyperdrive_pool.deployer_account.address,
-                    "hyperdrive_contract": self._deployed_hyperdrive_pool.hyperdrive_contract.address,
-                    "base_token_contract": self._deployed_hyperdrive_pool.base_token_contract.address,
-                    "vault_shares_token_contract": self._deployed_hyperdrive_pool.vault_shares_token_contract.address,
-                    "deploy_block_number": self._deploy_block_number,
-                    "pool_deploy_config": asdict(self._deployed_hyperdrive_pool.pool_deploy_config),
-                }
-            )
-
         # Run the data pipeline in background threads if experimental mode
         self.data_pipeline_timeout = self.config.data_pipeline_timeout
 

--- a/src/agent0/ethpy/base/errors/errors.py
+++ b/src/agent0/ethpy/base/errors/errors.py
@@ -47,6 +47,11 @@ class ContractCallException(Exception):
         self.block_number = block_number
         self.raw_txn = raw_txn
 
+    def __repr__(self):
+        # We overwrite repr here to ensure the orig exception gets printed for
+        # repr(ContractCallException)
+        return f"ContractCallException({self.args + (repr(self.orig_exception),)})"
+
 
 def decode_error_selector_for_contract(error_selector: str, contract: Contract) -> str:
     """Decode the error selector for a contract,

--- a/src/agent0/ethpy/base/errors/errors.py
+++ b/src/agent0/ethpy/base/errors/errors.py
@@ -50,7 +50,8 @@ class ContractCallException(Exception):
     def __repr__(self):
         # We overwrite repr here to ensure the orig exception gets printed for
         # repr(ContractCallException)
-        return f"ContractCallException({self.args + (repr(self.orig_exception),)})"
+        # Since args is already a tuple, no need for outer parenthesis
+        return f"ContractCallException{self.args + (repr(self.orig_exception),)}"
 
 
 def decode_error_selector_for_contract(error_selector: str, contract: Contract) -> str:

--- a/src/agent0/ethpy/base/transactions.py
+++ b/src/agent0/ethpy/base/transactions.py
@@ -509,22 +509,21 @@ async def _async_send_transaction_and_wait_for_receipt(
         try:
             # Tracing doesn't exist in typing for some reason.
             # Doing this in error checking with try/catch.
-            tx_hash = tx_receipt["transactionHash"]
             trace = web3.tracing.trace_transaction(tx_hash)  # type: ignore
             if len(trace) == 0:
-                error_message = f"Receipt has status of 0. {tx_hash=}"
+                error_message = "Receipt has status of 0."
             else:
                 # Trace gives a list of values, the last one should contain the error
                 error_message = trace[-1].get("error", None)
                 # If no trace, add back in status == 0 error
                 if error_message is None:
-                    error_message = f"Receipt has status of 0. {tx_hash=}"
+                    error_message = "Receipt has status of 0."
         # TODO does this need to be BaseException?
         except Exception as e:  # pylint: disable=broad-exception-caught
             # Don't crash in crash reporting
             logging.warning("Tracing failed for handling failed status: %s", repr(e))
             error_message = f"Receipt has status of 0. Error getting trace: {repr(e)}"
-        raise UnknownBlockError(f"{error_message}", f"{block_number=}", f"{tx_receipt=}")
+        raise UnknownBlockError(f"{error_message}", f"{block_number=}", f"{tx_hash=}")
     return tx_receipt
 
 
@@ -658,7 +657,7 @@ async def async_smart_contract_transact(
         assert "block_number=" in block_number_arg
         block_number = int(block_number_arg.split("block_number=")[1])
 
-        orig_exception: list[Exception] = [err]
+        retry_preview_exception: Exception | None = None
         try:
             smart_contract_preview_transaction(
                 contract,
@@ -670,24 +669,22 @@ async def async_smart_contract_transact(
                 **fn_kwargs,
             )
             # If the preview was successful, then we raise this message here
-            raise AssertionError("Preview was successful.")  # pylint: disable=raise-missing-from
+            raise ValueError("Preview was successful.")  # pylint: disable=raise-missing-from
 
         except Exception as preview_err:  # pylint: disable=broad-except
             if isinstance(preview_err, ContractCallException):
                 # We add a message to the preview error saying what this error is
-                preview_err.args = ("Previewing transaction on transaction failure:",) + (
-                    repr(preview_err.orig_exception),
-                )
+                preview_err.args = ("Retry preview result: ",) + (repr(preview_err.orig_exception),)
             else:
-                preview_err.args = ("Previewing transaction on transaction failure:",) + (repr(preview_err),)
+                preview_err.args = ("Retry preview result: ",) + (repr(preview_err),)
 
             # We report both the exception from the transaction and the exception from the preview
-            orig_exception.append(preview_err)
+            retry_preview_exception = preview_err
 
         raise ContractCallException(
             "Error in smart_contract_transact: " + err.args[0],
-            "Retry preview result: " + repr(orig_exception[-1]),
-            orig_exception=orig_exception,
+            repr(retry_preview_exception),
+            orig_exception=err,
             contract_call_type=ContractCallType.TRANSACTION,
             function_name_or_signature=function_name_or_signature,
             fn_args=fn_args,
@@ -751,22 +748,21 @@ def _send_transaction_and_wait_for_receipt(
         try:
             # Tracing doesn't exist in typing for some reason.
             # Doing this in error checking with try/catch.
-            tx_hash = tx_receipt["transactionHash"]
             trace = web3.tracing.trace_transaction(tx_hash)  # type: ignore
             if len(trace) == 0:
-                error_message = f"Receipt has status of 0. {tx_hash=}"
+                error_message = "Receipt has status of 0."
             else:
                 # Trace gives a list of values, the last one should contain the error
                 error_message = trace[-1].get("error", None)
                 # If no trace, add back in status == 0 error
                 if error_message is None:
-                    error_message = f"Receipt has status of 0. {tx_hash=}"
+                    error_message = "Receipt has status of 0."
         # TODO does this need to be BaseException?
         except Exception as e:  # pylint: disable=broad-exception-caught
             # Don't crash in crash reporting
             logging.warning("Tracing failed for handling failed status: %s", repr(e))
             error_message = f"Receipt has status of 0. Error getting trace: {repr(e)}"
-        raise UnknownBlockError(f"{error_message}", f"{block_number=}", f"{tx_receipt=}")
+        raise UnknownBlockError(f"{error_message}", f"{block_number=}", f"{tx_hash=}")
     return tx_receipt
 
 
@@ -892,7 +888,7 @@ def smart_contract_transact(
         assert "block_number=" in block_number_arg
         block_number = int(block_number_arg.split("block_number=")[1])
 
-        orig_exception: list[Exception] = [err]
+        retry_preview_exception: Exception | None = None
         try:
             smart_contract_preview_transaction(
                 contract,
@@ -909,19 +905,17 @@ def smart_contract_transact(
         except Exception as preview_err:  # pylint: disable=broad-except
             if isinstance(preview_err, ContractCallException):
                 # We add a message to the preview error saying what this error is
-                preview_err.args = ("Previewing transaction on transaction failure:",) + (
-                    repr(preview_err.orig_exception),
-                )
+                preview_err.args = ("Retry preview result: ",) + (repr(preview_err.orig_exception),)
             else:
-                preview_err.args = ("Previewing transaction on transaction failure:",) + (repr(preview_err),)
+                preview_err.args = ("Retry preview result: ",) + (repr(preview_err),)
 
             # We report both the exception from the transaction and the exception from the preview
-            orig_exception.append(preview_err)
+            retry_preview_exception = preview_err
 
         raise ContractCallException(
-            "Error in smart_contract_transact",
-            "Retry preview result: " + repr(orig_exception[-1]),
-            orig_exception=orig_exception,
+            "Error in smart_contract_transact: " + err.args[0],
+            repr(retry_preview_exception),
+            orig_exception=err,
             contract_call_type=ContractCallType.TRANSACTION,
             function_name_or_signature=function_name_or_signature,
             fn_args=fn_args,

--- a/src/agent0/ethpy/base/transactions.py
+++ b/src/agent0/ethpy/base/transactions.py
@@ -673,12 +673,7 @@ async def async_smart_contract_transact(
 
         except Exception as preview_err:  # pylint: disable=broad-except
             if isinstance(preview_err, ContractCallException):
-                # We add a message to the preview error saying what this error is
-                preview_err.args = ("Retry preview result: ",) + (repr(preview_err.orig_exception),)
-            else:
-                preview_err.args = ("Retry preview result: ",) + (repr(preview_err),)
-
-            # We report both the exception from the transaction and the exception from the preview
+                preview_err.args = ("Retry preview result: ",) + preview_err.args
             retry_preview_exception = preview_err
 
         raise ContractCallException(
@@ -900,16 +895,11 @@ def smart_contract_transact(
                 **fn_kwargs,
             )
             # If the preview was successful, then we raise this message here
-            raise AssertionError("Preview was successful.")  # pylint: disable=raise-missing-from
+            raise ValueError("Preview was successful.")  # pylint: disable=raise-missing-from
 
         except Exception as preview_err:  # pylint: disable=broad-except
             if isinstance(preview_err, ContractCallException):
-                # We add a message to the preview error saying what this error is
-                preview_err.args = ("Retry preview result: ",) + (repr(preview_err.orig_exception),)
-            else:
-                preview_err.args = ("Retry preview result: ",) + (repr(preview_err),)
-
-            # We report both the exception from the transaction and the exception from the preview
+                preview_err.args = ("Retry preview result: ",) + preview_err.args
             retry_preview_exception = preview_err
 
         raise ContractCallException(

--- a/src/agent0/ethpy/hyperdrive/interface/_contract_calls.py
+++ b/src/agent0/ethpy/hyperdrive/interface/_contract_calls.py
@@ -214,10 +214,12 @@ async def _async_open_long(
     # Convert the trade amount from steth to lido shares
     # before passing into hyperdrive
     if interface.vault_is_steth:
-        trade_amount = trade_amount / interface.current_pool_state.pool_info.vault_share_price
-        # TODO the more accurate way to do this is to use the underlying `getPooledEthByShares`
-        # call to convert steth to shares, or by using
-        # trade_amount.mul_div_down(getTotalPooledEther(), getTotalShares()).
+        # Convert input steth into lido shares
+        trade_amount = FixedPoint(
+            scaled_value=interface.vault_shares_token_contract.functions.getSharesByPooledEth(
+                trade_amount.scaled_value
+            ).call()
+        )
 
     fn_args = (
         trade_amount.scaled_value,
@@ -571,10 +573,12 @@ async def _async_add_liquidity(
     # Convert the trade amount from steth to lido shares
     # before passing into hyperdrive
     if interface.vault_is_steth:
-        trade_amount = trade_amount / interface.current_pool_state.pool_info.vault_share_price
-        # TODO the more accurate way to do this is to use the underlying `getPooledEthByShares`
-        # call to convert steth to shares, or by using
-        # trade_amount.mul_div_down(getTotalPooledEther(), getTotalShares()).
+        # Convert input steth into lido shares
+        trade_amount = FixedPoint(
+            scaled_value=interface.vault_shares_token_contract.functions.getSharesByPooledEth(
+                trade_amount.scaled_value
+            ).call()
+        )
 
     fn_args = (
         trade_amount.scaled_value,

--- a/src/agent0/hyperlogs/rollbar_utilities.py
+++ b/src/agent0/hyperlogs/rollbar_utilities.py
@@ -11,8 +11,6 @@ import platform
 import rollbar
 from dotenv import load_dotenv
 
-from agent0.ethpy.base.errors import ContractCallException
-
 load_dotenv(".env")
 ROLLBAR_API_KEY = os.getenv("ROLLBAR_API_KEY")
 

--- a/src/agent0/hyperlogs/rollbar_utilities.py
+++ b/src/agent0/hyperlogs/rollbar_utilities.py
@@ -91,6 +91,4 @@ def log_rollbar_exception(
     else:
         log_message = rollbar_log_prefix + ": "
     log_message += repr(exception)
-    if isinstance(exception, ContractCallException):
-        log_message += ": " + repr(exception.orig_exception)
     rollbar.report_message(log_message, log_level_name, extra_data=extra_data)


### PR DESCRIPTION
- Adding `DistributeExcessIdleFailed` and `DecreasedPresentValuWhenAddingLiquidity` to ignored errors for pausing fuzz.
- No longer logging deploy info in fuzz testing (too much info in rollbar, can't find actual useful information)
- More accurate steth -> lido shares conversion when making trades.
- Fixing rollbar logging for status == 0 issues.
- Wrapping unit fuzz warnings in log level threshold check.