### PR TITLE
Allow passing of block identifiers (e.g., "pending") to interface functions.

### DIFF
--- a/src/agent0/chainsync/analysis/calc_position_value.py
+++ b/src/agent0/chainsync/analysis/calc_position_value.py
@@ -195,7 +195,7 @@ def calc_closeout_value(
 
     # Get the pool state at this position
     block_number = int(current_positions["block_number"].iloc[0])
-    hyperdrive_state = interface.get_hyperdrive_state(interface.get_block(block_number))
+    hyperdrive_state = interface.get_hyperdrive_state(block_number)
 
     # Prepare the checkpoint info dataframe for lookups based on checkpoint time
     checkpoint_share_prices = checkpoint_info.set_index("checkpoint_time")["checkpoint_vault_share_price"]

--- a/src/agent0/chainsync/db/hyperdrive/chain_to_db.py
+++ b/src/agent0/chainsync/db/hyperdrive/chain_to_db.py
@@ -82,7 +82,7 @@ def data_chain_to_db(interfaces: list[HyperdriveReadInterface], block_number: in
 
     for interface in interfaces:
         hyperdrive_address = interface.hyperdrive_address
-        pool_state = interface.get_hyperdrive_state(block)
+        pool_state = interface.get_hyperdrive_state(block_data=block)
 
         ## Query and add block_pool_info
         # Adding this last as pool info is what we use to determine if this block is in the db for analysis

--- a/src/agent0/core/hyperdrive/crash_report/crash_report.py
+++ b/src/agent0/core/hyperdrive/crash_report/crash_report.py
@@ -139,7 +139,7 @@ def build_crash_trade_result(
             query_block_id = trade_result.block_number
 
         try:
-            pool_state = interface.get_hyperdrive_state(interface.get_block(query_block_id))
+            pool_state = interface.get_hyperdrive_state(query_block_id)
         except Exception:  # pylint: disable=broad-except
             pass
 

--- a/src/agent0/core/hyperdrive/policies/simple_lp.py
+++ b/src/agent0/core/hyperdrive/policies/simple_lp.py
@@ -100,7 +100,7 @@ class SimpleLP(HyperdriveBasePolicy):
         """
         # Get the current state of the pool & the bot's position
         current_block = interface.get_current_block()
-        pool_state = interface.get_hyperdrive_state(current_block)
+        pool_state = interface.get_hyperdrive_state(block_data=current_block)
         lp_base_holding = wallet.lp_tokens * pool_state.pool_info.lp_share_price
 
         # Need to be in the game to play it

--- a/src/agent0/ethpy/hyperdrive/interface/_contract_calls.py
+++ b/src/agent0/ethpy/hyperdrive/interface/_contract_calls.py
@@ -21,7 +21,7 @@ from agent0.hypertypes import ERC20MintableContract, IHyperdriveContract, MockER
 if TYPE_CHECKING:
     from eth_account.signers.local import LocalAccount
     from eth_typing import BlockNumber
-    from web3.types import Nonce
+    from web3.types import BlockIdentifier, Nonce
 
     from agent0.ethpy.hyperdrive.event_types import (
         AddLiquidity,
@@ -43,37 +43,37 @@ if TYPE_CHECKING:
 
 
 def _get_total_supply_withdrawal_shares(
-    hyperdrive_contract: IHyperdriveContract, block_number: BlockNumber | None = None
+    hyperdrive_contract: IHyperdriveContract, block_identifier: BlockIdentifier | None = None
 ) -> FixedPoint:
     """See API for documentation."""
     asset_id = encode_asset_id(AssetIdPrefix.WITHDRAWAL_SHARE, 0)
     total_supply_withdrawal_shares = hyperdrive_contract.functions.balanceOf(
         asset_id, hyperdrive_contract.address
-    ).call(block_identifier=block_number or "latest")
+    ).call(block_identifier=block_identifier or "latest")
     return FixedPoint(scaled_value=int(total_supply_withdrawal_shares))
 
 
 def _get_variable_rate(
-    yield_contract: MockERC4626Contract | MockLidoContract, block_number: BlockNumber | None = None
+    yield_contract: MockERC4626Contract | MockLidoContract, block_identifier: BlockIdentifier | None = None
 ) -> FixedPoint:
     """See API for documentation."""
-    rate = yield_contract.functions.getRate().call(block_identifier=block_number or "latest")
+    rate = yield_contract.functions.getRate().call(block_identifier=block_identifier or "latest")
     return FixedPoint(scaled_value=rate)
 
 
 def _get_vault_shares(
     interface: HyperdriveReadInterface,
     hyperdrive_contract: IHyperdriveContract,
-    block_number: BlockNumber | None = None,
+    block_identifier: BlockIdentifier | None = None,
 ) -> FixedPoint:
     """See API for documentation."""
     if interface.vault_is_steth:
         vault_shares = interface.vault_shares_token_contract.functions.sharesOf(hyperdrive_contract.address).call(
-            block_identifier=block_number or "latest"
+            block_identifier=block_identifier or "latest"
         )
     else:
         vault_shares = interface.vault_shares_token_contract.functions.balanceOf(hyperdrive_contract.address).call(
-            block_identifier=block_number or "latest"
+            block_identifier=block_identifier or "latest"
         )
     return FixedPoint(scaled_value=vault_shares)
 
@@ -93,11 +93,11 @@ def _get_eth_base_balances(interface: HyperdriveReadInterface, agent: LocalAccou
 def _get_hyperdrive_base_balance(
     base_contract: ERC20MintableContract,
     hyperdrive_contract: IHyperdriveContract,
-    block_number: BlockNumber | None,
+    block_identifier: BlockIdentifier | None,
 ) -> FixedPoint:
     """See API for documentation."""
     base_balance = base_contract.functions.balanceOf(hyperdrive_contract.address).call(
-        block_identifier=block_number or "latest"
+        block_identifier=block_identifier or "latest"
     )
     return FixedPoint(scaled_value=base_balance)
 
@@ -115,13 +115,11 @@ def _get_hyperdrive_eth_balance(
 
 def _get_gov_fees_accrued(
     hyperdrive_contract: IHyperdriveContract,
-    block_number: BlockNumber | None,
+    block_identifier: BlockIdentifier | None,
 ) -> FixedPoint:
     """See API for documentation."""
-    if block_number is None:
+    if block_identifier is None:
         block_identifier = "latest"
-    else:
-        block_identifier = block_number
     gov_fees_accrued = hyperdrive_contract.functions.getUncollectedGovernanceFees().call(
         block_identifier=block_identifier
     )

--- a/src/agent0/ethpy/hyperdrive/interface/_contract_calls.py
+++ b/src/agent0/ethpy/hyperdrive/interface/_contract_calls.py
@@ -129,7 +129,6 @@ def _get_gov_fees_accrued(
 def _create_checkpoint(
     interface: HyperdriveReadWriteInterface,
     sender: LocalAccount,
-    block_number: BlockNumber | None = None,
     checkpoint_time: int | None = None,
     gas_limit: int | None = None,
     write_retry_count: int | None = None,
@@ -140,10 +139,7 @@ def _create_checkpoint(
         write_retry_count = interface.write_retry_count
 
     if checkpoint_time is None:
-        if block_number is None:
-            block_timestamp = interface.get_block_timestamp(interface.get_current_block())
-        else:
-            block_timestamp = interface.get_block_timestamp(interface.get_block(block_number))
+        block_timestamp = interface.get_block_timestamp(interface.get_current_block())
         checkpoint_time = interface.calc_checkpoint_id(interface.pool_config.checkpoint_duration, block_timestamp)
 
     # 0 is the max iterations for distribute excess idle, where it will default to

--- a/src/agent0/ethpy/hyperdrive/interface/read_interface.py
+++ b/src/agent0/ethpy/hyperdrive/interface/read_interface.py
@@ -404,7 +404,7 @@ class HyperdriveReadInterface:
         checkpoint_time: Timestamp
             The block timestamp that indexes the checkpoint to get.
         block_identifier: BlockIdentifier, optional
-            The number for any minted block.
+            The identifier for a block.
             If not given, the latest block is used.
 
         Returns
@@ -422,7 +422,7 @@ class HyperdriveReadInterface:
         Arguments
         ---------
         block_identifier: BlockIdentifier, optional
-            The number for any minted block.
+            The identifier for a block.
             If not given, the latest block number is used.
 
         Returns
@@ -440,7 +440,7 @@ class HyperdriveReadInterface:
         Arguments
         ---------
         block_identifier: BlockNumber, optional
-            The number for any minted block.
+            The identifier for a block.
             Defaults to the current block number.
 
         Returns
@@ -483,7 +483,7 @@ class HyperdriveReadInterface:
         Arguments
         ---------
         block_identifier : BlockIdentifier, optional
-            The number for any minted block.
+            The identifier for a block.
             Defaults to the current block number.
 
         Returns
@@ -565,7 +565,7 @@ class HyperdriveReadInterface:
         Arguments
         ---------
         block_identifier: BlockIdentifier, optional
-            The number for any minted block.
+            The identifier for a block.
             Defaults to the current block number.
 
         Returns
@@ -581,7 +581,7 @@ class HyperdriveReadInterface:
         Arguments
         ---------
         block_identifier: BlockIdentifier, optional
-            The number for any minted block.
+            The identifier for a block.
             Defaults to the current block number.
 
         Returns

--- a/src/agent0/ethpy/hyperdrive/interface/read_interface.py
+++ b/src/agent0/ethpy/hyperdrive/interface/read_interface.py
@@ -332,7 +332,7 @@ class HyperdriveReadInterface:
             The block identifier to get hyperdrive state on.
         block_data: BlockData, optional
             The block data to use to get hyperdrive state. This parameter is useful for reusing a
-            previously retrieved block data. Can't provide both block_identifier and block
+            previously retrieved block data. Can't provide both block_identifier and block_data
             at the same time.
 
         Returns

--- a/src/agent0/ethpy/hyperdrive/interface/read_interface.py
+++ b/src/agent0/ethpy/hyperdrive/interface/read_interface.py
@@ -256,7 +256,7 @@ class HyperdriveReadInterface:
         current_block = self.get_current_block()
         current_block_number = self.get_block_number(current_block)
         if current_block_number > self.last_state_block_number:
-            self._current_pool_state = self.get_hyperdrive_state(current_block)
+            self._current_pool_state = self.get_hyperdrive_state(block_data=current_block)
             self.last_state_block_number = current_block_number
             return True
         return False
@@ -321,14 +321,20 @@ class HyperdriveReadInterface:
         """
         return _get_block_time(block)
 
-    def get_hyperdrive_state(self, block: BlockData | None = None) -> PoolState:
+    def get_hyperdrive_state(
+        self, block_identifier: BlockIdentifier | None = None, block_data: BlockData | None = None
+    ) -> PoolState:
         """Use RPCs and contract calls to get the Hyperdrive pool and block state, given a block identifier.
 
         Arguments
         ---------
-        block: BlockData, optional
-            A web3py dataclass for storing block information.
-            Defaults to the latest block.
+        block_identifier: BlockIdentifier, optional
+            The block identifier to get hyperdrive state on.
+
+        block_data: BlockData, optional
+            The block data to use to get hyperdrive state. This parameter is useful for reusing a
+            previously retrieved block data. Can't provide both block_identifier and block
+            at the same time.
 
         Returns
         -------
@@ -336,17 +342,26 @@ class HyperdriveReadInterface:
             A dataclass containing PoolInfo, PoolConfig, Checkpoint, and Block
             information that is synced to a given block number.
         """
-        if block is None:
-            block_identifier = cast(BlockIdentifier, "latest")
-            block = self.get_block(block_identifier)
-        block_number = self.get_block_number(block)
-        pool_info = get_hyperdrive_pool_info(self.hyperdrive_contract, block_number)
-        checkpoint_time = self.calc_checkpoint_id(self.pool_config.checkpoint_duration, self.get_block_timestamp(block))
-        checkpoint = get_hyperdrive_checkpoint(self.hyperdrive_contract, checkpoint_time, block_number)
-        exposure = get_hyperdrive_checkpoint_exposure(self.hyperdrive_contract, checkpoint_time, block_number)
+
+        if block_identifier is not None and block_data is not None:
+            raise ValueError("Can't provide both block_identifier and block_data.")
+
+        if block_data is None:
+            if block_identifier is None:
+                block_identifier = cast(BlockIdentifier, "latest")
+            block_data = self.get_block(block_identifier)
+        else:
+            block_identifier = self.get_block_number(block_data)
+
+        pool_info = get_hyperdrive_pool_info(self.hyperdrive_contract, block_identifier)
+        checkpoint_time = self.calc_checkpoint_id(
+            self.pool_config.checkpoint_duration, self.get_block_timestamp(block_data)
+        )
+        checkpoint = get_hyperdrive_checkpoint(self.hyperdrive_contract, checkpoint_time, block_identifier)
+        exposure = get_hyperdrive_checkpoint_exposure(self.hyperdrive_contract, checkpoint_time, block_identifier)
 
         try:
-            variable_rate = self.get_variable_rate(block_number)
+            variable_rate = self.get_variable_rate(block_identifier)
         except BadFunctionCallOutput:
             logging.warning(
                 "Underlying yield contract has no `getRate` function, setting `state.variable_rate` as `None`."
@@ -359,13 +374,13 @@ class HyperdriveReadInterface:
             )
             variable_rate = None
 
-        vault_shares = self.get_vault_shares(block_number)
-        total_supply_withdrawal_shares = self.get_total_supply_withdrawal_shares(block_number)
-        hyperdrive_base_balance = self.get_hyperdrive_base_balance(block_number)
+        vault_shares = self.get_vault_shares(block_identifier)
+        total_supply_withdrawal_shares = self.get_total_supply_withdrawal_shares(block_identifier)
+        hyperdrive_base_balance = self.get_hyperdrive_base_balance(block_identifier)
         hyperdrive_eth_balance = self.get_hyperdrive_eth_balance()
-        gov_fees_accrued = self.get_gov_fees_accrued(block_number)
+        gov_fees_accrued = self.get_gov_fees_accrued(block_identifier)
         return PoolState(
-            block=block,
+            block=block_data,
             pool_config=self.pool_config,
             pool_info=pool_info,
             checkpoint_time=checkpoint_time,
@@ -379,32 +394,34 @@ class HyperdriveReadInterface:
             gov_fees_accrued=gov_fees_accrued,
         )
 
-    def get_checkpoint(self, checkpoint_time: Timestamp, block_number: BlockNumber | None = None) -> CheckpointFP:
+    def get_checkpoint(
+        self, checkpoint_time: Timestamp, block_identifier: BlockIdentifier | None = None
+    ) -> CheckpointFP:
         """Use an RPC to get the checkpoint info for the Hyperdrive contract for a given checkpoint_time index.
 
         Arguments
         ---------
         checkpoint_time: Timestamp
             The block timestamp that indexes the checkpoint to get.
-        block_number: BlockNumber, optional
+        block_identifier: BlockIdentifier, optional
             The number for any minted block.
-            If not given, the latest block number is used.
+            If not given, the latest block is used.
 
         Returns
         -------
         CheckpointFP
             The dataclass containing the checkpoint info in fixed point
         """
-        if block_number is None:
-            block_number = self.get_block_number(self.get_current_block())
-        return get_hyperdrive_checkpoint(self.hyperdrive_contract, checkpoint_time, block_number)
+        if block_identifier is None:
+            block_identifier = "latest"
+        return get_hyperdrive_checkpoint(self.hyperdrive_contract, checkpoint_time, block_identifier)
 
-    def get_total_supply_withdrawal_shares(self, block_number: BlockNumber | None) -> FixedPoint:
+    def get_total_supply_withdrawal_shares(self, block_identifier: BlockIdentifier | None) -> FixedPoint:
         """Use an RPC to get the total supply of withdrawal shares in the pool at the given block.
 
         Arguments
         ---------
-        block_number: BlockNumber, optional
+        block_identifier: BlockIdentifier, optional
             The number for any minted block.
             If not given, the latest block number is used.
 
@@ -413,16 +430,16 @@ class HyperdriveReadInterface:
         FixedPoint
             The quantity of withdrawal shares available in the Hyperdrive pool.
         """
-        if block_number is None:
-            block_number = self.get_block_number(self.get_current_block())
-        return _get_total_supply_withdrawal_shares(self.hyperdrive_contract, block_number)
+        if block_identifier is None:
+            block_identifier = "latest"
+        return _get_total_supply_withdrawal_shares(self.hyperdrive_contract, block_identifier)
 
-    def get_vault_shares(self, block_number: BlockNumber | None) -> FixedPoint:
+    def get_vault_shares(self, block_identifier: BlockIdentifier | None) -> FixedPoint:
         """Use an RPC to get the balance of shares that the Hyperdrive pool has in the underlying yield source.
 
         Arguments
         ---------
-        block_number: BlockNumber, optional
+        block_identifier: BlockNumber, optional
             The number for any minted block.
             Defaults to the current block number.
 
@@ -431,9 +448,9 @@ class HyperdriveReadInterface:
         FixedPoint
             The quantity of vault shares for the yield source at the provided block.
         """
-        if block_number is None:
-            block_number = self.get_block_number(self.get_current_block())
-        return _get_vault_shares(self, self.hyperdrive_contract, block_number)
+        if block_identifier is None:
+            block_identifier = "latest"
+        return _get_vault_shares(self, self.hyperdrive_contract, block_identifier)
 
     def get_idle_shares(self, pool_state: PoolState | None) -> FixedPoint:
         """Get the balance of idle shares that the Hyperdrive pool has.
@@ -457,7 +474,7 @@ class HyperdriveReadInterface:
         )
         return idle_shares
 
-    def get_variable_rate(self, block_number: BlockNumber | None = None) -> FixedPoint:
+    def get_variable_rate(self, block_identifier: BlockIdentifier | None = None) -> FixedPoint:
         """Use an RPC to get the yield source variable rate.
 
         .. note:: This function assumes there exists an underlying `getRate` function in the contract.
@@ -465,7 +482,7 @@ class HyperdriveReadInterface:
 
         Arguments
         ---------
-        block_number: BlockNumber, optional
+        block_identifier : BlockIdentifier, optional
             The number for any minted block.
             Defaults to the current block number.
 
@@ -474,9 +491,9 @@ class HyperdriveReadInterface:
         FixedPoint
             The variable rate for the yield source at the provided block.
         """
-        if block_number is None:
-            block_number = self.get_block_number(self.get_current_block())
-        return _get_variable_rate(self.vault_shares_token_contract, block_number)
+        if block_identifier is None:
+            block_identifier = "latest"
+        return _get_variable_rate(self.vault_shares_token_contract, block_identifier)
 
     def get_standardized_variable_rate(self, time_range: int = 604800) -> FixedPoint:
         """Get a standardized variable rate using vault share prices from checkpoints in the last `time_range` seconds.
@@ -542,12 +559,12 @@ class HyperdriveReadInterface:
         """
         return _get_hyperdrive_eth_balance(self, self.web3, self.hyperdrive_contract.address)
 
-    def get_hyperdrive_base_balance(self, block_number: BlockNumber | None = None) -> FixedPoint:
+    def get_hyperdrive_base_balance(self, block_identifier: BlockIdentifier | None = None) -> FixedPoint:
         """Get the current Hyperdrive balance in the base contract.
 
         Arguments
         ---------
-        block_number: BlockNumber, optional
+        block_identifier: BlockIdentifier, optional
             The number for any minted block.
             Defaults to the current block number.
 
@@ -556,14 +573,14 @@ class HyperdriveReadInterface:
         FixedPoint
             The result of base_token_contract.balanceOf(hyperdrive_address).
         """
-        return _get_hyperdrive_base_balance(self.base_token_contract, self.hyperdrive_contract, block_number)
+        return _get_hyperdrive_base_balance(self.base_token_contract, self.hyperdrive_contract, block_identifier)
 
-    def get_gov_fees_accrued(self, block_number: BlockNumber | None = None) -> FixedPoint:
+    def get_gov_fees_accrued(self, block_identifier: BlockIdentifier | None = None) -> FixedPoint:
         """Get the current amount of Uncollected Governance Fees in the Hyperdrive contract.
 
         Arguments
         ---------
-        block_number: BlockNumber, optional
+        block_identifier: BlockIdentifier, optional
             The number for any minted block.
             Defaults to the current block number.
 
@@ -572,7 +589,7 @@ class HyperdriveReadInterface:
         FixedPoint
             The result of hyperdrive_contract.functions.getUncollectedGovernanceFees
         """
-        return _get_gov_fees_accrued(self.hyperdrive_contract, block_number)
+        return _get_gov_fees_accrued(self.hyperdrive_contract, block_identifier)
 
     def get_transfer_single_events(
         self, from_block: BlockIdentifier | None = None, argument_filters: dict[str, Any] | None = None

--- a/src/agent0/ethpy/hyperdrive/interface/read_interface.py
+++ b/src/agent0/ethpy/hyperdrive/interface/read_interface.py
@@ -330,7 +330,6 @@ class HyperdriveReadInterface:
         ---------
         block_identifier: BlockIdentifier, optional
             The block identifier to get hyperdrive state on.
-
         block_data: BlockData, optional
             The block data to use to get hyperdrive state. This parameter is useful for reusing a
             previously retrieved block data. Can't provide both block_identifier and block

--- a/src/agent0/ethpy/hyperdrive/interface/read_write_interface.py
+++ b/src/agent0/ethpy/hyperdrive/interface/read_write_interface.py
@@ -19,7 +19,7 @@ from .read_interface import HyperdriveReadInterface
 
 if TYPE_CHECKING:
     from eth_account.signers.local import LocalAccount
-    from eth_typing import BlockNumber, ChecksumAddress
+    from eth_typing import ChecksumAddress
     from fixedpointmath import FixedPoint
     from web3 import Web3
     from web3.types import Nonce
@@ -103,7 +103,6 @@ class HyperdriveReadWriteInterface(HyperdriveReadInterface):
     def create_checkpoint(
         self,
         sender: LocalAccount,
-        block_number: BlockNumber | None = None,
         checkpoint_time: int | None = None,
         gas_limit: int | None = None,
         write_retry_count: int | None = None,
@@ -114,9 +113,6 @@ class HyperdriveReadWriteInterface(HyperdriveReadInterface):
         ---------
         sender: LocalAccount
             The sender account that is executing and signing the trade transaction.
-        block_number: BlockNumber, optional
-            The number for any minted block.
-            Defaults to the current block number.
         checkpoint_time: int, optional
             The checkpoint time to use. Defaults to the corresponding checkpoint for the provided block_number
         gas_limit: int | None, optional
@@ -132,7 +128,6 @@ class HyperdriveReadWriteInterface(HyperdriveReadInterface):
         return _create_checkpoint(
             interface=self,
             sender=sender,
-            block_number=block_number,
             checkpoint_time=checkpoint_time,
             gas_limit=gas_limit,
             write_retry_count=write_retry_count,

--- a/src/agent0/ethpy/hyperdrive/transactions.py
+++ b/src/agent0/ethpy/hyperdrive/transactions.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
-from eth_typing import BlockNumber
 from fixedpointmath import FixedPoint
 from web3 import Web3
-from web3.types import Timestamp, TxReceipt
+from web3.types import BlockIdentifier, Timestamp, TxReceipt
 
 from agent0.ethpy.base import get_transaction_logs
 from agent0.hypertypes import IHyperdriveContract
@@ -52,27 +51,27 @@ def get_hyperdrive_pool_config(hyperdrive_contract: IHyperdriveContract) -> Pool
     return pool_config_to_fixedpoint(cast(Any, pool_config))
 
 
-def get_hyperdrive_pool_info(hyperdrive_contract: IHyperdriveContract, block_number: BlockNumber) -> PoolInfoFP:
+def get_hyperdrive_pool_info(hyperdrive_contract: IHyperdriveContract, block_identifier: BlockIdentifier) -> PoolInfoFP:
     """Get the block pool info from the Hyperdrive contract.
 
     Arguments
     ---------
     hyperdrive_contract: Contract
         The contract to query the pool info from.
-    block_number: BlockNumber
-        The block number to query from the chain.
+    block_identifier: BlockIdentifier
+        The block identifier to query from the chain.
 
     Returns
     -------
     dict[str, Any]
         A dictionary containing the Hyperdrive pool info returned from the smart contract.
     """
-    pool_info = hyperdrive_contract.functions.getPoolInfo().call(None, block_number)
+    pool_info = hyperdrive_contract.functions.getPoolInfo().call(None, block_identifier)
     return pool_info_to_fixedpoint(pool_info)
 
 
 def get_hyperdrive_checkpoint(
-    hyperdrive_contract: IHyperdriveContract, checkpoint_time: Timestamp, block_number: BlockNumber
+    hyperdrive_contract: IHyperdriveContract, checkpoint_time: Timestamp, block_identifier: BlockIdentifier
 ) -> CheckpointFP:
     """Get the checkpoint info for the Hyperdrive contract at a given block.
 
@@ -82,7 +81,7 @@ def get_hyperdrive_checkpoint(
         The contract to query the pool info from.
     checkpoint_time: Timestamp
         The block timestamp that indexes the checkpoint to get.
-    block_number: BlockNumber
+    block_identifier: BlockIdentifier
         The block number to query from the chain.
 
     Returns
@@ -90,12 +89,12 @@ def get_hyperdrive_checkpoint(
     CheckpointFP
         The dataclass containing the checkpoint info in fixed point
     """
-    checkpoint = hyperdrive_contract.functions.getCheckpoint(checkpoint_time).call(None, block_number)
+    checkpoint = hyperdrive_contract.functions.getCheckpoint(checkpoint_time).call(None, block_identifier)
     return checkpoint_to_fixedpoint(checkpoint)
 
 
 def get_hyperdrive_checkpoint_exposure(
-    hyperdrive_contract: IHyperdriveContract, checkpoint_time: Timestamp, block_number: BlockNumber
+    hyperdrive_contract: IHyperdriveContract, checkpoint_time: Timestamp, block_identifier: BlockIdentifier
 ) -> FixedPoint:
     """Get the checkpoint exposure for the Hyperdrive contract at a given block.
 
@@ -106,7 +105,7 @@ def get_hyperdrive_checkpoint_exposure(
     checkpoint_time: Timestamp
         The block timestamp that indexes the checkpoint to get.
         This must be an exact checkpoint time for the deployed pool.
-    block_number: BlockNumber
+    block_identifier: BlockIdentifier
         The block number to query from the chain.
 
     Returns
@@ -114,7 +113,7 @@ def get_hyperdrive_checkpoint_exposure(
     CheckpointFP
         The dataclass containing the checkpoint info in fixed point.
     """
-    exposure = hyperdrive_contract.functions.getCheckpointExposure(checkpoint_time).call(None, block_number)
+    exposure = hyperdrive_contract.functions.getCheckpointExposure(checkpoint_time).call(None, block_identifier)
     return FixedPoint(scaled_value=exposure)
 
 

--- a/src/agent0/hyperfuzz/system_fuzz/invariant_checks.py
+++ b/src/agent0/hyperfuzz/system_fuzz/invariant_checks.py
@@ -74,7 +74,7 @@ def run_invariant_checks(
         rollbar_log_level_threshold = logging.DEBUG
 
     # Get the variables to check & check each invariant
-    pool_state = interface.get_hyperdrive_state(check_block_data)
+    pool_state = interface.get_hyperdrive_state(block_data=check_block_data)
 
     results: list[InvariantCheckResults]
     if lp_share_price_test is None:
@@ -399,7 +399,7 @@ def _check_lp_share_price(
 
     # This is known to fail when checking the first block, as block - 1 doesn't exist.
     try:
-        previous_pool_state = interface.get_hyperdrive_state(interface.get_block(block_number - 1))
+        previous_pool_state = interface.get_hyperdrive_state(block_number - 1)
     except BlockNotFound:
         # Not a failure
         return InvariantCheckResults(


### PR DESCRIPTION
Additionally allows `interface.get_hyperdrive_state()` to get a `block_identifier` instead of the block data. Still allows passing in of an explicit `block_data` parameter if the caller has this information.