### PR TITLE
Various fixes and features for rl bots training

### DIFF
--- a/src/agent0/core/hyperdrive/interactive/exec/__init__.py
+++ b/src/agent0/core/hyperdrive/interactive/exec/__init__.py
@@ -1,5 +1,10 @@
 """Helper functions for executing agent trades."""
 
 from .check_for_new_block import check_for_new_block
-from .execute_agent_trades import async_execute_agent_trades, async_execute_single_trade
+from .execute_agent_trades import (
+    async_execute_agent_trades,
+    async_execute_single_trade,
+    get_liquidation_trades,
+    get_trades,
+)
 from .set_max_approval import set_max_approval

--- a/src/agent0/core/hyperdrive/interactive/hyperdrive.py
+++ b/src/agent0/core/hyperdrive/interactive/hyperdrive.py
@@ -296,7 +296,6 @@ class Hyperdrive:
         return self.interface.hyperdrive_address
 
     def _sync_events(self) -> None:
-        # Remote hyperdrive stack syncs only the agent's wallet
         trade_events_to_db([self.interface], wallet_addr=None, db_session=self.chain.db_session)
         # We sync checkpoint events as well
         checkpoint_events_to_db([self.interface], db_session=self.chain.db_session)

--- a/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
@@ -154,7 +154,7 @@ class HyperdriveAgent:
 
     def _get_nonce_safe(self) -> Nonce:
         with self.nonce_lock:
-            # Since we're handing nonces here, we assume this wallet isn't making other trades
+            # Since we're handling nonces here, we assume this wallet isn't making other trades
             # so we always use the latest block
             chain_nonce = self.chain._web3.eth.get_transaction_count(self.address, "latest")
             if chain_nonce > self.current_nonce:

--- a/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
@@ -76,6 +76,7 @@ class HyperdriveAgent:
     """Interactive Hyperdrive Agent."""
 
     # pylint: disable=too-many-public-methods
+    # pylint: disable=too-many-instance-attributes
 
     ################
     # Initialization

--- a/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
@@ -128,13 +128,14 @@ class HyperdriveAgent:
         elif public_address is not None:
             self.address = Web3.to_checksum_address(public_address)
 
+        # If we don't set a name, we only set the object name as the abbreviated address.
+        # The pandas side will handle missing name to address mappings
         if name is None:
             self.name = abbreviate_address(self.address)
         else:
             self.name = name
-
-        # Register the username if it was provided
-        add_addr_to_username(self.name, [self.address], self.chain.db_session)
+            # Register the username if it was provided
+            add_addr_to_username(self.name, [self.address], self.chain.db_session)
 
     # Expose account and address for type narrowing in local agent
     @property

--- a/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
@@ -629,7 +629,7 @@ class HyperdriveAgent:
         if pool is None:
             pool = self._active_pool
         if pool is None:
-            raise ValueError("Executing policy action requires an active pool.")
+            raise ValueError("Getting policy action requires an active pool.")
 
         return get_trades(
             interface=pool.interface.get_read_interface(),
@@ -657,7 +657,7 @@ class HyperdriveAgent:
         if pool is None:
             pool = self._active_pool
         if pool is None:
-            raise ValueError("Executing policy action requires an active pool.")
+            raise ValueError("Getting liquidate actions requires an active pool.")
 
         # For type narrowing
         # rng should always be set in post_init

--- a/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
@@ -693,6 +693,12 @@ class HyperdriveAgent:
         if pool is None:
             raise ValueError("Executing actions requires an active pool.")
 
+        # We don't want to call `_get_nonce_safe()` if we don't do any actions,
+        # as this results in a skipped nonce value. Hence, we explicitly check for
+        # empty actions here and return early.
+        if len(actions) == 0:
+            return []
+
         trade_results: list[TradeResult] = asyncio.run(
             async_execute_agent_trades(
                 actions,

--- a/src/agent0/core/hyperdrive/interactive/local_chain.py
+++ b/src/agent0/core/hyperdrive/interactive/local_chain.py
@@ -314,7 +314,7 @@ class LocalChain(Chain):
         if (not create_checkpoints) or (len(self._deployed_hyperdrive_pools) == 0):
             self._advance_chain_time(time_delta)
             for pool in self._deployed_hyperdrive_pools:
-                pool._run_blocking_data_pipeline()  # pylint: disable=protected-access
+                pool._maybe_run_blocking_data_pipeline()  # pylint: disable=protected-access
         else:
             # For every pool, check the checkpoint duration and advance the chain for that amount of time,
             # followed by creating a checkpoint for that pool.
@@ -373,7 +373,7 @@ class LocalChain(Chain):
 
             curr_block = self._web3.eth.get_block_number()
             for pool in self._deployed_hyperdrive_pools:
-                pool._run_blocking_data_pipeline(curr_block)  # pylint: disable=protected-access
+                pool._maybe_run_blocking_data_pipeline(curr_block)  # pylint: disable=protected-access
 
         return out_dict
 

--- a/src/agent0/core/hyperdrive/interactive/local_chain.py
+++ b/src/agent0/core/hyperdrive/interactive/local_chain.py
@@ -571,6 +571,8 @@ class LocalChain(Chain):
                     if target_pool is None:
                         raise ValueError("Saved active pool not found in list of deployed pools.")
                     agent._active_pool = target_pool
+            # Reset the agent's nonce handler
+            agent._reset_nonce()
 
             agent._max_approval_pools = {}
 

--- a/src/agent0/core/hyperdrive/interactive/local_chain.py
+++ b/src/agent0/core/hyperdrive/interactive/local_chain.py
@@ -79,6 +79,14 @@ class LocalChain(Chain):
         The number of times to retry creating checkpoints when advancing time.
         Defaults to no retries.
         """
+        manual_database_sync: bool = False
+        """
+        If True, depends on the user to sync the database against the chain by calling
+        `pool.sync_database()`.
+        NOTE if this is `True`, the caller must call `pool.sync_database()` before any references
+        to getting the user's wallet, including any policy actions that require a wallet. Otherwise,
+        the wallet may be out of date. Use this at your own risk.
+        """
 
         crash_log_ticker: bool = False
         """Whether to log the trade ticker in crash reports. Defaults to False."""

--- a/src/agent0/core/hyperdrive/interactive/local_chain.py
+++ b/src/agent0/core/hyperdrive/interactive/local_chain.py
@@ -550,6 +550,9 @@ class LocalChain(Chain):
             if agent._active_pool is not None:
                 with open(active_pool_file, "wb") as file:
                     dill.dump(agent._active_pool.hyperdrive_address, file, protocol=dill.HIGHEST_PROTOCOL)
+            max_approval_file = save_dir / (agent.address + "-max-approval.pkl")
+            with open(max_approval_file, "wb") as file:
+                dill.dump(agent._max_approval_pools, file, protocol=dill.HIGHEST_PROTOCOL)
 
     def _load_agent_bookkeeping(self, load_dir: Path) -> None:
         policy_file = load_dir / "agents.pkl"
@@ -582,7 +585,10 @@ class LocalChain(Chain):
             # Reset the agent's nonce handler
             agent._reset_nonce()
 
-            agent._max_approval_pools = {}
+            # Keep track of which pools we set max approval for already
+            max_approval_file = load_dir / (agent.address + "-max-approval.pkl")
+            with open(max_approval_file, "rb") as file:
+                agent._max_approval_pools = dill.load(file)
 
     def _save_policy_state(self, save_dir: Path) -> None:
         for agent in self._chain_agents:

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
@@ -296,18 +296,29 @@ class LocalHyperdrive(Hyperdrive):
 
         if backfill_data_start_block is not None:
             logging.info("Backfilling data from block %s to %s", self._data_start_block, chain.block_number())
-            self._run_blocking_data_pipeline(progress_bar=True)
+            self.sync_database(progress_bar=True)
         else:
-            self._run_blocking_data_pipeline()
+            self.sync_database()
 
-    def _run_blocking_data_pipeline(self, start_block: int | None = None, progress_bar: bool = False) -> None:
-        # TODO these functions are not thread safe, need to fix if we expose async functions
-        # Runs the data pipeline synchronously
+    def sync_database(self, start_block: int | None = None, progress_bar: bool = False) -> None:
+        """Syncs the database with the chain.
 
-        # We call this function with a start block if we want to skip intermediate blocks.
-        # Subsequent calls after can again be `self._deploy_block_number` as long as the
-        # call with skipping blocks wrote a row, as the data pipeline checks the latest
-        # block entry and starts from there.
+        The database itself will determine how to append new data to ensure non-duplicated data.
+        We call this function with a start block if we want to skip intermediate blocks.
+        Subsequent calls after can again be `self._deploy_block_number` as long as the
+        call with skipping blocks wrote a row, as the data pipeline checks the latest
+        block entry and starts from there.
+
+        TODO these functions are not thread safe, need to fix if we expose async functions
+
+        Arguments
+        ---------
+        start_block: int | None, optional
+            The block number to start syncing from. Only used if we want to skip blocks in the database.
+            Defaults to ensuring all blocks are synced.
+        progress_bar: bool, optional
+            If True, will show a progress bar.
+        """
         if start_block is None:
             data_start_block = self._data_start_block
             analysis_start_block = self._analysis_start_block
@@ -331,6 +342,11 @@ class LocalHyperdrive(Hyperdrive):
             suppress_logs=True,
             calc_pnl=self.calc_pnl,
         )
+
+    def _run_blocking_data_pipeline(self, start_block: int | None = None, progress_bar: bool = False) -> None:
+        # Checks the chain config to see if manual sync is on. Noop if it is.
+        if not self.chain.config.manual_database_sync:
+            self.sync_database(start_block, progress_bar)
 
     # We overwrite these dunder methods to allow this object to be used as a dictionary key
     # This is used to allow chain's `advance_time` function to return this object as a key.

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
@@ -303,7 +303,8 @@ class LocalHyperdrive(Hyperdrive):
             self._maybe_run_blocking_data_pipeline()
 
     def sync_database(self, start_block: int | None = None, progress_bar: bool = False) -> None:
-        """Syncs the database with the chain.
+        """Explicitly syncs the database with the chain.
+        This function doesn't need to be explicitly called if `manual_database_sync = False`.
 
         The database itself will determine how to append new data to ensure non-duplicated data.
         We call this function with a start block if we want to skip intermediate blocks.

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive_agent.py
@@ -218,7 +218,7 @@ class LocalHyperdriveAgent(HyperdriveAgent):
         # If we explicitly set approval, we mark it as such.
         self._max_approval_pools[pool.hyperdrive_address] = True
         # Setting approval mines a block, so we update the data pipeline
-        pool._run_blocking_data_pipeline()  # pylint: disable=protected-access
+        pool._maybe_run_blocking_data_pipeline()  # pylint: disable=protected-access
 
     def open_long(self, base: FixedPoint, pool: Hyperdrive | None = None) -> OpenLong:
         """Opens a long for this agent.
@@ -242,7 +242,7 @@ class LocalHyperdriveAgent(HyperdriveAgent):
 
         self._ensure_approval_set(pool)
         out = super().open_long(base, pool)
-        pool._run_blocking_data_pipeline()  # pylint: disable=protected-access
+        pool._maybe_run_blocking_data_pipeline()  # pylint: disable=protected-access
         return out
 
     def close_long(self, maturity_time: int, bonds: FixedPoint, pool: Hyperdrive | None = None) -> CloseLong:
@@ -269,7 +269,7 @@ class LocalHyperdriveAgent(HyperdriveAgent):
 
         self._ensure_approval_set(pool)
         out = super().close_long(maturity_time, bonds, pool)
-        pool._run_blocking_data_pipeline()  # pylint: disable=protected-access
+        pool._maybe_run_blocking_data_pipeline()  # pylint: disable=protected-access
         return out
 
     def open_short(self, bonds: FixedPoint, pool: Hyperdrive | None = None) -> OpenShort:
@@ -294,7 +294,7 @@ class LocalHyperdriveAgent(HyperdriveAgent):
 
         self._ensure_approval_set(pool)
         out = super().open_short(bonds, pool)
-        pool._run_blocking_data_pipeline()  # pylint: disable=protected-access
+        pool._maybe_run_blocking_data_pipeline()  # pylint: disable=protected-access
         return out
 
     def close_short(self, maturity_time: int, bonds: FixedPoint, pool: Hyperdrive | None = None) -> CloseShort:
@@ -321,7 +321,7 @@ class LocalHyperdriveAgent(HyperdriveAgent):
 
         self._ensure_approval_set(pool)
         out = super().close_short(maturity_time, bonds, pool)
-        pool._run_blocking_data_pipeline()  # pylint: disable=protected-access
+        pool._maybe_run_blocking_data_pipeline()  # pylint: disable=protected-access
         return out
 
     def add_liquidity(self, base: FixedPoint, pool: Hyperdrive | None = None) -> AddLiquidity:
@@ -346,7 +346,7 @@ class LocalHyperdriveAgent(HyperdriveAgent):
 
         self._ensure_approval_set(pool)
         out = super().add_liquidity(base, pool)
-        pool._run_blocking_data_pipeline()  # pylint: disable=protected-access
+        pool._maybe_run_blocking_data_pipeline()  # pylint: disable=protected-access
         return out
 
     def remove_liquidity(self, shares: FixedPoint, pool: Hyperdrive | None = None) -> RemoveLiquidity:
@@ -371,7 +371,7 @@ class LocalHyperdriveAgent(HyperdriveAgent):
 
         self._ensure_approval_set(pool)
         out = super().remove_liquidity(shares, pool)
-        pool._run_blocking_data_pipeline()  # pylint: disable=protected-access
+        pool._maybe_run_blocking_data_pipeline()  # pylint: disable=protected-access
         return out
 
     def redeem_withdrawal_share(self, shares: FixedPoint, pool: Hyperdrive | None = None) -> RedeemWithdrawalShares:
@@ -396,7 +396,7 @@ class LocalHyperdriveAgent(HyperdriveAgent):
 
         self._ensure_approval_set(pool)
         out = super().redeem_withdrawal_share(shares, pool)
-        pool._run_blocking_data_pipeline()  # pylint: disable=protected-access
+        pool._maybe_run_blocking_data_pipeline()  # pylint: disable=protected-access
         return out
 
     def get_policy_action(self, pool: Hyperdrive | None = None) -> list[Trade[HyperdriveMarketAction]]:
@@ -460,7 +460,7 @@ class LocalHyperdriveAgent(HyperdriveAgent):
             raise ValueError("Executing action requires an active pool.")
         self._ensure_approval_set(pool)
         out = super().execute_action(actions, pool)
-        pool._run_blocking_data_pipeline()  # pylint: disable=protected-access
+        pool._maybe_run_blocking_data_pipeline()  # pylint: disable=protected-access
         return out
 
     # Helper functions for trades

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive_agent.py
@@ -105,7 +105,8 @@ class LocalHyperdriveAgent(HyperdriveAgent):
 
         # We keep track of pools this agent has been approved for
         # and call set max approval for any pools this agent has interacted with
-        self._max_approval_pools: dict[LocalHyperdrive, bool] = {}
+        # This is keyed by the hyperdrive address.
+        self._max_approval_pools: dict[str, bool] = {}
 
     def add_funds(
         self,
@@ -183,9 +184,8 @@ class LocalHyperdriveAgent(HyperdriveAgent):
 
     def _ensure_approval_set(self, pool: LocalHyperdrive) -> None:
         # Call set max approval for the pool if it hasn't been called yet.
-        if pool not in self._max_approval_pools:
+        if pool.hyperdrive_address not in self._max_approval_pools:
             self.set_max_approval(pool)
-            self._max_approval_pools[pool] = True
 
     def _ensure_pool_type(self, pool: Hyperdrive | None) -> LocalHyperdrive | None:
         # Explicit type checking
@@ -199,7 +199,7 @@ class LocalHyperdriveAgent(HyperdriveAgent):
             pool = self._active_pool
 
         return pool
-    
+
     def set_max_approval(self, pool: Hyperdrive | None = None) -> None:
         """Sets the max approval to the hyperdrive contract.
 
@@ -216,7 +216,7 @@ class LocalHyperdriveAgent(HyperdriveAgent):
             raise ValueError("Setting approval requires an active pool.")
         super().set_max_approval(pool)
         # If we explicitly set approval, we mark it as such.
-        self._max_approval_pools[pool] = True
+        self._max_approval_pools[pool.hyperdrive_address] = True
         # Setting approval mines a block, so we update the data pipeline
         pool._run_blocking_data_pipeline()  # pylint: disable=protected-access
 

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive_agent.py
@@ -199,6 +199,26 @@ class LocalHyperdriveAgent(HyperdriveAgent):
             pool = self._active_pool
 
         return pool
+    
+    def set_max_approval(self, pool: Hyperdrive | None = None) -> None:
+        """Sets the max approval to the hyperdrive contract.
+
+        .. warning:: This sets the max approval to the underlying hyperdrive contract for
+        this wallet. Do this at your own risk.
+
+        Arguments
+        ---------
+        pool: Hyperdrive | None, optional
+            The pool to interact with. Defaults to the active pool.
+        """
+        pool = self._ensure_pool_type(pool)
+        if pool is None:
+            raise ValueError("Setting approval requires an active pool.")
+        super().set_max_approval(pool)
+        # If we explicitly set approval, we mark it as such.
+        self._max_approval_pools[pool] = True
+        # Setting approval mines a block, so we update the data pipeline
+        pool._run_blocking_data_pipeline()  # pylint: disable=protected-access
 
     def open_long(self, base: FixedPoint, pool: Hyperdrive | None = None) -> OpenLong:
         """Opens a long for this agent.

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive_test.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive_test.py
@@ -1157,7 +1157,7 @@ def test_liquidate(fast_chain_fixture: LocalChain):
     alice.add_liquidity(base=FixedPoint(100))
     current_wallet = alice.get_positions()
     assert current_wallet.shape[0] == 3  # we have 3 open positions
-    alice.liquidate()
+    alice.execute_liquidate()
     current_wallet = alice.get_positions()
     assert current_wallet.shape[0] == 0  # we have 0 open position
 
@@ -1179,11 +1179,11 @@ def test_random_liquidate(fast_chain_fixture: LocalChain):
         alice.add_liquidity(base=FixedPoint(100))
         current_wallet = interactive_hyperdrive.get_positions()
         assert current_wallet.shape[0] == 4  # we have 4 open positions, including base
-        liquidate_events = alice.liquidate(randomize=True)
+        liquidate_events = alice.execute_liquidate(randomize=True)
         # We run liquidate here twice, as there's a chance the trades result in gaining withdrawal shares
         # TODO write loop within liquidate to call this multiple times
         # and also account for when no withdrawal shares are available to withdraw.
-        liquidate_events.extend(alice.liquidate(randomize=True))
+        liquidate_events.extend(alice.execute_liquidate(randomize=True))
         current_wallet = interactive_hyperdrive.get_positions()
         all_liquidate_events.append(liquidate_events)
         assert current_wallet.shape[0] == 1  # we have 1 open position, including base


### PR DESCRIPTION
This PR adds various changes to support rl bots training. Some of these changes helps take a step in allowing async trades in agent0, such that multiple transactions can be submitted on the same block.

# Breaking changes
- Renaming `agent.liquidate` to `agent.execute_liquidate`.

# Changes
- Splitting up getting an agent's actions (i.e., `get_policy_action` and `get_liquidate_action`) and executing an agent's actions (i.e., `execute_action`) into two separate steps, with `execute_policy_action` and `execute_liquidate` calling the two steps sequentially.
- Adding `manual_database_sync` to `LocalChain.Config` to allow for manual database syncing instead of syncing after every trade.
- Executing transactions (e.g., `agent.open_long`) no longer eagerly gets the wallet, and instead only gets wallet information if the trade crashes (the wallet was only being used for crash reporting).
- Only adds the addr -> username mapping to the database if we're not using the default username.
- Adds thread safe nonce handlers in the agent object.
- Don't set nonce for `build_transaction`, and set nonce after. This fixes an issue with requiring transactions to be built in order.