### PR TITLE
Remove variable rate from pool state and instead require an explicit call

### DIFF
--- a/src/agent0/chainsync/db/hyperdrive/chain_to_db.py
+++ b/src/agent0/chainsync/db/hyperdrive/chain_to_db.py
@@ -97,7 +97,7 @@ def data_chain_to_db(interfaces: list[HyperdriveReadInterface], block_number: in
         pool_info_dict["gov_fees_accrued"] = pool_state.gov_fees_accrued
         pool_info_dict["hyperdrive_base_balance"] = pool_state.hyperdrive_base_balance
         pool_info_dict["hyperdrive_eth_balance"] = pool_state.hyperdrive_eth_balance
-        pool_info_dict["variable_rate"] = pool_state.variable_rate
+        pool_info_dict["variable_rate"] = interface.get_variable_rate()
         pool_info_dict["vault_shares"] = pool_state.vault_shares
         pool_info_dict["spot_price"] = interface.calc_spot_price(pool_state)
         pool_info_dict["fixed_rate"] = interface.calc_spot_rate(pool_state)

--- a/src/agent0/core/hyperdrive/crash_report/crash_report.py
+++ b/src/agent0/core/hyperdrive/crash_report/crash_report.py
@@ -190,7 +190,7 @@ def build_crash_trade_result(
         trade_result.additional_info = {
             "spot_price": interface.calc_spot_price(pool_state),
             "fixed_rate": interface.calc_spot_rate(pool_state),
-            "variable_rate": pool_state.variable_rate,
+            "variable_rate": interface.get_variable_rate(),
             "vault_shares": pool_state.vault_shares,
         }
 

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive_test.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive_test.py
@@ -676,6 +676,7 @@ def test_bot_to_db(fast_hyperdrive_fixture: LocalHyperdrive, cycle_trade_policy:
         # Pool analysis keys
         "spot_price": fast_hyperdrive_fixture.interface.calc_spot_price(pool_state),
         "fixed_rate": fast_hyperdrive_fixture.interface.calc_spot_rate(pool_state),
+        "variable_rate": fast_hyperdrive_fixture.interface.get_variable_rate(),
     }
     # Ensure keys match
     # Converting to sets and compare

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive_test.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive_test.py
@@ -672,7 +672,6 @@ def test_bot_to_db(fast_hyperdrive_fixture: LocalHyperdrive, cycle_trade_policy:
         "gov_fees_accrued": pool_state.gov_fees_accrued,
         "hyperdrive_base_balance": pool_state.hyperdrive_base_balance,
         "hyperdrive_eth_balance": pool_state.hyperdrive_eth_balance,
-        "variable_rate": pool_state.variable_rate,
         "vault_shares": pool_state.vault_shares,
         # Pool analysis keys
         "spot_price": fast_hyperdrive_fixture.interface.calc_spot_price(pool_state),
@@ -1245,7 +1244,7 @@ def test_share_price_compounding_quincunx(fast_chain_fixture: LocalChain):
     )
     interactive_hyperdrive = LocalHyperdrive(fast_chain_fixture, interactive_config)
     hyperdrive_interface = interactive_hyperdrive.interface
-    logging.info(f"Variable rate: {hyperdrive_interface.current_pool_state.variable_rate}")
+    logging.info(f"Variable rate: {hyperdrive_interface.get_variable_rate()}")
     logging.info(f"Starting share price: {hyperdrive_interface.current_pool_state.pool_info.lp_share_price}")
     number_of_compounding_periods = 5
     for _ in range(number_of_compounding_periods):
@@ -1276,7 +1275,7 @@ def test_share_price_compounding_annus(fast_chain_fixture: LocalChain):
     interactive_hyperdrive = LocalHyperdrive(fast_chain_fixture, interactive_config)
     hyperdrive_interface = interactive_hyperdrive.interface
     beginning_share_price = hyperdrive_interface.current_pool_state.pool_info.lp_share_price
-    logging.info(f"Variable rate: {hyperdrive_interface.current_pool_state.variable_rate}")
+    logging.info(f"Variable rate: {hyperdrive_interface.get_variable_rate()}")
     logging.info(f"Starting share price: {beginning_share_price}")
     fast_chain_fixture.advance_time(YEAR_IN_SECONDS, create_checkpoints=False)
     ending_share_price = hyperdrive_interface.current_pool_state.pool_info.lp_share_price
@@ -1455,6 +1454,7 @@ def test_hyperdrive_read_interface_standardized_variable_rate(fast_chain_fixture
     hyperdrive_interface = interactive_hyperdrive.interface
 
     mock_variable_rate = hyperdrive_interface.get_variable_rate()
+    assert mock_variable_rate is not None
 
     # This should fail since pool was just deloyed
     with pytest.raises(ValueError):

--- a/src/agent0/core/hyperdrive/policies/lpandarb.py
+++ b/src/agent0/core/hyperdrive/policies/lpandarb.py
@@ -76,7 +76,7 @@ def arb_fixed_rate_down(
     """
     action_list = []
 
-    variable_rate = pool_state.variable_rate
+    variable_rate = interface.get_variable_rate()
     # Variable rate can be None if underlying yield doesn't have a `getRate` function
     if variable_rate is None:
         variable_rate = interface.get_standardized_variable_rate()
@@ -161,7 +161,7 @@ def arb_fixed_rate_up(
     """
     action_list = []
 
-    variable_rate = pool_state.variable_rate
+    variable_rate = interface.get_variable_rate()
     # Variable rate can be None if underlying yield doesn't have a `getRate` function
     if variable_rate is None:
         variable_rate = interface.get_standardized_variable_rate()
@@ -535,7 +535,7 @@ class LPandArb(HyperdriveBasePolicy):
             )
             max_trade_amount_base -= lp_amount
 
-        variable_rate = current_pool_state.variable_rate
+        variable_rate = interface.get_variable_rate()
         # Variable rate can be None if underlying yield doesn't have a `getRate` function
         if variable_rate is None:
             variable_rate = interface.get_standardized_variable_rate()

--- a/src/agent0/core/hyperdrive/policies/lpandarb_test.py
+++ b/src/agent0/core/hyperdrive/policies/lpandarb_test.py
@@ -131,7 +131,7 @@ def test_open_long(
 
     # report results
     fixed_rate = interactive_hyperdrive.interface.calc_spot_rate()
-    variable_rate = interactive_hyperdrive.interface.current_pool_state.variable_rate
+    variable_rate = interactive_hyperdrive.interface.get_variable_rate()
     assert variable_rate is not None
     logging.info("ending fixed rate is %s", fixed_rate)
     logging.info("variable rate is %s", variable_rate)
@@ -160,7 +160,7 @@ def test_open_short(
 
     # report results
     fixed_rate = interactive_hyperdrive.interface.calc_spot_rate()
-    variable_rate = interactive_hyperdrive.interface.current_pool_state.variable_rate
+    variable_rate = interactive_hyperdrive.interface.get_variable_rate()
     assert variable_rate is not None
     logging.info("ending fixed rate is %s", fixed_rate)
     logging.info("variable rate is %s", variable_rate)
@@ -263,7 +263,7 @@ def test_close_long(
 
     # report results
     fixed_rate = interactive_hyperdrive.interface.calc_spot_rate()
-    variable_rate = interactive_hyperdrive.interface.current_pool_state.variable_rate
+    variable_rate = interactive_hyperdrive.interface.get_variable_rate()
     logging.info("ending fixed rate is %s", fixed_rate)
     logging.info("variable rate is %s", variable_rate)
     assert variable_rate is not None
@@ -283,7 +283,7 @@ def test_already_at_target(interactive_hyperdrive: LocalHyperdrive, arbitrage_an
 
     # report results
     fixed_rate = interactive_hyperdrive.interface.calc_spot_rate()
-    variable_rate = interactive_hyperdrive.interface.current_pool_state.variable_rate
+    variable_rate = interactive_hyperdrive.interface.get_variable_rate()
     logging.info("ending fixed rate is %s", fixed_rate)
     logging.info("variable rate is %s", variable_rate)
     assert variable_rate is not None

--- a/src/agent0/core/hyperdrive/policies/smart_long.py
+++ b/src/agent0/core/hyperdrive/policies/smart_long.py
@@ -103,7 +103,7 @@ class SmartLong(HyperdriveBasePolicy):
         long_balances = [long.balance for long in wallet.longs.values()]
         has_opened_long = bool(any(long_balance > 0 for long_balance in long_balances))
 
-        variable_rate = pool_state.variable_rate
+        variable_rate = interface.get_variable_rate()
         # Variable rate can be None if underlying yield doesn't have a `getRate` function
         if variable_rate is None:
             variable_rate = interface.get_standardized_variable_rate()

--- a/src/agent0/core/hyperdrive/utilities/predict.py
+++ b/src/agent0/core/hyperdrive/utilities/predict.py
@@ -116,9 +116,11 @@ def predict_long(
             shares_needed /= FixedPoint(1) - price_discount * curve_fee
         else:
             shares_needed /= FixedPoint(1) - price_discount * curve_fee * governance_fee
-        share_price_on_next_block = share_price * (
-            FixedPoint(1) + hyperdrive_interface.get_variable_rate(pool_state.block_number) / FixedPoint(YEAR_IN_BLOCKS)
-        )
+        variable_rate = hyperdrive_interface.get_variable_rate(pool_state.block_number)
+        # Variable rate can be None if underlying yield doesn't have a `getRate` function
+        if variable_rate is None:
+            variable_rate = hyperdrive_interface.get_standardized_variable_rate()
+        share_price_on_next_block = share_price * (FixedPoint(1) + variable_rate / FixedPoint(YEAR_IN_BLOCKS))
         base_needed = shares_needed * share_price_on_next_block
     else:
         raise ValueError("Need to specify either bonds or base, but not both.")

--- a/src/agent0/core/hyperdrive/utilities/predict_trade_test.py
+++ b/src/agent0/core/hyperdrive/utilities/predict_trade_test.py
@@ -166,9 +166,9 @@ def test_predict_open_long_bonds(fast_chain_fixture: LocalChain):
     shares_needed = hyperdrive_interface.calc_shares_in_given_bonds_out_up(bonds_needed)
     shares_needed /= FixedPoint(1) - price_discount * curve_fee
     share_price = hyperdrive_interface.current_pool_state.pool_info.vault_share_price
-    share_price_on_next_block = share_price * (
-        FixedPoint(1) + hyperdrive_interface.get_variable_rate(pool_state.block_number) / FixedPoint(YEAR_IN_BLOCKS)
-    )
+    variable_rate = hyperdrive_interface.get_variable_rate(pool_state.block_number)
+    assert variable_rate is not None
+    share_price_on_next_block = share_price * (FixedPoint(1) + variable_rate / FixedPoint(YEAR_IN_BLOCKS))
     base_needed = shares_needed * share_price_on_next_block
     # use rust to predict trade outcome
     delta = predict_long(hyperdrive_interface=hyperdrive_interface, bonds=bonds_needed)

--- a/src/agent0/ethpy/hyperdrive/interface/read_interface.py
+++ b/src/agent0/ethpy/hyperdrive/interface/read_interface.py
@@ -422,20 +422,6 @@ class HyperdriveReadInterface:
         checkpoint = get_hyperdrive_checkpoint(self.hyperdrive_contract, checkpoint_time, block_identifier)
         exposure = get_hyperdrive_checkpoint_exposure(self.hyperdrive_contract, checkpoint_time, block_identifier)
 
-        try:
-            variable_rate = self.get_variable_rate(block_identifier)
-        except (BadFunctionCallOutput, ValueError):
-            logging.warning(
-                "Underlying yield contract has no `getRate` function, setting `state.variable_rate` as `None`."
-            )
-            variable_rate = None
-        # Some contracts throw a logic error
-        except ContractLogicError:
-            logging.warning(
-                "Underlying yield contract reverted `getRate` function, setting `state.variable_rate` as `None`."
-            )
-            variable_rate = None
-
         vault_shares = self.get_vault_shares(block_identifier)
         total_supply_withdrawal_shares = self.get_total_supply_withdrawal_shares(block_identifier)
         hyperdrive_base_balance = self.get_hyperdrive_base_balance(block_identifier)
@@ -448,7 +434,6 @@ class HyperdriveReadInterface:
             checkpoint_time=checkpoint_time,
             checkpoint=checkpoint,
             exposure=exposure,
-            variable_rate=variable_rate,
             vault_shares=vault_shares,
             total_supply_withdrawal_shares=total_supply_withdrawal_shares,
             hyperdrive_base_balance=hyperdrive_base_balance,

--- a/src/agent0/ethpy/hyperdrive/interface/read_interface.py
+++ b/src/agent0/ethpy/hyperdrive/interface/read_interface.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Any, cast
 import eth_abi
 from fixedpointmath import FixedPoint
 from web3 import Web3
-from web3.exceptions import BadFunctionCallOutput, ContractLogicError
 from web3.types import BlockData, BlockIdentifier, Timestamp
 
 from agent0.ethpy.base import ETH_CONTRACT_ADDRESS, initialize_web3_with_http_provider
@@ -521,11 +520,12 @@ class HyperdriveReadInterface:
         )
         return idle_shares
 
-    def get_variable_rate(self, block_identifier: BlockIdentifier | None = None) -> FixedPoint:
+    def get_variable_rate(self, block_identifier: BlockIdentifier | None = None) -> FixedPoint | None:
         """Use an RPC to get the yield source variable rate.
 
         .. note:: This function assumes there exists an underlying `getRate` function in the contract.
-        This call will fail if the deployed yield contract doesn't have a `getRate` function.
+        This call will return None if the deployed yield contract doesn't have a `getRate` function.
+        In this case, use `get_standardized_variable_rate` instead.
 
         Arguments
         ---------
@@ -535,8 +535,9 @@ class HyperdriveReadInterface:
 
         Returns
         -------
-        FixedPoint
-            The variable rate for the yield source at the provided block.
+        FixedPoint | None
+            The variable rate for the yield source at the provided block, or None if the yield source doesn't
+            have a `getRate` function.
         """
         if block_identifier is None:
             block_identifier = "latest"

--- a/src/agent0/ethpy/hyperdrive/interface/read_interface_test.py
+++ b/src/agent0/ethpy/hyperdrive/interface/read_interface_test.py
@@ -151,12 +151,13 @@ class TestHyperdriveReadInterface:
         """
         # State
         _ = hyperdrive_read_interface_fixture.current_pool_state
-        _ = hyperdrive_read_interface_fixture.current_pool_state.variable_rate
         _ = hyperdrive_read_interface_fixture.current_pool_state.vault_shares
         _ = hyperdrive_read_interface_fixture.calc_bonds_given_shares_and_rate(FixedPoint(0.05))
         _ = hyperdrive_read_interface_fixture.calc_checkpoint_timestamp(int(datetime.now().timestamp()))
         _ = hyperdrive_read_interface_fixture.calc_idle_share_reserves_in_base()
         _ = hyperdrive_read_interface_fixture.calc_solvency()
+
+        _ = hyperdrive_read_interface_fixture.get_variable_rate()
 
         spot_price = hyperdrive_read_interface_fixture.calc_spot_price()
         max_spot_price = hyperdrive_read_interface_fixture.calc_max_spot_price()

--- a/src/agent0/ethpy/hyperdrive/interface/read_write_interface_test.py
+++ b/src/agent0/ethpy/hyperdrive/interface/read_write_interface_test.py
@@ -27,6 +27,7 @@ class TestHyperdriveReadWriteInterface:
 
     def test_set_variable_rate(self, hyperdrive_read_write_interface_fixture: HyperdriveReadWriteInterface):
         variable_rate = hyperdrive_read_write_interface_fixture.get_variable_rate()
+        assert variable_rate is not None
         new_rate = variable_rate * FixedPoint("0.1")
         # TODO: Setup a fixture to create a funded local account
         extra_key_bytes = text_if_str(to_bytes, "extra_entropy")

--- a/src/agent0/ethpy/hyperdrive/state/pool_state.py
+++ b/src/agent0/ethpy/hyperdrive/state/pool_state.py
@@ -29,9 +29,6 @@ class PoolState:
     checkpoint_time: int
     checkpoint: CheckpointFP
     exposure: FixedPoint
-    # TODO we may want to remove this from pool state and have users explicitly
-    # retrieve variable rate via a function
-    variable_rate: FixedPoint | None
     vault_shares: FixedPoint
     total_supply_withdrawal_shares: FixedPoint
     hyperdrive_base_balance: FixedPoint


### PR DESCRIPTION
Previously, we would always attempt to get the variable rate when getting pool state. Since the underlying getter is assuming mock yield sources, the `getRate` call would likely fail on mainnet or testnet, which would pollute error logs in alchemy. This PR makes getting variable rate from the yield source an explicit call, and not tied to getting the pool state.