### PR TITLE
Wrap getting anvil state dump in a chain config flag, defaulting to False

### DIFF
--- a/scripts/invariant_checks.py
+++ b/scripts/invariant_checks.py
@@ -137,6 +137,7 @@ def main(argv: Sequence[str] | None = None) -> None:
                     rollbar_log_level_threshold=chain.config.rollbar_log_level_threshold,
                     rollbar_log_filter_func=invariance_ignore_func,
                     pool_name=hyperdrive_obj.name,
+                    log_anvil_state_dump=chain.config.log_anvil_state_dump,
                 )
                 for hyperdrive_obj in deployed_pools
             ]

--- a/src/agent0/core/hyperdrive/interactive/chain.py
+++ b/src/agent0/core/hyperdrive/interactive/chain.py
@@ -97,6 +97,8 @@ class Chain:
         If False, the policy `post_action` function will only be called after `execute_policy_action`.
         Defaults to False.
         """
+        log_anvil_state_dump: bool = False
+        """Whether to log the anvil state dump in crash reports. Defaults to False."""
 
         # Data pipeline parameters
         calc_pnl: bool = True

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive_agent.py
@@ -485,7 +485,8 @@ class LocalHyperdriveAgent(HyperdriveAgent):
             # TODO we likely want to explicitly check for slippage here and not
             # get anvil state dump if it's a slippage error and the user wants to
             # ignore slippage errors
-            trade_result.anvil_state = get_anvil_state_dump(self.chain._web3)  # pylint: disable=protected-access
+            if self.chain.config.log_anvil_state_dump:
+                trade_result.anvil_state = get_anvil_state_dump(self.chain._web3)  # pylint: disable=protected-access
             if self.chain.config.crash_log_ticker:
                 if trade_result.additional_info is None:
                     trade_result.additional_info = {"trade_events": self.get_trade_events()}

--- a/src/agent0/hyperfuzz/system_fuzz/invariant_checks.py
+++ b/src/agent0/hyperfuzz/system_fuzz/invariant_checks.py
@@ -33,6 +33,7 @@ def run_invariant_checks(
     pool_name: str | None = None,
     lp_share_price_test: bool | None = None,
     crash_report_additional_info: dict[str, Any] | None = None,
+    log_anvil_state_dump: bool = False,
 ) -> list[FuzzAssertionException]:
     """Run the invariant checks.
 
@@ -69,6 +70,8 @@ def run_invariant_checks(
         If None (default), runs all tests.
     crash_report_additional_info: dict[str, Any] | None
         Additional information to include in the crash report.
+    log_anvil_state_dump: bool
+        If True, log anvil state dump on crash.
 
     Returns
     -------
@@ -156,7 +159,8 @@ def run_invariant_checks(
         error = FuzzAssertionException(*exception_message, exception_data=exception_data)
         out_exceptions.append(error)
         report = build_crash_trade_result(error, interface, additional_info=error.exception_data, pool_state=pool_state)
-        report.anvil_state = get_anvil_state_dump(interface.web3)
+        if log_anvil_state_dump:
+            report.anvil_state = get_anvil_state_dump(interface.web3)
         rollbar_data = error.exception_data
 
         if pool_name is not None:

--- a/src/agent0/hyperfuzz/system_fuzz/run_fuzz_bots.py
+++ b/src/agent0/hyperfuzz/system_fuzz/run_fuzz_bots.py
@@ -306,6 +306,7 @@ def run_fuzz_bots(
                     rollbar_log_filter_func=chain.config.rollbar_log_filter_func,
                     lp_share_price_test=lp_share_price_test,
                     crash_report_additional_info=hyperdrive_pool._crash_report_additional_info,
+                    log_anvil_state_dump=chain.config.log_anvil_state_dump,
                 )
                 if len(fuzz_exceptions) > 0 and raise_error_on_failed_invariance_checks:
                     # If we have an ignore function, we filter exceptions


### PR DESCRIPTION
We don't use anvil state dumps for crash debugging anymore, due to complexities around loading state from a state dump. Additionally, known failures on testnet attempt to get anvil state dump, which pollutes alchemy error loggings.