### PR TITLE
Run invariant checks after every bot trade

### DIFF
--- a/scripts/invariant_checks.py
+++ b/scripts/invariant_checks.py
@@ -141,7 +141,6 @@ def main(argv: Sequence[str] | None = None) -> None:
                     run_invariant_checks,
                     check_block_data=check_block_data,
                     interface=hyperdrive_obj.interface,
-                    simulation_mode=False,
                     log_to_rollbar=log_to_rollbar,
                     rollbar_log_level_threshold=chain.config.rollbar_log_level_threshold,
                     rollbar_log_filter_func=invariance_ignore_func,

--- a/src/agent0/hyperfuzz/system_fuzz/run_fuzz_bots.py
+++ b/src/agent0/hyperfuzz/system_fuzz/run_fuzz_bots.py
@@ -322,7 +322,6 @@ def run_fuzz_bots(
                     fuzz_exceptions = run_invariant_checks(
                         check_block_data=latest_block,
                         interface=pool.interface,
-                        simulation_mode=True,
                         log_to_rollbar=log_to_rollbar,
                         rollbar_log_level_threshold=chain.config.rollbar_log_level_threshold,
                         rollbar_log_filter_func=chain.config.rollbar_log_filter_func,

--- a/src/agent0/hyperfuzz/system_fuzz/run_fuzz_bots.py
+++ b/src/agent0/hyperfuzz/system_fuzz/run_fuzz_bots.py
@@ -299,6 +299,7 @@ def run_fuzz_bots(
                     pending_pool_state = pool.interface.get_hyperdrive_state("pending")
 
                 # Execute trades
+                agent_trade = []
                 try:
                     agent_trade = agent.execute_policy_action(pool=pool)
                 except Exception as exc:  # pylint: disable=broad-exception-caught


### PR DESCRIPTION
This fixes fuzz testing to only run invariance tests after trades have been made. This also adds an optional `pending_pool_state` to be passed into invariance tests for local fuzz testing.