### PR TITLE
Dashboard updates

### DIFF
--- a/src/agent0/chainsync/dashboard/build_dashboard_dfs.py
+++ b/src/agent0/chainsync/dashboard/build_dashboard_dfs.py
@@ -205,10 +205,10 @@ def build_wallet_dashboard(
     # Split up into open and closed positions
     out_dfs["open_positions"] = (
         current_positions[current_positions["Token Balance"] != 0].reset_index(drop=True).astype(str)
-    )
+    ).astype(str)
     out_dfs["closed_positions"] = (
         current_positions[current_positions["Token Balance"] == 0].reset_index(drop=True).astype(str)
-    )
+    ).astype(str)
 
     pnl_over_time = get_total_pnl_over_time(
         session, wallet_address=wallet_addresses, start_block=-max_plot_blocks, coerce_float=True

--- a/src/agent0/chainsync/dashboard/build_ticker.py
+++ b/src/agent0/chainsync/dashboard/build_ticker.py
@@ -48,7 +48,7 @@ def build_ticker_for_pool_page(
 
     # Shorten wallet address string
     trade_events["Wallet"] = mapped_addrs["abbr_address"]
-    return trade_events
+    return trade_events.astype(str)
 
 
 def build_ticker_for_wallet_page(
@@ -112,4 +112,4 @@ def build_ticker_for_wallet_page(
     trade_events["Hyperdrive Address"] = abbreviate_address(trade_events["Hyperdrive Address"])
 
     # Sort latest first
-    return trade_events
+    return trade_events.astype(str)

--- a/src/agent0/core/hyperdrive/interactive/local_chain.py
+++ b/src/agent0/core/hyperdrive/interactive/local_chain.py
@@ -48,10 +48,10 @@ class LocalChain(Chain):
     class Config(Chain.Config):
         """The configuration for the local chain object."""
 
-        anvil_verbose: bool = False
-        """If True, will print underlying anvil output to stdout. Defaults to suppressing output."""
-        dashboard_port: int = 7777
-        """The URL port for the deployed dashboard."""
+        verbose: bool = False
+        """If True, will print underlying subprocess output to stdout. Defaults to suppressing output."""
+        dashboard_port: int | None = None
+        """The URL port for the deployed dashboard. Defaults to finding an open port."""
         block_time: int | None = None
         """If None, mines per transaction. Otherwise mines every `block_time` seconds."""
         block_timestamp_interval: int | None = 12
@@ -145,7 +145,7 @@ class LocalChain(Chain):
                 anvil_launch_args.extend(["--fork-block-number", str(fork_block_number)])
 
         # This process never stops, so we run this in the background and explicitly clean up later
-        if config.anvil_verbose:
+        if config.verbose:
             self.anvil_process = subprocess.Popen(  # pylint: disable=consider-using-with
                 anvil_launch_args,
                 close_fds=True,
@@ -806,24 +806,36 @@ class LocalChain(Chain):
             If False, will clean up subprocess in cleanup.
         """
 
-        dashboard_run_command = self._get_dashboard_run_command(
-            flags=[
-                "--server.port",
-                str(self.config.dashboard_port),
-                "--server.address",
-                "localhost",
-            ]
-        )
+        streamlit_cli_flags = [
+            "--server.address",
+            "localhost",
+        ]
+        if self.config.dashboard_port is not None:
+            streamlit_cli_flags.extend(
+                [
+                    "--server.port",
+                    str(self.config.dashboard_port),
+                ]
+            )
+
+        dashboard_run_command = self._get_dashboard_run_command(flags=streamlit_cli_flags)
         env = {key: str(val) for key, val in asdict(self.postgres_config).items()}
 
         assert self.dashboard_subprocess is None
         # Since dashboard is a non-terminating process, we need to manually control its lifecycle
-        self.dashboard_subprocess = subprocess.Popen(  # pylint: disable=consider-using-with
-            dashboard_run_command,
-            env=env,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.STDOUT,
-        )
+
+        if self.config.verbose:
+            self.dashboard_subprocess = subprocess.Popen(  # pylint: disable=consider-using-with
+                dashboard_run_command,
+                env=env,
+            )
+        else:
+            self.dashboard_subprocess = subprocess.Popen(  # pylint: disable=consider-using-with
+                dashboard_run_command,
+                env=env,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.STDOUT,
+            )
         if blocking:
             input("Press any key to kill dashboard server.")
             self.dashboard_subprocess.kill()


### PR DESCRIPTION
- Dataframes views in dashboard gets converted to strings to avoid warning when viewing small numbers.
- Dashboard defaults to finding an open port by default.
- Chain config `anvil_verbose` changed to `verbose`, and also controls dashboard subprocess output.