### PR TITLE
Fix event decoder

### DIFF
--- a/src/agent0/ethpy/hyperdrive/deploy.py
+++ b/src/agent0/ethpy/hyperdrive/deploy.py
@@ -775,8 +775,8 @@ def _deploy_and_initialize_hyperdrive_pool(
     logs = get_transaction_logs(factory_contract, tx_receipt)
     hyperdrive_address: str | None = None
     for log in logs:
-        if log["event"] == "GovernanceUpdated":
-            hyperdrive_address = log["address"]
+        if log["event"] == "Deployed":
+            hyperdrive_address = log["args"]["hyperdrive"]
     if hyperdrive_address is None:
         raise AssertionError("Generating hyperdrive contract didn't return address")
     return hyperdrive_address


### PR DESCRIPTION
Event decoder in agent0 wasn't working for nested event types. This PR allows the event decoder to properly decode nested types to look for topic hashes.