### PR TITLE
Fix hanging CI

### DIFF
--- a/src/agent0/hyperfuzz/system_fuzz/invariant_checks.py
+++ b/src/agent0/hyperfuzz/system_fuzz/invariant_checks.py
@@ -526,7 +526,7 @@ def _check_lp_share_price(
     loop_counter = 0
     while True:
         if loop_counter > 24:
-            logging.warning("Check block number has not been mined in a reasonable amount of time")
+            raise AssertionError("Check block number has not been mined in a reasonable amount of time")
         curr_block = interface.get_block_number(interface.get_current_block())
         if curr_block < check_block_number:
             loop_counter += 1

--- a/src/agent0/hyperfuzz/system_fuzz/run_fuzz_bots.py
+++ b/src/agent0/hyperfuzz/system_fuzz/run_fuzz_bots.py
@@ -327,8 +327,11 @@ def run_fuzz_bots(
 
                 trades.append(agent_trade)
 
-                # Check invariance on every iteration
-                if check_invariance:
+                # Check invariance on every iteration if we're not doing lp_share_price_test.
+                # Only check invariance if a trade was executed for lp_share_price_test.
+                # This is because the lp_share_price_test requires a trade to be executed
+                # in order to mine a block, as it waits for the pending block to be mined.
+                if check_invariance and (not lp_share_price_test or (lp_share_price_test and len(agent_trade) > 0)):
                     latest_block = pool.interface.get_block("latest")
                     latest_block_number = latest_block.get("number", None)
                     if latest_block_number is None:


### PR DESCRIPTION
This PR fixes forever hanging CI when running `local_fuzz_bots_test`. The issue is around `lp_share_price_test`, which hangs forever if the iteration of fuzz bots doesn't execute a trade.