### PR TITLE
Adding accrue interest logic for ezeth

### DIFF
--- a/scripts/fork_fuzz_bots.py
+++ b/scripts/fork_fuzz_bots.py
@@ -247,9 +247,6 @@ def main(argv: Sequence[str] | None = None) -> None:
 
         # Get list of deployed pools on initial iteration
         deployed_pools = LocalHyperdrive.get_hyperdrive_pools_from_registry(chain, registry_address)
-        # FIXME
-
-        deployed_pools = [p for p in deployed_pools if "ezETH" in p.name]
 
         log_message = f"Running fuzzing on pools {[p.name for p in deployed_pools]}..."
         logging.info(log_message)
@@ -287,8 +284,6 @@ def main(argv: Sequence[str] | None = None) -> None:
                 rollbar_log_prefix="Fork FuzzBot: Unexpected error", exception=e, log_level=logging.ERROR
             )
             if parsed_args.pause_on_invariance_fail:
-                # FIXME
-                raise e
                 logging.error(
                     "Pausing pool (chain:%s port:%s) on crash %s",
                     chain.name,

--- a/scripts/fork_fuzz_bots.py
+++ b/scripts/fork_fuzz_bots.py
@@ -17,6 +17,7 @@ from web3.exceptions import ContractCustomError
 
 from agent0 import LocalChain, LocalHyperdrive
 from agent0.hyperfuzz import FuzzAssertionException
+from agent0.hyperfuzz.fork_fuzz import accrue_interest_fork
 from agent0.hyperfuzz.system_fuzz import run_fuzz_bots
 from agent0.hyperlogs.rollbar_utilities import initialize_rollbar, log_rollbar_exception, log_rollbar_message
 
@@ -279,6 +280,7 @@ def main(argv: Sequence[str] | None = None) -> None:
                 base_budget_per_bot=FixedPoint(1_000),
                 whale_accounts=whale_accounts,
                 num_iterations=parsed_args.num_iterations_per_episode,
+                accrue_interest_func=accrue_interest_fork,
             )
         except Exception as e:  # pylint: disable=broad-except
             log_rollbar_exception(

--- a/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
+++ b/src/agent0/core/hyperdrive/interactive/hyperdrive_agent.py
@@ -53,7 +53,7 @@ from agent0.core.hyperdrive.agent import (
 from agent0.core.hyperdrive.agent.hyperdrive_wallet import Long, Short
 from agent0.core.hyperdrive.crash_report import log_hyperdrive_crash_report
 from agent0.core.hyperdrive.policies import HyperdriveBasePolicy
-from agent0.ethpy.base import get_account_balance, set_anvil_account_balance
+from agent0.ethpy.base import get_account_balance, set_account_balance
 
 from .exec import async_execute_agent_trades, async_execute_single_trade, get_liquidation_trades, get_trades
 
@@ -244,7 +244,7 @@ class HyperdriveAgent:
             # Eth is a set balance call
             eth_balance = self.get_eth()
             new_eth_balance = eth_balance + eth
-            _ = set_anvil_account_balance(self.chain._web3, self.account.address, new_eth_balance.scaled_value)
+            _ = set_account_balance(self.chain._web3, self.account.address, new_eth_balance.scaled_value)
 
         if base > FixedPoint(0):
             if pool is None:
@@ -287,7 +287,7 @@ class HyperdriveAgent:
                     raise KeyError("Response did not have a result.")
 
                 # Give eth to the whale account for gas
-                _ = set_anvil_account_balance(self.chain._web3, whale_account_addr, FixedPoint(10).scaled_value)
+                _ = set_account_balance(self.chain._web3, whale_account_addr, FixedPoint(10).scaled_value)
 
                 # Transfer base from whale to account
                 base_token_contract.functions.transfer(self.account.address, base_scaled_value).transact(

--- a/src/agent0/ethpy/base/__init__.py
+++ b/src/agent0/ethpy/base/__init__.py
@@ -1,6 +1,6 @@
 """Base utilities for working with contracts via web3"""
 
-from .rpc_interface import get_account_balance, set_anvil_account_balance
+from .rpc_interface import get_account_balance, set_account_balance
 from .transactions import async_wait_for_transaction_receipt
 from .web3_setup import initialize_web3_with_http_provider
 

--- a/src/agent0/ethpy/base/rpc_interface.py
+++ b/src/agent0/ethpy/base/rpc_interface.py
@@ -6,7 +6,7 @@ from web3 import Web3
 from web3.types import RPCEndpoint, RPCResponse
 
 
-def set_anvil_account_balance(web3: Web3, account_address: str, amount_wei: int) -> RPCResponse:
+def set_account_balance(web3: Web3, account_address: str, amount_wei: int) -> RPCResponse:
     """Set the eth balance of the the account using the web3 provider.
 
     Arguments

--- a/src/agent0/ethpy/hyperdrive/deploy.py
+++ b/src/agent0/ethpy/hyperdrive/deploy.py
@@ -40,7 +40,7 @@ from web3.contract.contract import Contract
 from web3.logs import DISCARD
 from web3.types import TxParams, Wei
 
-from agent0.ethpy.base import ETH_CONTRACT_ADDRESS, get_account_balance, set_anvil_account_balance
+from agent0.ethpy.base import ETH_CONTRACT_ADDRESS, get_account_balance, set_account_balance
 
 # Deploying a Hyperdrive pool requires a long sequence of contract and RPCs,
 # resulting in long functions with many parameter arguments.
@@ -545,7 +545,7 @@ def _mint_and_approve(
         # No need to approve, but we still need to ensure there's enough eth to fund
         eth_balance = FixedPoint(scaled_value=get_account_balance(web3, funding_account.address))
         new_eth_balance = eth_balance + mint_amount
-        _ = set_anvil_account_balance(web3, funding_account.address, new_eth_balance.scaled_value)
+        _ = set_account_balance(web3, funding_account.address, new_eth_balance.scaled_value)
 
     else:
         assert isinstance(funding_contract, ERC20MintableContract)

--- a/src/agent0/ethpy/hyperdrive/interface/read_interface.py
+++ b/src/agent0/ethpy/hyperdrive/interface/read_interface.py
@@ -196,17 +196,12 @@ class HyperdriveReadInterface:
         # - The pool doesn't support some operations in base (i.e., Moonwell EURC, Moonwell USDC)
         # In all of these cases, we use the yield token as the base.
         # Calls to trades will use "as_base=False"
-<<<<<<< HEAD
-=======
-        self.hyperdrive_name = self.hyperdrive_contract.functions.name().call()
->>>>>>> 1bb049c8 (Adding EETH as hyperdrive kind. Setting hyperdrive name as interface member variable)
         if (
             base_token_contract_address
             in (
                 ETH_CONTRACT_ADDRESS,
                 ADDRESS_ZERO,
             )
-<<<<<<< HEAD
             or self.hyperdrive_kind == self.HyperdriveKind.STKWELL
             or self.hyperdrive_name
             in (
@@ -215,12 +210,6 @@ class HyperdriveReadInterface:
                 "ElementDAO 182 Day Moonwell USDC Hyperdrive",
                 "ElementDAO 182 Day Moonwell EURC Hyperdrive",
             )
-=======
-            or "Moonwell USDC" in self.hyperdrive_name
-            or "Moonwell EURC" in self.hyperdrive_name
-            or "Moonwell StkWell" in self.hyperdrive_name
-            or "Num Finance snARS" in self.hyperdrive_name
->>>>>>> 1bb049c8 (Adding EETH as hyperdrive kind. Setting hyperdrive name as interface member variable)
         ):
             self.base_is_yield = True
             # We use the yield token as the base token (e.g., steth)

--- a/src/agent0/ethpy/hyperdrive/interface/read_interface.py
+++ b/src/agent0/ethpy/hyperdrive/interface/read_interface.py
@@ -117,6 +117,7 @@ class HyperdriveReadInterface:
         EZETH = "EzETHHyperdrive"
         RETH = "RETHHyperdrive"
         STKWELL = "StkWellHyperdrive"
+        EETH = "EETHHyperdrive"
 
     def __init__(
         self,
@@ -195,12 +196,17 @@ class HyperdriveReadInterface:
         # - The pool doesn't support some operations in base (i.e., Moonwell EURC, Moonwell USDC)
         # In all of these cases, we use the yield token as the base.
         # Calls to trades will use "as_base=False"
+<<<<<<< HEAD
+=======
+        self.hyperdrive_name = self.hyperdrive_contract.functions.name().call()
+>>>>>>> 1bb049c8 (Adding EETH as hyperdrive kind. Setting hyperdrive name as interface member variable)
         if (
             base_token_contract_address
             in (
                 ETH_CONTRACT_ADDRESS,
                 ADDRESS_ZERO,
             )
+<<<<<<< HEAD
             or self.hyperdrive_kind == self.HyperdriveKind.STKWELL
             or self.hyperdrive_name
             in (
@@ -209,6 +215,12 @@ class HyperdriveReadInterface:
                 "ElementDAO 182 Day Moonwell USDC Hyperdrive",
                 "ElementDAO 182 Day Moonwell EURC Hyperdrive",
             )
+=======
+            or "Moonwell USDC" in self.hyperdrive_name
+            or "Moonwell EURC" in self.hyperdrive_name
+            or "Moonwell StkWell" in self.hyperdrive_name
+            or "Num Finance snARS" in self.hyperdrive_name
+>>>>>>> 1bb049c8 (Adding EETH as hyperdrive kind. Setting hyperdrive name as interface member variable)
         ):
             self.base_is_yield = True
             # We use the yield token as the base token (e.g., steth)

--- a/src/agent0/ethpy/hyperdrive/interface/read_write_interface_test.py
+++ b/src/agent0/ethpy/hyperdrive/interface/read_write_interface_test.py
@@ -12,7 +12,7 @@ from eth_utils.curried import text_if_str
 from fixedpointmath import FixedPoint
 from hexbytes import HexBytes
 
-from agent0.ethpy.base import set_anvil_account_balance
+from agent0.ethpy.base import set_account_balance
 
 if TYPE_CHECKING:
     from eth_account.signers.local import LocalAccount
@@ -37,6 +37,6 @@ class TestHyperdriveReadWriteInterface:
         private_key = HexBytes(key_bytes).hex()
         sender: LocalAccount = Account().from_key(private_key)
 
-        set_anvil_account_balance(hyperdrive_read_write_interface_fixture.web3, sender.address, 10**19)
+        set_account_balance(hyperdrive_read_write_interface_fixture.web3, sender.address, 10**19)
         hyperdrive_read_write_interface_fixture.set_variable_rate(sender, new_rate)
         assert hyperdrive_read_write_interface_fixture.get_variable_rate() == new_rate

--- a/src/agent0/hyperfuzz/fork_fuzz/__init__.py
+++ b/src/agent0/hyperfuzz/fork_fuzz/__init__.py
@@ -1,0 +1,3 @@
+"""Functions for fork fuzzing."""
+
+from .accrue_interest_fork import accrue_interest_fork

--- a/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_ezeth.py
+++ b/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_ezeth.py
@@ -18,7 +18,18 @@ RESTAKE_MANAGER_ADDR = "0x74a09653A083691711cF8215a6ab074BB4e99ef5"
 DEPOSIT_QUEUE_ADDR = "0xf2F305D14DCD8aaef887E0428B3c9534795D0d60"
 
 
-def accrue_interest_ezeth(interface: HyperdriveReadWriteInterface, variable_rate: FixedPoint):
+def accrue_interest_ezeth(interface: HyperdriveReadWriteInterface, variable_rate: FixedPoint) -> None:
+    """
+    Function to accrue interest in the ezeth pool when fork fuzzing.
+
+    Arguments
+    ---------
+    interface: HyperdriveReadWriteInterface
+        The interface to the Hyperdrive pool.
+    variable_rate: FixedPoint
+        The variable rate of the pool.
+    """
+
     assert variable_rate > FixedPoint(0)
 
     # TODO we may want to build these objects once and store them

--- a/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_ezeth.py
+++ b/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_ezeth.py
@@ -19,8 +19,7 @@ DEPOSIT_QUEUE_ADDR = "0xf2F305D14DCD8aaef887E0428B3c9534795D0d60"
 
 
 def accrue_interest_ezeth(interface: HyperdriveReadWriteInterface, variable_rate: FixedPoint) -> None:
-    """
-    Function to accrue interest in the ezeth pool when fork fuzzing.
+    """Function to accrue interest in the ezeth pool when fork fuzzing.
 
     Arguments
     ---------

--- a/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_ezeth.py
+++ b/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_ezeth.py
@@ -1,0 +1,7 @@
+"""Function to accrue interest in the ezeth pool when fork fuzzing."""
+
+from agent0.ethpy.hyperdrive import HyperdriveReadWriteInterface
+
+
+def accrue_interest_ezeth(interface: HyperdriveReadWriteInterface):
+    pass

--- a/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_ezeth.py
+++ b/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_ezeth.py
@@ -38,9 +38,7 @@ def accrue_interest_ezeth(interface: HyperdriveReadWriteInterface, variable_rate
     # There's a current issue with pypechain where it breaks if the called function returns a double nested list,
     # e.g., in calculateTVLs. We fall back to using pure web3 for this.
     # https://github.com/delvtech/pypechain/issues/147
-
     total_tvl = restake_manager.get_function_by_name("calculateTVLs")().call()[2]
-    # total_tvl = restake_manager.functions.calculateTVLs().call().arg3
 
     # Build accrue_interest_data
     accrue_interest_data = {

--- a/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_ezeth.py
+++ b/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_ezeth.py
@@ -1,7 +1,72 @@
 """Function to accrue interest in the ezeth pool when fork fuzzing."""
 
+from __future__ import annotations
+
+from fixedpointmath import FixedPoint, FixedPointIntegerMath
+from hyperdrivetypes.types import IDepositQueueContract, IRestakeManagerContract
+from pypechain.core import check_txn_receipt
+from web3 import Web3
+from web3.types import RPCEndpoint, TxParams, Wei
+
+from agent0.ethpy.base import get_account_balance, set_account_balance
 from agent0.ethpy.hyperdrive import HyperdriveReadWriteInterface
 
+SECONDS_IN_YEAR = 365 * 24 * 60 * 60
 
-def accrue_interest_ezeth(interface: HyperdriveReadWriteInterface):
-    pass
+# Contract addresses for mainnet fork
+RESTAKE_MANAGER_ADDR = "0x74a09653A083691711cF8215a6ab074BB4e99ef5"
+DEPOSIT_QUEUE_ADDR = "0xf2F305D14DCD8aaef887E0428B3c9534795D0d60"
+
+
+def accrue_interest_ezeth(interface: HyperdriveReadWriteInterface, variable_rate: FixedPoint):
+    assert variable_rate > FixedPoint(0)
+
+    # TODO we may want to build these objects once and store them
+    restake_manager = IRestakeManagerContract.factory(w3=interface.web3)(Web3.to_checksum_address(RESTAKE_MANAGER_ADDR))
+    deposit_queue = IDepositQueueContract.factory(w3=interface.web3)(Web3.to_checksum_address(DEPOSIT_QUEUE_ADDR))
+
+    # Build accrue_interest_data
+    accrue_interest_data = {
+        "block_timestamp": interface.get_block_timestamp(interface.get_current_block()),
+        # 3rd arg is total tvl
+        "total_tvl": FixedPoint(scaled_value=restake_manager.functions.calculateTVLs().call().arg3),
+    }
+
+    # TODO we hack in a stateful variable into the interface here to check
+    # how much time has advanced between subsequent calls.
+    # Initial call, we look to see if the attribute exists
+    previous_accrue_interest_data: dict | None = getattr(interface, "_accrue_interest_data", None)
+    # Always set the new state here
+    setattr(interface, "_previous_interest_accrual_time", accrue_interest_data)
+
+    if previous_accrue_interest_data is None:
+        # Skip this check on initial call, not a failure
+        # On initial call, we impersonate the restake manager
+        response = interface.web3.provider.make_request(
+            method=RPCEndpoint("anvil_impersonateAccount"), params=[RESTAKE_MANAGER_ADDR]
+        )
+        # ensure response is valid
+        if "result" not in response:
+            raise KeyError("Response did not have a result.")
+
+        return
+
+    adjusted_variable_rate = FixedPoint(
+        scaled_value=FixedPointIntegerMath.mul_div_down(
+            variable_rate.scaled_value, interface.pool_config.position_duration, SECONDS_IN_YEAR
+        )
+    )
+
+    previous_total_tvl: FixedPoint = previous_accrue_interest_data["total_tvl"]
+    assert isinstance(previous_total_tvl, FixedPoint)
+    eth_to_add = previous_total_tvl * adjusted_variable_rate
+
+    # Give eth to restake manager
+    curr_balance = FixedPoint(scaled_value=get_account_balance(interface.web3, RESTAKE_MANAGER_ADDR))
+    _ = set_account_balance(interface.web3, RESTAKE_MANAGER_ADDR, (curr_balance + eth_to_add).scaled_value)
+
+    # TODO we need a "transact and wait" function in pypechain, as we don't need to sign due to impersonation
+    tx_func = deposit_queue.functions.depositETHFromProtocol()
+    tx_hash = tx_func.transact(TxParams({"from": RESTAKE_MANAGER_ADDR, "value": Wei(eth_to_add.scaled_value)}))
+    tx_receipt = interface.web3.eth.wait_for_transaction_receipt(tx_hash)
+    check_txn_receipt(tx_func, tx_hash, tx_receipt)

--- a/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_fork.py
+++ b/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_fork.py
@@ -7,7 +7,19 @@ from agent0.ethpy.hyperdrive import HyperdriveReadWriteInterface
 from .accrue_interest_ezeth import accrue_interest_ezeth
 
 
-def accrue_interest_fork(interface: HyperdriveReadWriteInterface, variable_rate: FixedPoint):
+def accrue_interest_fork(interface: HyperdriveReadWriteInterface, variable_rate: FixedPoint) -> None:
+    """Function to accrue interest in underlying yields when fork fuzzing.
+    This function looks at the kind of pool defined in the interface, and
+    matches the correct accrual function to call.
+
+    Arguments
+    ---------
+    interface: HyperdriveReadWriteInterface
+        The interface to the Hyperdrive pool.
+    variable_rate: FixedPoint
+        The variable rate of the pool.
+    """
+
     # Switch case for pool types for interest accrual
     # TODO do we need to switch chain?
     hyperdrive_kind = interface.hyperdrive_kind

--- a/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_fork.py
+++ b/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_fork.py
@@ -1,0 +1,14 @@
+"""Function to accrue interest in underlying yields when fork fuzzing."""
+
+from agent0.ethpy.hyperdrive import HyperdriveReadWriteInterface
+
+from .accrue_interest_ezeth import accrue_interest_ezeth
+
+
+def accrue_interest_fork(interface: HyperdriveReadWriteInterface):
+    # Switch case for pool types for interest accrual
+    # TODO do we need to switch chain?
+    hyperdrive_kind = interface.hyperdrive_kind
+    match hyperdrive_kind:
+        case interface.HyperdriveKind.EZETH:
+            accrue_interest_ezeth(interface)

--- a/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_fork.py
+++ b/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_fork.py
@@ -1,14 +1,16 @@
 """Function to accrue interest in underlying yields when fork fuzzing."""
 
+from fixedpointmath import FixedPoint
+
 from agent0.ethpy.hyperdrive import HyperdriveReadWriteInterface
 
 from .accrue_interest_ezeth import accrue_interest_ezeth
 
 
-def accrue_interest_fork(interface: HyperdriveReadWriteInterface):
+def accrue_interest_fork(interface: HyperdriveReadWriteInterface, variable_rate: FixedPoint):
     # Switch case for pool types for interest accrual
     # TODO do we need to switch chain?
     hyperdrive_kind = interface.hyperdrive_kind
     match hyperdrive_kind:
         case interface.HyperdriveKind.EZETH:
-            accrue_interest_ezeth(interface)
+            accrue_interest_ezeth(interface, variable_rate)

--- a/src/agent0/hyperfuzz/system_fuzz/run_fuzz_bots.py
+++ b/src/agent0/hyperfuzz/system_fuzz/run_fuzz_bots.py
@@ -14,7 +14,7 @@ from agent0 import Chain, Hyperdrive, LocalChain, LocalHyperdrive, PolicyZoo
 from agent0.chainsync.db.hyperdrive import get_trade_events
 from agent0.core.base.make_key import make_private_key
 from agent0.core.hyperdrive.interactive.hyperdrive_agent import HyperdriveAgent
-from agent0.ethpy.base import set_anvil_account_balance
+from agent0.ethpy.base import set_account_balance
 from agent0.ethpy.hyperdrive import HyperdriveReadWriteInterface
 from agent0.hyperfuzz import FuzzAssertionException
 from agent0.hyperfuzz.system_fuzz.invariant_checks import run_invariant_checks
@@ -223,7 +223,8 @@ def run_fuzz_bots(
     num_iterations: int | None = None,
     lp_share_price_test: bool = False,
     whale_accounts: dict[ChecksumAddress, ChecksumAddress] | None = None,
-    accrue_interest_func: Callable[[HyperdriveReadWriteInterface], None] | None = None,
+    accrue_interest_func: Callable[[HyperdriveReadWriteInterface, FixedPoint], None] | None = None,
+    accrue_interest_rate: FixedPoint | None = None,
 ) -> None:
     """Runs fuzz bots on a hyperdrive pool.
 
@@ -279,6 +280,10 @@ def run_fuzz_bots(
         A function that will accrue interest on the hyperdrive pool. This function will get called
         before and after each set of trades, with the pool's hyperdrive interface as an argument.
         It's up to the function itself to maintain the last time interest was accrued.
+    accrue_interest_rate: FixedPoint | None, optional
+        The variable rate to be passed into the accrue_interest_func. Note this value is only used when
+        forking, as variable interest is handled by a mock yield source when simulating.
+        If `random_variable_rate` is True, this value will be ignored.
     """
     # TODO cleanup
     # pylint: disable=too-many-arguments
@@ -361,6 +366,27 @@ def run_fuzz_bots(
     while True:
         if num_iterations is not None and iteration >= num_iterations:
             break
+
+        # Set the variable rate
+        if random_variable_rate:
+            # This will change an underlying yield source twice if pools share the same underlying
+            # yield source
+            if lp_share_price_test:
+                variable_rate_range = LP_SHARE_PRICE_VARIABLE_RATE_RANGE
+            else:
+                variable_rate_range = VARIABLE_RATE_RANGE
+            for hyperdrive_pool in hyperdrive_pools:
+                if isinstance(hyperdrive_pool, LocalHyperdrive):
+                    # RNG should always exist, config's post_init should always
+                    # initialize an rng object
+                    assert hyperdrive_pool.chain.config.rng is not None
+                    accrue_interest_rate = FixedPoint(hyperdrive_pool.chain.config.rng.uniform(*variable_rate_range))
+                    # TODO this call will break on forks, we likely want to ignore this call
+                    # if this is the case
+                    hyperdrive_pool.set_variable_rate(accrue_interest_rate)
+                else:
+                    raise ValueError("Random variable rate only allowed for LocalHyperdrive pools")
+
         iteration += 1
         if run_async:
             # There are race conditions throughout that need to be fixed here
@@ -377,8 +403,8 @@ def run_fuzz_bots(
                     pending_pool_state = pool.interface.get_hyperdrive_state("pending")
 
                 # Accrue interest before and after making the trades
-                if accrue_interest_func is not None:
-                    accrue_interest_func(pool.interface)
+                if accrue_interest_func is not None and accrue_interest_rate is not None:
+                    accrue_interest_func(pool.interface, accrue_interest_rate)
 
                 # Execute trades
                 agent_trade = []
@@ -403,8 +429,8 @@ def run_fuzz_bots(
                     # These errors will get logged regardless
 
                 # Accrue interest before and after making the trades
-                if accrue_interest_func is not None:
-                    accrue_interest_func(pool.interface)
+                if accrue_interest_func is not None and accrue_interest_rate is not None:
+                    accrue_interest_func(pool.interface, accrue_interest_rate)
 
                 # Check invariance on every iteration if we're not doing lp_share_price_test.
                 # Only check invariance if a trade was executed for lp_share_price_test.
@@ -485,7 +511,7 @@ def run_fuzz_bots(
                 deployer_account = chain.get_deployer_account()
                 deployer_agent_eth = hyperdrive_pools[0].interface.get_eth_base_balances(deployer_account)[0]
                 if deployer_agent_eth < minimum_avg_agent_eth:
-                    _ = set_anvil_account_balance(
+                    _ = set_account_balance(
                         hyperdrive_pools[0].interface.web3, deployer_account.address, eth_budget_per_bot.scaled_value
                     )
                 # RNG should always exist, config's post_init should always
@@ -496,20 +522,3 @@ def run_fuzz_bots(
                 chain.advance_time(random_time, create_checkpoints=True)
             else:
                 raise ValueError("Random advance time only allowed for pools deployed on LocalChain")
-
-        if random_variable_rate:
-            # This will change an underlying yield source twice if pools share the same underlying
-            # yield source
-            if lp_share_price_test:
-                variable_rate_range = LP_SHARE_PRICE_VARIABLE_RATE_RANGE
-            else:
-                variable_rate_range = VARIABLE_RATE_RANGE
-            for hyperdrive_pool in hyperdrive_pools:
-                if isinstance(hyperdrive_pool, LocalHyperdrive):
-                    # RNG should always exist, config's post_init should always
-                    # initialize an rng object
-                    assert hyperdrive_pool.chain.config.rng is not None
-                    random_rate = FixedPoint(hyperdrive_pool.chain.config.rng.uniform(*variable_rate_range))
-                    hyperdrive_pool.set_variable_rate(random_rate)
-                else:
-                    raise ValueError("Random variable rate only allowed for LocalHyperdrive pools")

--- a/src/agent0/hyperfuzz/system_fuzz/run_fuzz_bots.py
+++ b/src/agent0/hyperfuzz/system_fuzz/run_fuzz_bots.py
@@ -276,10 +276,10 @@ def run_fuzz_bots(
         A mapping between token -> whale addresses to use to fund the fuzz agent.
         If the token is not in the mapping, fuzzing will attempt to call `mint` on
         the token contract. Defaults to an empty mapping.
-    accrue_interest_func: Callable[[HyperdriveReadWriteInterface], None] | None, optional
+    accrue_interest_func: Callable[[HyperdriveReadWriteInterface, FixedPoint], None] | None, optional
         A function that will accrue interest on the hyperdrive pool. This function will get called
-        before and after each set of trades, with the pool's hyperdrive interface as an argument.
-        It's up to the function itself to maintain the last time interest was accrued.
+        before and after each set of trades, with the pool's hyperdrive interface and the variable rate
+        as an argument. It's up to the function itself to maintain the last time interest was accrued.
     accrue_interest_rate: FixedPoint | None, optional
         The variable rate to be passed into the accrue_interest_func. Note this value is only used when
         forking, as variable interest is handled by a mock yield source when simulating.


### PR DESCRIPTION
This PR adds the structure for implementing accrual interest logic in fork fuzzing. Currently, only ezeth is implemented.