### PR TITLE
Minor fixes to fork fuzz

### DIFF
--- a/scripts/fork_fuzz_bots.py
+++ b/scripts/fork_fuzz_bots.py
@@ -284,7 +284,6 @@ def main(argv: Sequence[str] | None = None) -> None:
                 accrue_interest_rate=FixedPoint(0.05),
             )
         except Exception as e:  # pylint: disable=broad-except
-            raise e
             log_rollbar_exception(
                 rollbar_log_prefix="Fork FuzzBot: Unexpected error", exception=e, log_level=logging.ERROR
             )

--- a/scripts/fork_fuzz_bots.py
+++ b/scripts/fork_fuzz_bots.py
@@ -228,10 +228,8 @@ def main(argv: Sequence[str] | None = None) -> None:
         crash_log_level=logging.ERROR,
         crash_report_additional_info={"rng_seed": rng_seed},
         gas_limit=int(3e6),  # Plenty of gas limit for transactions
-        # In order to accrue interest correctly, mining a block on the fork must not advance time.
-        # We advance time manually when fuzzing.
-        # This option will mine blocks based on real time.
-        block_timestamp_interval=None,
+        # There's an issue with oracles getting out of date, so we don't advance time when fuzzing
+        block_timestamp_interval=0,
     )
 
     while True:
@@ -274,7 +272,7 @@ def main(argv: Sequence[str] | None = None) -> None:
                 ignore_raise_error_func=_fuzz_ignore_errors,
                 run_async=False,
                 # TODO advance time and randomize variable rates
-                random_advance_time=True,
+                random_advance_time=False,
                 random_variable_rate=False,
                 lp_share_price_test=False,
                 base_budget_per_bot=FixedPoint(1_000),

--- a/scripts/fork_fuzz_bots.py
+++ b/scripts/fork_fuzz_bots.py
@@ -228,6 +228,10 @@ def main(argv: Sequence[str] | None = None) -> None:
         crash_log_level=logging.ERROR,
         crash_report_additional_info={"rng_seed": rng_seed},
         gas_limit=int(3e6),  # Plenty of gas limit for transactions
+        # In order to accrue interest correctly, mining a block on the fork must not advance time.
+        # We advance time manually when fuzzing.
+        # This option will mine blocks based on real time.
+        block_timestamp_interval=None,
     )
 
     while True:
@@ -270,7 +274,7 @@ def main(argv: Sequence[str] | None = None) -> None:
                 ignore_raise_error_func=_fuzz_ignore_errors,
                 run_async=False,
                 # TODO advance time and randomize variable rates
-                random_advance_time=False,
+                random_advance_time=True,
                 random_variable_rate=False,
                 lp_share_price_test=False,
                 base_budget_per_bot=FixedPoint(1_000),
@@ -280,6 +284,7 @@ def main(argv: Sequence[str] | None = None) -> None:
                 accrue_interest_rate=FixedPoint(0.05),
             )
         except Exception as e:  # pylint: disable=broad-except
+            raise e
             log_rollbar_exception(
                 rollbar_log_prefix="Fork FuzzBot: Unexpected error", exception=e, log_level=logging.ERROR
             )

--- a/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
+++ b/src/agent0/core/hyperdrive/interactive/local_hyperdrive.py
@@ -549,6 +549,7 @@ class LocalHyperdrive(Hyperdrive):
                 self.chain.get_deployer_account(),
                 checkpoint_time=checkpoint_time,
                 gas_limit=gas_limit,
+                preview=self.chain.config.preview_before_trade,
             )
         except AssertionError as exc:
             # Adding additional context to the "Transaction receipt has no logs" error

--- a/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_ezeth.py
+++ b/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_ezeth.py
@@ -51,8 +51,9 @@ def accrue_interest_ezeth(interface: HyperdriveReadWriteInterface, variable_rate
     # how much time has advanced between subsequent calls.
     # Initial call, we look to see if the attribute exists
     previous_accrue_interest_data: dict | None = getattr(interface, "_accrue_interest_data", None)
+
     # Always set the new state here
-    setattr(interface, "_previous_interest_accrual_time", accrue_interest_data)
+    setattr(interface, "_accrue_interest_data", accrue_interest_data)
 
     if previous_accrue_interest_data is None:
         # Skip this check on initial call, not a failure

--- a/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_ezeth.py
+++ b/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_ezeth.py
@@ -18,7 +18,9 @@ RESTAKE_MANAGER_ADDR = "0x74a09653A083691711cF8215a6ab074BB4e99ef5"
 DEPOSIT_QUEUE_ADDR = "0xf2F305D14DCD8aaef887E0428B3c9534795D0d60"
 
 
-def accrue_interest_ezeth(interface: HyperdriveReadWriteInterface, variable_rate: FixedPoint) -> None:
+def accrue_interest_ezeth(
+    interface: HyperdriveReadWriteInterface, variable_rate: FixedPoint, block_number_before_advance: int
+) -> None:
     """Function to accrue interest in the ezeth pool when fork fuzzing.
 
     Arguments
@@ -27,6 +29,8 @@ def accrue_interest_ezeth(interface: HyperdriveReadWriteInterface, variable_rate
         The interface to the Hyperdrive pool.
     variable_rate: FixedPoint
         The variable rate of the pool.
+    block_number_before_advance: int
+        The block number before time was advanced.
     """
 
     assert variable_rate > FixedPoint(0)
@@ -34,38 +38,22 @@ def accrue_interest_ezeth(interface: HyperdriveReadWriteInterface, variable_rate
     # TODO we may want to build these objects once and store them
     restake_manager = IRestakeManagerContract.factory(w3=interface.web3)(Web3.to_checksum_address(RESTAKE_MANAGER_ADDR))
     deposit_queue = IDepositQueueContract.factory(w3=interface.web3)(Web3.to_checksum_address(DEPOSIT_QUEUE_ADDR))
+    # TODO we probably just want to do this once
+    response = interface.web3.provider.make_request(
+        method=RPCEndpoint("anvil_impersonateAccount"), params=[RESTAKE_MANAGER_ADDR]
+    )
+    # ensure response is valid
+    if "result" not in response:
+        raise KeyError("Response did not have a result.")
 
     # There's a current issue with pypechain where it breaks if the called function returns a double nested list,
     # e.g., in calculateTVLs. We fall back to using pure web3 for this.
     # https://github.com/delvtech/pypechain/issues/147
-    total_tvl = restake_manager.get_function_by_name("calculateTVLs")().call()[2]
-
-    # Build accrue_interest_data
-    accrue_interest_data = {
-        "block_timestamp": interface.get_block_timestamp(interface.get_current_block()),
-        # 3rd arg is total tvl
-        "total_tvl": FixedPoint(scaled_value=total_tvl),
-    }
-
-    # TODO we hack in a stateful variable into the interface here to check
-    # how much time has advanced between subsequent calls.
-    # Initial call, we look to see if the attribute exists
-    previous_accrue_interest_data: dict | None = getattr(interface, "_accrue_interest_data", None)
-
-    # Always set the new state here
-    setattr(interface, "_accrue_interest_data", accrue_interest_data)
-
-    if previous_accrue_interest_data is None:
-        # Skip this check on initial call, not a failure
-        # On initial call, we impersonate the restake manager
-        response = interface.web3.provider.make_request(
-            method=RPCEndpoint("anvil_impersonateAccount"), params=[RESTAKE_MANAGER_ADDR]
-        )
-        # ensure response is valid
-        if "result" not in response:
-            raise KeyError("Response did not have a result.")
-
-        return
+    previous_total_tvl = FixedPoint(
+        scaled_value=restake_manager.get_function_by_name("calculateTVLs")().call(
+            block_identifier=block_number_before_advance
+        )[2]
+    )
 
     adjusted_variable_rate = FixedPoint(
         scaled_value=FixedPointIntegerMath.mul_div_down(
@@ -73,14 +61,16 @@ def accrue_interest_ezeth(interface: HyperdriveReadWriteInterface, variable_rate
         )
     )
 
-    previous_total_tvl: FixedPoint = previous_accrue_interest_data["total_tvl"]
-    assert isinstance(previous_total_tvl, FixedPoint)
-    # Give a little bit extra for gas
-    eth_to_add = previous_total_tvl * adjusted_variable_rate + FixedPoint(0.01)
+    eth_to_add = previous_total_tvl * adjusted_variable_rate
 
     # Give eth to restake manager
     curr_balance = FixedPoint(scaled_value=get_account_balance(interface.web3, RESTAKE_MANAGER_ADDR))
-    _ = set_account_balance(interface.web3, RESTAKE_MANAGER_ADDR, (curr_balance + eth_to_add).scaled_value)
+    _ = set_account_balance(
+        interface.web3,
+        RESTAKE_MANAGER_ADDR,
+        # Give a little bit extra for gas
+        (curr_balance + eth_to_add + FixedPoint(0.01)).scaled_value,
+    )
 
     # TODO we need a "transact and wait" function in pypechain, as we don't need to sign due to impersonation
     tx_func = deposit_queue.functions.depositETHFromProtocol()

--- a/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_ezeth.py
+++ b/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_ezeth.py
@@ -54,11 +54,12 @@ def accrue_interest_ezeth(
             block_identifier=block_number_before_advance
         )[2]
     )
+    previous_timestamp = interface.get_block_timestamp(interface.get_block(block_number_before_advance))
+    current_timestamp = interface.get_block_timestamp(interface.get_block("latest"))
+    time_delta = current_timestamp - previous_timestamp
 
     adjusted_variable_rate = FixedPoint(
-        scaled_value=FixedPointIntegerMath.mul_div_down(
-            variable_rate.scaled_value, interface.pool_config.position_duration, SECONDS_IN_YEAR
-        )
+        scaled_value=FixedPointIntegerMath.mul_div_down(variable_rate.scaled_value, time_delta, SECONDS_IN_YEAR)
     )
 
     eth_to_add = previous_total_tvl * adjusted_variable_rate

--- a/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_ezeth.py
+++ b/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_ezeth.py
@@ -75,7 +75,8 @@ def accrue_interest_ezeth(interface: HyperdriveReadWriteInterface, variable_rate
 
     previous_total_tvl: FixedPoint = previous_accrue_interest_data["total_tvl"]
     assert isinstance(previous_total_tvl, FixedPoint)
-    eth_to_add = previous_total_tvl * adjusted_variable_rate
+    # Give a little bit extra for gas
+    eth_to_add = previous_total_tvl * adjusted_variable_rate + FixedPoint(0.01)
 
     # Give eth to restake manager
     curr_balance = FixedPoint(scaled_value=get_account_balance(interface.web3, RESTAKE_MANAGER_ADDR))

--- a/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_ezeth.py
+++ b/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_ezeth.py
@@ -32,6 +32,7 @@ def accrue_interest_ezeth(
     block_number_before_advance: int
         The block number before time was advanced.
     """
+    # pylint: disable=too-many-locals
 
     assert variable_rate > FixedPoint(0)
 

--- a/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_fork.py
+++ b/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_fork.py
@@ -20,6 +20,8 @@ def accrue_interest_fork(
         The interface to the Hyperdrive pool.
     variable_rate: FixedPoint
         The variable rate of the pool.
+    block_number_before_advance: int
+        The block number before time was advanced.
     """
 
     # Switch case for pool types for interest accrual

--- a/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_fork.py
+++ b/src/agent0/hyperfuzz/fork_fuzz/accrue_interest_fork.py
@@ -7,7 +7,9 @@ from agent0.ethpy.hyperdrive import HyperdriveReadWriteInterface
 from .accrue_interest_ezeth import accrue_interest_ezeth
 
 
-def accrue_interest_fork(interface: HyperdriveReadWriteInterface, variable_rate: FixedPoint) -> None:
+def accrue_interest_fork(
+    interface: HyperdriveReadWriteInterface, variable_rate: FixedPoint, block_number_before_advance: int
+) -> None:
     """Function to accrue interest in underlying yields when fork fuzzing.
     This function looks at the kind of pool defined in the interface, and
     matches the correct accrual function to call.
@@ -25,4 +27,4 @@ def accrue_interest_fork(interface: HyperdriveReadWriteInterface, variable_rate:
     hyperdrive_kind = interface.hyperdrive_kind
     match hyperdrive_kind:
         case interface.HyperdriveKind.EZETH:
-            accrue_interest_ezeth(interface, variable_rate)
+            accrue_interest_ezeth(interface, variable_rate, block_number_before_advance)

--- a/src/agent0/hyperfuzz/system_fuzz/invariant_checks.py
+++ b/src/agent0/hyperfuzz/system_fuzz/invariant_checks.py
@@ -22,6 +22,7 @@ from agent0.hyperfuzz import FuzzAssertionException
 LP_SHARE_PRICE_EPSILON = 1e-4
 TOTAL_SHARES_EPSILON = 1e-9
 NEGATIVE_INTEREST_EPSILON = FixedPoint(scaled_value=10)  # 10 wei
+PRESENT_VALUE_EPSILON = FixedPoint(scaled_value=1)  # 1 wei
 
 
 def run_invariant_checks(
@@ -477,7 +478,7 @@ def _check_present_value_greater_than_idle_shares(
             failed=True, exception_message=repr(e), exception_data=exception_data, log_level=logging.CRITICAL
         )
 
-    if not present_value >= idle_shares:
+    if not present_value >= (idle_shares - PRESENT_VALUE_EPSILON):
         difference_in_wei = abs(present_value.scaled_value - idle_shares.scaled_value)
         exception_message = f"{present_value=} < {idle_shares=}, {difference_in_wei=}"
         exception_data["invariance_check:idle_shares"] = idle_shares

--- a/src/agent0/hyperfuzz/system_fuzz/run_fuzz_bots.py
+++ b/src/agent0/hyperfuzz/system_fuzz/run_fuzz_bots.py
@@ -43,7 +43,7 @@ INITIAL_TIME_STRETCH_APR_RANGE: tuple[float, float] = (0.005, 0.5)
 # The variable rate to set after each episode
 VARIABLE_RATE_RANGE: tuple[float, float] = (0, 1)
 # How much to advance time between episodes
-ADVANCE_TIME_SECONDS_RANGE: tuple[int, int] = (0, ONE_DAY_IN_SECONDS)
+ADVANCE_TIME_SECONDS_RANGE: tuple[int, int] = (0, 5 * ONE_DAY_IN_SECONDS)
 # The fee percentage. The range controls all 4 fees
 FEE_RANGE: tuple[float, float] = (0.0001, 0.2)
 
@@ -197,9 +197,9 @@ def _check_trades_made_on_pool(
                     )
 
             if has_err:
-                error_message = "FuzzBots: " + error_message
                 logging.error(error_message)
-                log_rollbar_message(error_message, logging.ERROR)
+                # We log message to get rollbar to group these messages together
+                log_rollbar_exception(ValueError(error_message), logging.ERROR, rollbar_log_prefix="FuzzBots:")
 
 
 def run_fuzz_bots(
@@ -223,7 +223,7 @@ def run_fuzz_bots(
     num_iterations: int | None = None,
     lp_share_price_test: bool = False,
     whale_accounts: dict[ChecksumAddress, ChecksumAddress] | None = None,
-    accrue_interest_func: Callable[[HyperdriveReadWriteInterface, FixedPoint], None] | None = None,
+    accrue_interest_func: Callable[[HyperdriveReadWriteInterface, FixedPoint, int], None] | None = None,
     accrue_interest_rate: FixedPoint | None = None,
 ) -> None:
     """Runs fuzz bots on a hyperdrive pool.
@@ -276,10 +276,10 @@ def run_fuzz_bots(
         A mapping between token -> whale addresses to use to fund the fuzz agent.
         If the token is not in the mapping, fuzzing will attempt to call `mint` on
         the token contract. Defaults to an empty mapping.
-    accrue_interest_func: Callable[[HyperdriveReadWriteInterface, FixedPoint], None] | None, optional
+    accrue_interest_func: Callable[[HyperdriveReadWriteInterface, FixedPoint, int], None] | None, optional
         A function that will accrue interest on the hyperdrive pool. This function will get called
-        before and after each set of trades, with the pool's hyperdrive interface and the variable rate
-        as an argument. It's up to the function itself to maintain the last time interest was accrued.
+        after advancing time, with the following signature:
+        `accrue_interest_func(hyperdrive_interface, variable_rate, block_number_before_advance)`.
     accrue_interest_rate: FixedPoint | None, optional
         The variable rate to be passed into the accrue_interest_func. Note this value is only used when
         forking, as variable interest is handled by a mock yield source when simulating.
@@ -402,10 +402,6 @@ def run_fuzz_bots(
                 if check_invariance and lp_share_price_test:
                     pending_pool_state = pool.interface.get_hyperdrive_state("pending")
 
-                # Accrue interest before and after making the trades
-                if accrue_interest_func is not None and accrue_interest_rate is not None:
-                    accrue_interest_func(pool.interface, accrue_interest_rate)
-
                 # Execute trades
                 agent_trade = []
                 try:
@@ -427,10 +423,6 @@ def run_fuzz_bots(
                             raise exc
                     # Otherwise, we ignore crashes, we want the bot to keep trading
                     # These errors will get logged regardless
-
-                # Accrue interest before and after making the trades
-                if accrue_interest_func is not None and accrue_interest_rate is not None:
-                    accrue_interest_func(pool.interface, accrue_interest_rate)
 
                 # Check invariance on every iteration if we're not doing lp_share_price_test.
                 # Only check invariance if a trade was executed for lp_share_price_test.
@@ -505,8 +497,29 @@ def run_fuzz_bots(
         if random_advance_time:
             # We only allow random advance time if the chain connected to the pool is a
             # LocalChain object
-            if isinstance(chain, LocalChain):
-                # The deployer pays gas for advancing time
+            if not isinstance(chain, LocalChain):
+                raise ValueError("Random advance time only allowed for pools deployed on LocalChain")
+
+            # RNG should always exist, config's post_init should always
+            # initialize an rng object
+            assert chain.config.rng is not None
+            random_time = int(chain.config.rng.integers(*ADVANCE_TIME_SECONDS_RANGE))
+
+            if accrue_interest_func is not None and accrue_interest_rate is not None:
+                # Get block number before we advance time
+                block_number_before_advance = chain.block_number()
+                # There's issues around generating intermittent checkpoints with
+                # an out of date oracle, and we can't do any other contract calls
+                # until we accrue interest. Hence, we break up the call
+                # to accrue interest, then update the db.
+                chain._advance_chain_time(random_time)  # pylint: disable=protected-access
+                for pool in hyperdrive_pools:
+                    accrue_interest_func(pool.interface, accrue_interest_rate, block_number_before_advance)
+                    assert isinstance(pool, LocalHyperdrive)
+                    pool._maybe_run_blocking_data_pipeline()  # pylint: disable=protected-access
+
+            else:
+                # The deployer pays gas for creating checkpoints when advancing time
                 # We check the eth balance and refund if it runs low
                 deployer_account = chain.get_deployer_account()
                 deployer_agent_eth = hyperdrive_pools[0].interface.get_eth_base_balances(deployer_account)[0]
@@ -514,11 +527,4 @@ def run_fuzz_bots(
                     _ = set_account_balance(
                         hyperdrive_pools[0].interface.web3, deployer_account.address, eth_budget_per_bot.scaled_value
                     )
-                # RNG should always exist, config's post_init should always
-                # initialize an rng object
-                assert chain.config.rng is not None
-                # TODO should there be an upper bound for advancing time?
-                random_time = int(chain.config.rng.integers(*ADVANCE_TIME_SECONDS_RANGE))
                 chain.advance_time(random_time, create_checkpoints=True)
-            else:
-                raise ValueError("Random advance time only allowed for pools deployed on LocalChain")


### PR DESCRIPTION
- Set block timestamp interval to be 0 (which increments block time by 1 second per transaction) to avoid advancing time when fork fuzzing. This is to bypass the `oraclePriceExpired` issue on ezETH.
- Use chain config preview before trade call when creating checkpoints.
- Using call on block for accruing interest for ezeth function instead of hacking in stateful variable into interface (not currently being used).
- Only accrue interest when advancing time (not currently being used).
- Increasing total shares epsilon for wstETH/USDA pool in invariance checks.
- Adding an epsilon of 1 wei for present value invariance check.
- Logging "no trades on fork fuzz pool" as an exception to have rollbar combine items.